### PR TITLE
Add dynamic single product build system

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,36 @@ npm run start
 
 ```bash
 # Development
-npm run start                     # Start development server
+npm run start                     # Start development server (all products)
 
 # Building & Testing
-npm run build                     # Full production build
+npm run build                     # Full production build (all products)
 
 # Utilities
 npm run clear                     # Clear Docusaurus cache
 npm run serve                     # Serve production build after `npm run build`
 ```
+
+### Single Product Builds
+
+For faster development and reduced memory usage, you can build documentation for specific products only:
+
+```bash
+# Development server for single product
+npm run start:product pingcastle
+
+# Build single product
+npm run build:product pingcastle
+
+# Multiple products
+npm run start:product pingcastle,auditor
+npm run build:product 1secure,threatmanager
+```
+
+**Benefits:**
+- ⚡ Faster startup times (seconds vs minutes)
+- 💾 Reduced memory usage
+- 🎯 Cleaner development focus
 
 ### Development Workflow
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,14 @@
   "scripts": {
     "docusaurus": "npx docusaurus",
     "start": "cross-env NODE_OPTIONS=--max-old-space-size=16384 CHOKIDAR_USEPOLLING=false npx docusaurus start --port=4500 --no-open",
-    "build": "NODE_OPTIONS=--max-old-space-size=16384 npx docusaurus build",
+    "build": "cross-env NODE_OPTIONS=--max-old-space-size=16384 npx docusaurus build",
     "swizzle": "npx docusaurus swizzle",
     "clear": "npx docusaurus clear",
     "serve": "npx serve -s build -l 8080",
     "write-translations": "npx docusaurus write-translations",
-    "write-heading-ids": "npx docusaurus write-heading-ids"
+    "write-heading-ids": "npx docusaurus write-heading-ids",
+    "start:product": "node scripts/build-product.js start",
+    "build:product": "node scripts/build-product.js build"
   },
   "dependencies": {
     "@docusaurus/babel": "^3.8.1",

--- a/scripts/build-product.js
+++ b/scripts/build-product.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+// Import the ALL_PRODUCTS to validate product IDs
+// We need to read the file directly since it's not exported
+const fs = require('fs');
+const productsFile = fs.readFileSync(path.join(__dirname, '..', 'src', 'config', 'products.js'), 'utf8');
+
+// Extract product IDs from the file (simple regex approach)
+const productIds = [];
+const productMatches = productsFile.matchAll(/id:\s*'([^']+)'/g);
+for (const match of productMatches) {
+  productIds.push(match[1]);
+}
+
+function showUsage() {
+  console.log('Usage:');
+  console.log('  npm run start:product <product-ids>');
+  console.log('  npm run build:product <product-ids>');
+  console.log('');
+  console.log('Examples:');
+  console.log('  npm run start:product pingcastle');
+  console.log('  npm run start:product pingcastle,auditor');
+  console.log('  npm run build:product 1secure');
+  console.log('');
+  console.log('Available products:');
+  productIds.forEach(id => console.log(`  - ${id}`));
+}
+
+function main() {
+  const command = process.argv[2]; // 'start' or 'build'
+  const products = process.argv[3]; // product IDs
+
+  if (!command || !['start', 'build'].includes(command)) {
+    console.error('Error: Invalid command. Must be "start" or "build".');
+    showUsage();
+    process.exit(1);
+  }
+
+  if (!products) {
+    console.error('Error: No products specified.');
+    showUsage();
+    process.exit(1);
+  }
+
+  // Validate product IDs
+  const requestedProducts = products.split(',').map(p => p.trim());
+  const invalidProducts = requestedProducts.filter(p => !productIds.includes(p));
+  
+  if (invalidProducts.length > 0) {
+    console.error(`Error: Invalid product IDs: ${invalidProducts.join(', ')}`);
+    console.log('');
+    console.log('Available products:');
+    productIds.forEach(id => console.log(`  - ${id}`));
+    process.exit(1);
+  }
+
+  // Set environment variable and run command
+  const env = { ...process.env, BUILD_PRODUCTS: products };
+  const npmCommand = command === 'start' ? 'npm start' : 'npm run build';
+
+  console.log(`Building documentation for: ${requestedProducts.join(', ')}`);
+  console.log(`Running: ${npmCommand}`);
+  console.log('');
+
+  try {
+    execSync(npmCommand, { 
+      stdio: 'inherit', 
+      env: env,
+      cwd: path.join(__dirname, '..')
+    });
+  } catch (error) {
+    console.error('Build failed:', error.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { main, showUsage };

--- a/src/config/products.js
+++ b/src/config/products.js
@@ -784,7 +784,8 @@ export function generateNavbarDropdowns() {
  * Supports comma-separated product IDs: "pingcastle,auditor,1secure"
  */
 function filterProducts() {
-  const buildProducts = process.env.BUILD_PRODUCTS;
+  // Safe access to environment variable - fallback to undefined if process is not available (browser)
+  const buildProducts = typeof process !== 'undefined' && process.env ? process.env.BUILD_PRODUCTS : undefined;
   
   // If no filter specified, return all products
   if (!buildProducts) {

--- a/src/config/products.js
+++ b/src/config/products.js
@@ -35,7 +35,7 @@
  * All Netwrix products and their configurations
  * @type {Product[]}
  */
-export const PRODUCTS = [
+const ALL_PRODUCTS = [
   {
     id: '1secure',
     name: '1Secure',
@@ -778,3 +778,35 @@ export function generateNavbarDropdowns() {
       };
     });
 }
+
+/**
+ * Filter products based on BUILD_PRODUCTS environment variable
+ * Supports comma-separated product IDs: "pingcastle,auditor,1secure"
+ */
+function filterProducts() {
+  const buildProducts = process.env.BUILD_PRODUCTS;
+  
+  // If no filter specified, return all products
+  if (!buildProducts) {
+    return ALL_PRODUCTS;
+  }
+  
+  // Parse comma-separated list
+  const productIds = buildProducts.split(',').map(id => id.trim()).filter(Boolean);
+  
+  // Filter products that match the specified IDs
+  const filteredProducts = ALL_PRODUCTS.filter(product => 
+    productIds.includes(product.id)
+  );
+  
+  // Log what we're building for debugging
+  console.log(`Building documentation for: ${filteredProducts.map(p => p.name).join(', ')}`);
+  
+  return filteredProducts;
+}
+
+/**
+ * Exported products list - filtered based on BUILD_PRODUCTS environment variable
+ * @type {Product[]}
+ */
+export const PRODUCTS = filterProducts();


### PR DESCRIPTION
Added new functionality to dynamically build a single products docs so testing of single products is much much faster. This only builds the default version as specified in the sidebar.js file.

Examples:
- Build Single Product: `npm run start:product pingcastle`
- Build Multiple Products: `npm run build:product pingcastle,auditor`