### PR TITLE
change tracker: fix api agents doc to use 'request' not pull term

### DIFF
--- a/docs/changetracker/8.1/integration/api/agents.md
+++ b/docs/changetracker/8.1/integration/api/agents.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 # Agents
 
-To pull data on agent statues, configurations and group memberships, use the agentsRanked endpoint.
+To request data on agent statues, configurations and group memberships, use the agentsRanked endpoint.
 
 ## /api/agentsRanked
 


### PR DESCRIPTION
Test PR for training