### PR TITLE
Fix MDX compilation errors in KB articles

### DIFF
--- a/docs/kb/auditor/error_the_custom_attribute_{x}_was_requested,_but_not_set_in_domain_1_for_the_{y}_object_class.md
+++ b/docs/kb/auditor/error_the_custom_attribute_{x}_was_requested,_but_not_set_in_domain_1_for_the_{y}_object_class.md
@@ -7,13 +7,13 @@ keywords:
   - custom attributes
 sidebar_label: Custom Attribute Warning
 tags: []
-title: "Error: The Custom Attribute {x} Was Requested, but Not Set in Domain 1 for the {y} Object Class"
+title: "Error: The Custom Attribute {'{'}x{'}'} Was Requested, but Not Set in Domain 1 for the {'{'}y{'}'} Object Class"
 knowledge_article_id: kA0Qk000000306jKAA
 products:
   - auditor
 ---
 
-# Error: The Custom Attribute {x} Was Requested, but Not Set in Domain 1 for the {y} Object Class
+# Error: The Custom Attribute {'{'}x{'}'} Was Requested, but Not Set in Domain 1 for the {'{'}y{'}'} Object Class
 
 ## Related Queries
 

--- a/docs/kb/auditor/group-policy-error-is-not-in-a-valid-format.md
+++ b/docs/kb/auditor/group-policy-error-is-not-in-a-valid-format.md
@@ -49,4 +49,4 @@ There are 3 possible solutions:
    `*The file * is not in a valid format and must be replaced.*`  
    If you didn't find a solution please refer to the following Microsoft article regarding this issue - http://support.microsoft.com/kb/814751
 
-<div id="cke_pastebin" style="width: 1px;height: 1px;"> </div>
+<div id="cke_pastebin" style={{width: '1px', height: '1px'}}> </div>

--- a/docs/kb/auditor/investigating-failed-logons.md
+++ b/docs/kb/auditor/investigating-failed-logons.md
@@ -139,4 +139,4 @@ If you want an overview on how Failed Logon information is collected, check this
 
 If you have multiple Failed Logons, check this article: https://kb.netwrix.com/3553
 
-<div id="hzImg" style="width: auto;height: auto;background-color: rgb(255, 255, 255);display: none;"> </div>
+<div id="hzImg" style={{width: 'auto', height: 'auto', backgroundColor: 'rgb(255, 255, 255)', display: 'none'}}> </div>

--- a/docs/kb/general/error-401-unauthorized-access-is-denied-due-to-invalid-credentials.md
+++ b/docs/kb/general/error-401-unauthorized-access-is-denied-due-to-invalid-credentials.md
@@ -65,4 +65,4 @@ To resolve the issue verify authentication settings and account permisions.
 
    ![User-added image](./images/ka04u00000116cs_0EM700000004xco.png)
 
-<div id="cke_pastebin" style="width: 1px;height: 1px;"></div>
+<div id="cke_pastebin" style={{width: '1px', height: '1px'}}></div>


### PR DESCRIPTION
## Summary
Fix MDX compilation errors discovered during static site generation that prevent successful builds.

## Changes
- Fix JSX variable escaping in custom attribute error titles (`{x}` and `{y}` variables)
- Convert HTML-style string props to proper JSX style objects for 3 files
- Resolve static site generation errors preventing deployment

## Files Fixed
- `docs/kb/auditor/error_the_custom_attribute_{x}_was_requested,_but_not_set_in_domain_1_for_the_{y}_object_class.md`
- `docs/kb/auditor/group-policy-error-is-not-in-a-valid-format.md`
- `docs/kb/auditor/investigating-failed-logons.md` 
- `docs/kb/general/error-401-unauthorized-access-is-denied-due-to-invalid-credentials.md`

## Test Plan
- [x] Local build tested successfully
- [x] MDX compilation errors resolved
- [x] Static site generation should now pass

🤖 Generated with [Claude Code](https://claude.ai/code)