### PR TITLE
Fix KB routing by removing redundant kb/ prefix from all slugs

### DIFF
--- a/docs/kb/1secure/index.md
+++ b/docs/kb/1secure/index.md
@@ -1,7 +1,7 @@
 ---
 title: "1Secure Knowledge Base"
 description: "1Secure knowledge base articles and troubleshooting guides"
-slug: kb/1secure
+slug: 1secure
 ---
 
 # 1Secure Knowledge Base

--- a/docs/kb/accessanalyzer/index.md
+++ b/docs/kb/accessanalyzer/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Access Analyzer Knowledge Base"
 description: "Access Analyzer knowledge base articles and troubleshooting guides"
-slug: kb/accessanalyzer
+slug: accessanalyzer
 ---
 
 # Access Analyzer Knowledge Base

--- a/docs/kb/accessinformationcenter/index.md
+++ b/docs/kb/accessinformationcenter/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Access Information Center Knowledge Base"
 description: "Access Information Center knowledge base articles and troubleshooting guides"
-slug: kb/accessinformationcenter
+slug: accessinformationcenter
 ---
 
 # Access Information Center Knowledge Base

--- a/docs/kb/activitymonitor/index.md
+++ b/docs/kb/activitymonitor/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Activity Monitor Knowledge Base"
 description: "Activity Monitor knowledge base articles and troubleshooting guides"
-slug: kb/activitymonitor
+slug: activitymonitor
 ---
 
 # Activity Monitor Knowledge Base

--- a/docs/kb/auditor/index.md
+++ b/docs/kb/auditor/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Auditor Knowledge Base"
 description: "Auditor knowledge base articles and troubleshooting guides"
-slug: kb/auditor
+slug: auditor
 ---
 
 # Auditor Knowledge Base

--- a/docs/kb/dataclassification/index.md
+++ b/docs/kb/dataclassification/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Data Classification Knowledge Base"
 description: "Data Classification knowledge base articles and troubleshooting guides"
-slug: kb/dataclassification
+slug: dataclassification
 ---
 
 # Data Classification Knowledge Base

--- a/docs/kb/directorymanager/index.md
+++ b/docs/kb/directorymanager/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Directory Manager Knowledge Base"
 description: "Directory Manager knowledge base articles and troubleshooting guides"
-slug: kb/directorymanager
+slug: directorymanager
 ---
 
 # Directory Manager Knowledge Base

--- a/docs/kb/endpointpolicymanager/index.md
+++ b/docs/kb/endpointpolicymanager/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Endpoint Policy Manager Knowledge Base"
 description: "Endpoint Policy Manager knowledge base articles and troubleshooting guides"
-slug: kb/endpointpolicymanager
+slug: endpointpolicymanager
 ---
 
 # Endpoint Policy Manager Knowledge Base

--- a/docs/kb/endpointprotector/index.md
+++ b/docs/kb/endpointprotector/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Endpoint Protector Knowledge Base"
 description: "Endpoint Protector knowledge base articles and troubleshooting guides"
-slug: kb/endpointprotector
+slug: endpointprotector
 ---
 
 # Endpoint Protector Knowledge Base

--- a/docs/kb/general/index.md
+++ b/docs/kb/general/index.md
@@ -1,7 +1,7 @@
 ---
 title: "General Knowledge Base"
 description: "General knowledge base articles and troubleshooting guides"
-slug: kb/general
+slug: general
 ---
 
 # General Knowledge Base

--- a/docs/kb/logtracker/index.md
+++ b/docs/kb/logtracker/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Log Tracker Knowledge Base"
 description: "Log Tracker knowledge base articles and troubleshooting guides"
-slug: kb/logtracker
+slug: logtracker
 ---
 
 # Log Tracker Knowledge Base

--- a/docs/kb/passwordpolicyenforcer/index.md
+++ b/docs/kb/passwordpolicyenforcer/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Password Policy Enforcer Knowledge Base"
 description: "Password Policy Enforcer knowledge base articles and troubleshooting guides"
-slug: kb/passwordpolicyenforcer
+slug: passwordpolicyenforcer
 ---
 
 # Password Policy Enforcer Knowledge Base

--- a/docs/kb/passwordreset/index.md
+++ b/docs/kb/passwordreset/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Password Reset Knowledge Base"
 description: "Password Reset knowledge base articles and troubleshooting guides"
-slug: kb/passwordreset
+slug: passwordreset
 ---
 
 # Password Reset Knowledge Base

--- a/docs/kb/privilegesecure/index.md
+++ b/docs/kb/privilegesecure/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Privilege Secure Knowledge Base"
 description: "Privilege Secure knowledge base articles and troubleshooting guides"
-slug: kb/privilegesecure
+slug: privilegesecure
 ---
 
 # Privilege Secure Knowledge Base

--- a/docs/kb/privilegesecurediscovery/index.md
+++ b/docs/kb/privilegesecurediscovery/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Privilege Secure Discovery Knowledge Base"
 description: "Privilege Secure Discovery knowledge base articles and troubleshooting guides"
-slug: kb/privilegesecurediscovery
+slug: privilegesecurediscovery
 ---
 
 # Privilege Secure Discovery Knowledge Base

--- a/docs/kb/recoveryad/index.md
+++ b/docs/kb/recoveryad/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Recovery for Active Directory Knowledge Base"
 description: "Recovery for Active Directory knowledge base articles and troubleshooting guides"
-slug: kb/recoveryad
+slug: recoveryad
 ---
 
 # Recovery for Active Directory Knowledge Base

--- a/docs/kb/threatmanager/index.md
+++ b/docs/kb/threatmanager/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Threat Manager Knowledge Base"
 description: "Threat Manager knowledge base articles and troubleshooting guides"
-slug: kb/threatmanager
+slug: threatmanager
 ---
 
 # Threat Manager Knowledge Base

--- a/docs/kb/threatprevention/index.md
+++ b/docs/kb/threatprevention/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Threat Prevention Knowledge Base"
 description: "Threat Prevention knowledge base articles and troubleshooting guides"
-slug: kb/threatprevention
+slug: threatprevention
 ---
 
 # Threat Prevention Knowledge Base


### PR DESCRIPTION
## Summary
- Remove redundant `kb/` prefix from all 18 KB index file slugs  
- Fixes broken KB navigation links by correcting Docusaurus routing
- Resolves 404 errors for KB parent folder links across the documentation

## Root Cause Analysis
**The Problem:**
- KB plugin has `routeBasePath: 'docs/kb'`
- KB index files had `slug: kb/productname`
- Docusaurus URL generation: `routeBasePath + slug = docs/kb + kb/productname = /docs/kb/kb/productname`
- generateKBSidebar() generates: `/docs/kb/productname`
- **MISMATCH**: Links pointed to non-existent routes

**The Fix:**
- Changed all slugs from `kb/productname` → `productname`
- Now Docusaurus serves: `docs/kb + productname = /docs/kb/productname` ✅
- generateKBSidebar() generates: `/docs/kb/productname` ✅  
- **MATCH**: Links now work correctly

## Files Changed
Fixed slug configuration in all 18 KB index files:
- `1secure`, `accessanalyzer`, `accessinformationcenter`, `activitymonitor`
- `auditor`, `dataclassification`, `directorymanager`, `endpointpolicymanager`
- `endpointprotector`, `general`, `logtracker`, `passwordpolicyenforcer`
- `passwordreset`, `privilegesecure`, `privilegesecurediscovery`, `recoveryad`
- `threatmanager`, `threatprevention`

## Impact
This should resolve all broken KB index links reported in the build errors:
```
- Broken link on source page path = /docs/accessinformationcenter/11_6/:
   -> linking to /docs/kb/accessinformationcenter
```

🤖 Generated with [Claude Code](https://claude.ai/code)