### PR TITLE
Training dec22

### DIFF
--- a/docs/customer/training/learn-about/identity-manager.md
+++ b/docs/customer/training/learn-about/identity-manager.md
@@ -6,14 +6,17 @@ keywords: [training, course, identity manager]
 description: "Learn about Netwrix Identity Manager through introductory courses"
 ---
 
-import { NIMValue } from '@site/src/training/identity-manager';
+import { NIMValue, NIMLifeCycle } from '@site/src/training/identity-manager';
 import { NIM } from '@site/src/training/products';
 
 
-Estimated length: 5 minutes
+Estimated length: 10 minutes
 
 In this learning path, you will be introduced to <NIM />, formerly Netwrix Usercube. It contains the following courses:
 
 * 1720 <NIM /> – Valuable Features
+* 1721 <NIM /> – Identity & Identity Life Cycle
 
 <NIMValue />
+
+<NIMLifeCycle />

--- a/docs/customer/training/product/identity-manager.md
+++ b/docs/customer/training/product/identity-manager.md
@@ -6,7 +6,7 @@ keywords: [training, course, identity manager]
 description: "Learn to use Netwrix Identity Manager through courses"
 ---
 
-import { NIMValue, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro } from '@site/src/training/identity-manager';
+import { NIMValue, NIMLifeCycle, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro } from '@site/src/training/identity-manager';
 import { Company, NIM } from '@site/src/training/products';
 
 
@@ -15,6 +15,7 @@ Estimated length: 3.5 hours
 In this learning path, you will learn how to use <NIM /> learning path. This product was formerly Netwrix Usercube. It contains the following courses:
 
 * 1720 <NIM /> – Valuable Features
+* 1721 <NIM /> – Identity & Identity Life Cycle
 * 2721 <NIM /> – Architecture
 * 2722 <NIM /> – Standard Deployment Project
 * 2723 <NIM /> – Data Model
@@ -26,6 +27,8 @@ In this learning path, you will learn how to use <NIM /> learning path. This pro
 * 3720 Introduction to <NIM />
 
 <NIMValue />
+
+<NIMLifeCycle />
 
 <NIMArchitecture />
 

--- a/docs/customer/training/product/identity-manager.md
+++ b/docs/customer/training/product/identity-manager.md
@@ -1,0 +1,46 @@
+---
+title: Netwrix Identity Manager Learning Path
+sidebar_position: 190
+tags: [getting-started, training, identity-manager]
+keywords: [training, course, identity manager]
+description: "Learn to use Netwrix Identity Manager through courses"
+---
+
+import { NIMValue, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro } from '@site/src/training/identity-manager';
+import { Company, NIM } from '@site/src/training/products';
+
+
+Estimated length: 3.5 hours
+
+In this learning path, you will learn how to use <NIM /> learning path. This product was formerly Netwrix Usercube. It contains the following courses:
+
+* 1720 <NIM /> – Valuable Features
+* 2721 <NIM /> – Architecture
+* 2722 <NIM /> – Standard Deployment Project
+* 2723 <NIM /> – Data Model
+* 2724 <NIM /> – Connectors
+* 2725 <NIM /> – Profiles Fundamentals
+* 2726 <NIM /> – Identity Workflow Fundamentals
+* 2727 <NIM /> – Designing Role Model
+* 2728 <NIM /> – Reconciliation
+* 3720 Introduction to <NIM />
+
+<NIMValue />
+
+<NIMArchitecture />
+
+<NIMStandard />
+
+<NIMDataModel />
+
+<NIMConnectors />
+
+<NIMProfilesFundamentals />
+
+<NIMIdentityWorkflow />
+
+<NIMRoleModel />
+
+<NIMReconciliation />
+
+<NIMIntro />

--- a/docs/customer/training/product/index.md
+++ b/docs/customer/training/product/index.md
@@ -23,6 +23,7 @@ You will be automatically enrolled in the product learning path for the products
 * [Netwrix Directory Manager Learning Path](./directory-manager.md)
 * [Netwrix Endpoint Policy Manager Learning Path](./endpoint-policy-manager.md)
 * [Netwrix Endpoint Protector Learning Path](./endpoint-protector.md)
+* [Netwrix Identity Manager Learning Path](identity-manager.md)
 * [Netwrix Password Policy Enforcer Learning Path](./password-policy-enforcer.md)
 * [Netwrix Password Reset Learning Path](./password-reset.md)
 * [Netwrix Password Secure Learning Path](./password-secure.md)

--- a/docs/partner/implementation/identity-manager.md
+++ b/docs/partner/implementation/identity-manager.md
@@ -6,7 +6,7 @@ keywords: [training, course, certification, partners, professional services, ide
 description: "Become a certified Professional Services Engineer for Netwrix Identity Manager"
 ---
 
-import { NIMValue, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro, NIMAdditional } from '@site/src/training/identity-manager';
+import { NIMValue, NIMLifeCycle, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro, NIMAdditional } from '@site/src/training/identity-manager';
 import { Company, NIM } from '@site/src/training/products';
 
 
@@ -15,6 +15,7 @@ Estimated length: 3.5 hours
 This learning path offers training to <Company /> partner Professional Services engineers on <NIM />, formerly Netwrix Usercube. However, certification is not currently available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
 
 * 1720 <NIM /> – Valuable Features
+* 1721 <NIM /> – Identity & Identity Life Cycle
 * 2721 <NIM /> – Architecture
 * 2722 <NIM /> – Standard Deployment Project
 * 2723 <NIM /> – Data Model
@@ -26,6 +27,8 @@ This learning path offers training to <Company /> partner Professional Services 
 * 3720 Introduction to <NIM />
 
 <NIMValue />
+
+<NIMLifeCycle />
 
 <NIMArchitecture />
 

--- a/docs/partner/implementation/identity-manager.md
+++ b/docs/partner/implementation/identity-manager.md
@@ -10,7 +10,7 @@ import { NIMValue, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NI
 import { Company, NIM } from '@site/src/training/products';
 
 
-Estimated length: 4 hours
+Estimated length: 3.5 hours
 
 This learning path offers training to <Company /> partner Professional Services engineers on <NIM />, formerly Netwrix Usercube. However, certification is not currently available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
 

--- a/docs/partner/presales/data-classification.md
+++ b/docs/partner/presales/data-classification.md
@@ -6,11 +6,11 @@ keywords: [training, course, certification, partners, presales, data classificat
 description: "Become a certified Presales Engineer for Netwrix Data Classification"
 ---
 
-import { NDCValue, NDCConcepts, NDCIntro, NDCTaxonomies, NDCWorkflows, NDCUsersReporting, NDCAdministering, NDCIntegrationNA, NDCTroubleshooting, NDCDemoLab, NDCAdditional } from '@site/src/training/data-classification';
+import { NDCValue, NDCConcepts, NDCIntro, NDCTaxonomies, NDCWorkflows, NDCUsersReporting, NDCAdministering, NDCIntegrationNA, NDCTroubleshooting, NDCDemo, NDCAdditional } from '@site/src/training/data-classification';
 import { Company, NA, NDC } from '@site/src/training/products';
 
 
-Estimated length:  5 hours + Recording of Demo
+Estimated length:  5.75 hours
 
 This learning path grants <Company /> certification as a Presales Engineer for this product. It contains the following courses:
 
@@ -23,7 +23,7 @@ This learning path grants <Company /> certification as a Presales Engineer for t
 * 3124 <NDC /> – Administering
 * 3130 <NDC /> – Integration with <NA />
 * 4120 <NDC /> – Basic Troubleshooting
-* 6120 <NDC /> – Presales Lab Experience
+* 5120 <NDC /> – Demo Basic Use Cases
 
 <NDCValue />
 
@@ -43,6 +43,6 @@ This learning path grants <Company /> certification as a Presales Engineer for t
 
 <NDCTroubleshooting />
 
-<NDCDemoLab />
+<NDCDemo />
 
 <NDCAdditional />

--- a/docs/partner/presales/identity-manager.md
+++ b/docs/partner/presales/identity-manager.md
@@ -7,7 +7,7 @@ description: "Become a certified Presales Engineer for Netwrix Identity Manager"
 ---
 
 
-import { NIMValue, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro, NIMDemoLab, NIMAdditional } from '@site/src/training/identity-manager';
+import { NIMValue, NIMLifeCycle, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NIMProfilesFundamentals, NIMIdentityWorkflow, NIMRoleModel, NIMReconciliation, NIMIntro, NIMDemoLab, NIMAdditional } from '@site/src/training/identity-manager';
 import { Company, NIM } from '@site/src/training/products';
 
 
@@ -18,6 +18,7 @@ Prerequisite: <NIM /> Sales Professional learning path
 This learning path grants <Company /> certification as a Presales Engineer for this product. This application was formerly Netwrix Usercube. It contains the following courses:
 
 * 1720 <NIM /> – Valuable Features
+* 1721 <NIM /> – Identity & Identity Life Cycle
 * 2721 <NIM /> – Architecture
 * 2722 <NIM /> – Standard Deployment Project
 * 2723 <NIM /> – Data Model
@@ -30,6 +31,8 @@ This learning path grants <Company /> certification as a Presales Engineer for t
 * 6720 <NIM /> – Presales Lab Experience
 
 <NIMValue />
+
+<NIMLifeCycle />
 
 <NIMArchitecture />
 

--- a/docs/partner/presales/identity-manager.md
+++ b/docs/partner/presales/identity-manager.md
@@ -11,7 +11,7 @@ import { NIMValue, NIMArchitecture, NIMStandard, NIMDataModel, NIMConnectors, NI
 import { Company, NIM } from '@site/src/training/products';
 
 
-Estimated length: 4 hours + Recording of demo
+Estimated length: 3.5 hours + Recording of demo
 
 Prerequisite: <NIM /> Sales Professional learning path
 

--- a/src/training/data-classification/5120.md
+++ b/src/training/data-classification/5120.md
@@ -1,0 +1,17 @@
+import { NDC } from '@site/src/training/products';
+
+## 5120 <NDC /> – Demo the Basic Use Cases
+
+Recommended prerequisite: 4120 <NDC /> – Basic Troubleshooting
+
+The <NDC /> – Demo the Basic Use Cases course provides you with the ability to demonstrate the five basic use cases for this application:
+
+* High Fidelity Data Classification
+* Identify and Manage Stale and Duplicate Data (ROT Data Detection)
+* Data Subject Access Request (DSAR) / Search Data
+* Automated Risk Remediation
+* O365 Tagging and Tracking
+
+When you complete this course, you will understand the scenario and demonstration talking points for each use case.
+
+Estimated length: 30 minutes

--- a/src/training/data-classification/6120.md
+++ b/src/training/data-classification/6120.md
@@ -1,9 +1,0 @@
-import { NDC } from '@site/src/training/products';
-
-## 6120 <NDC /> – Presales Lab Experience
-
-Recommended prerequisite: 4120 <NDC /> – Basic Troubleshooting
-
-The <NDC /> – Presales Lab Experience requires you to stand up <NDC /> in a lab environment, as practice for customer demonstrations. It is a hands-on experience of a presales demonstration and the use cases learned in this certification program.
-
-Estimated Length: 1 hour

--- a/src/training/data-classification/index.js
+++ b/src/training/data-classification/index.js
@@ -7,6 +7,6 @@ export { default as NDCUsersReporting } from './3123.md';
 export { default as NDCAdministering } from './3124.md';
 export { default as NDCIntegrationNA } from './3130.md';
 export { default as NDCTroubleshooting } from './4120.md';
-export { default as NDCDemoLab } from './6120.md';
+export { default as NDCDemo } from './5120.md';
 export { default as NDCImplementLab } from './6121.md';
 export { default as NDCAdditional } from './additional.md';

--- a/src/training/endpoint-protector/additional.md
+++ b/src/training/endpoint-protector/additional.md
@@ -4,5 +4,6 @@ import { NEP } from '@site/src/training/products';
 
 The following courses are available for self-enrollment through the Learning Library:
 
+* What's New in Netwrix Endpoint Protector v2601
 * What's New in Netwrix Endpoint Protector — Client v2511
 * What's New in <NEP /> v2509

--- a/src/training/identity-manager/1720.md
+++ b/src/training/identity-manager/1720.md
@@ -4,6 +4,6 @@ import { NIM } from '@site/src/training/products';
 
 Recommended prerequisite: None
 
-The <NIM /> – Valuable Features course provides an understanding of the key aspects of the application, formerly Netwrix Usercube.
+The <NIM /> – Valuable Features course provides an understanding of the value this product offers to an IAM program. <NIM /> was formerly Netwrix Usercube.
 
-Estimated length:  30 minutes
+Estimated length:  5 minutes

--- a/src/training/identity-manager/1721.md
+++ b/src/training/identity-manager/1721.md
@@ -1,0 +1,9 @@
+import { NIM } from '@site/src/training/products';
+
+## 1721 <NIM /> – Identity & Identity Life Cycle
+
+Recommended prerequisite: 1720 <NIM /> – Valuable Features
+
+The <NIM /> – Identity & Identity Life Cycle course provides an understanding of what an identity is and how identities move through an organization: Joiners, Movers, and Leavers. <NIM /> was formerly Netwrix Usercube.
+
+Estimated length: 5 minutes

--- a/src/training/identity-manager/index.js
+++ b/src/training/identity-manager/index.js
@@ -1,4 +1,5 @@
 export { default as NIMValue } from './1720.md';
+export { default as NIMLifeCycle } from './1721.md';
 export { default as NIMArchitecture } from './2721.md';
 export { default as NIMStandard } from './2722.md';
 export { default as NIMDataModel } from './2723.md';

--- a/src/training/privilege-secure/additional.md
+++ b/src/training/privilege-secure/additional.md
@@ -4,6 +4,7 @@ import { NA, NPS } from '@site/src/training/products';
 
 The following courses are available for self-enrollment through the Learning Library:
 
+* What's New in <NPS /> v25.12 (AM & D)
 * What's New in <NPS /> (July 2025)
 * What's New in <NPS /> (May 2025)
 * Netwrix Secure Remote Access – Introduced into <NPS />

--- a/src/training/products/identity-recovery.md
+++ b/src/training/products/identity-recovery.md
@@ -1,0 +1,1 @@
+<span>Netwrix Identity Recovery</span>

--- a/src/training/products/index.js
+++ b/src/training/products/index.js
@@ -10,6 +10,7 @@ export { default as NDM } from './directory-manager.md';
 export { default as NEPM } from './endpoint-policy-manager.md';
 export { default as NEP } from './endpoint-protector.md';
 export { default as NIM } from './identity-manager.md';
+export { default as NIR } from './identity-recovery.md';
 export { default as NPPE } from './password-policy-enforcer.md';
 export { default as NPR } from './password-reset.md';
 export { default as NPWS } from './password-secure.md';

--- a/src/training/recovery-for-ad/additional.md
+++ b/src/training/recovery-for-ad/additional.md
@@ -1,8 +1,8 @@
-import { NRAD } from '@site/src/training/products';
+import { NIR, NRAD } from '@site/src/training/products';
 
 ## Additional <NRAD /> Courses for Partners
 
 The following courses are available for self-enrollment through the Learning Library:
 
-* What's New in <NRAD /> v3.0
+* What's New in <NIR /> v3.1 (formerly Recovery for AD)
 * Skills to Support <NRAD />


### PR DESCRIPTION
Updated NIM training with the 2 courses updated/released this month. Added new NDC Presales course and removed legacy lab course. Added the NPS, NIR, and NEP December LTTs for partners. 