### PR TITLE
Change PR permissions from 'read' to 'write' for Claude Code

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Fix Claude Code Review Workflow - Enable PR Comment Posting

### Problem
The Claude Code Review workflow was running successfully and generating reviews, but failing to post comments back to pull requests. The workflow would complete without errors, but no review comments appeared on PRs.

### Root Cause
The workflow had insufficient GitHub permissions. Line 24 specified `pull-requests: read`, but the `gh pr comment` command requires `pull-requests: write` permission to post comments.

### Solution
Changed the permissions from:
```yaml
pull-requests: read
```

To:
```yaml
pull-requests: write
```

This matches the official [Claude Code Action PR review example](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) and GitHub's requirements for the `gh pr comment` command.

### Verification
- Reviewed [official Claude Code Action examples](https://github.com/anthropics/claude-code-action/tree/main/examples)
- Confirmed with [GitHub Actions documentation](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) that `pull-requests: write` is required for commenting
- Examined [workflow run logs](https://github.com/netwrix/docs/actions/runs/20717136530/job/59470923969?pr=16) showing Claude successfully generated a review but couldn't post it