### PR TITLE
Add workflow to validate branch ancestry

### DIFF
--- a/.github/workflows/validate-branch-history.yml
+++ b/.github/workflows/validate-branch-history.yml
@@ -7,10 +7,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  SECURITY_CONTACT: 'jake-mahon-netwrix'
+
 jobs:
   validate-history:
     name: Validate Clean History
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -73,7 +81,7 @@ jobs:
             echo "4. Commit and push the clean branch"
             echo "5. Delete this branch: git push origin --delete ${{ github.ref_name }}"
             echo ""
-            echo "Contact Jake Mahon if you need assistance."
+            echo "Contact @${{ env.SECURITY_CONTACT }} if you need assistance."
 
             # Save invalid roots for issue creation
             echo "invalid_roots=${INVALID_ROOTS[*]}" >> $GITHUB_OUTPUT
@@ -87,17 +95,20 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const branch = context.ref.replace('refs/heads/', '');
+            const branch = context.eventName === 'pull_request'
+              ? context.payload.pull_request.head.ref
+              : context.ref.replace('refs/heads/', '');
             const pusher = context.actor;
             const invalidRoots = '${{ steps.check_ancestry.outputs.invalid_roots }}';
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `⚠️ Branch ${branch} contains invalid git history`,
-              assignees: [pusher],
-              labels: ['security', 'urgent'],
-              body: `## ⚠️ URGENT: Invalid Git History Detected
+            try {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `⚠️ Branch ${branch} contains invalid git history`,
+                assignees: [pusher],
+                labels: ['security', 'urgent'],
+                body: `## ⚠️ URGENT: Invalid Git History Detected
 
 **Branch:** \`${branch}\`
 **Pushed by:** @${pusher}
@@ -128,16 +139,39 @@ This branch contains git history from before the repository re-initialization an
 
 **This branch will be blocked from merging to dev/main.**
 
-Contact @jake-mahon-netwrix if you need assistance.
+Contact @${{ env.SECURITY_CONTACT }} if you need assistance.
 
 ---
 *Automated alert from [Validate Branch History workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*`
-            });
+              });
 
-            console.log('Issue created for invalid branch');
+              console.log('Issue created successfully');
+            } catch (error) {
+              console.error('Failed to create issue:', error.message);
 
+              // Fallback: Create without assignee or labels if they fail
+              try {
+                await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: `⚠️ Branch ${branch} contains invalid git history`,
+                  body: `## ⚠️ URGENT: Invalid Git History Detected
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
+**Branch:** \`${branch}\`
+**Pushed by:** @${pusher}
+**Invalid root commit(s):** \`${invalidRoots}\`
+
+This branch contains git history from before the repository re-initialization and must be deleted immediately to prevent exposure of sensitive data.
+
+Contact @${{ env.SECURITY_CONTACT }} for assistance.
+
+---
+*Automated alert from [Validate Branch History workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*
+
+_Note: Failed to assign or add labels due to: ${error.message}_`
+                });
+                console.log('Fallback issue created without assignee/labels');
+              } catch (fallbackError) {
+                console.error('Fallback issue creation also failed:', fallbackError.message);
+              }
+            }

--- a/.github/workflows/validate-branch-history.yml
+++ b/.github/workflows/validate-branch-history.yml
@@ -82,7 +82,8 @@ jobs:
             echo "2. Create a fresh branch from current dev: git checkout -b my-branch origin/dev"
             echo "3. Apply your patch: git apply my-changes.patch"
             echo "4. Commit and push the clean branch"
-            echo "5. Delete this branch: git push origin --delete ${{ github.ref_name }}"
+            echo "5. Delete the invalid branch (replace BRANCH_NAME with your branch name):"
+            echo "   git push origin --delete BRANCH_NAME"
             echo ""
             echo "Contact @${{ env.SECURITY_CONTACT }} if you need assistance."
 

--- a/.github/workflows/validate-branch-history.yml
+++ b/.github/workflows/validate-branch-history.yml
@@ -44,6 +44,9 @@ jobs:
           # Check each root commit
           INVALID_ROOTS=()
           while IFS= read -r branch_root; do
+            # Skip empty lines
+            [[ -z "$branch_root" ]] && continue
+
             VALID=false
             for valid_root in "${VALID_ROOTS[@]}"; do
               if [ "$branch_root" = "$valid_root" ]; then
@@ -91,7 +94,7 @@ jobs:
           echo "✅ Branch ancestry validation passed"
 
       - name: Create issue for invalid branch
-        if: failure() && steps.check_ancestry.outcome == 'failure'
+        if: failure() && steps.check_ancestry.outcome == 'failure' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/github-script@v7
         with:
           script: |
@@ -100,6 +103,24 @@ jobs:
               : context.ref.replace('refs/heads/', '');
             const pusher = context.actor;
             const invalidRoots = '${{ steps.check_ancestry.outputs.invalid_roots }}';
+
+            // Check for existing open issues about this branch
+            const existingIssues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+              per_page: 100
+            });
+
+            const branchIssueExists = existingIssues.data.some(issue =>
+              issue.title.includes(`Branch ${branch} contains invalid git history`)
+            );
+
+            if (branchIssueExists) {
+              console.log(`Issue already exists for branch ${branch}, skipping creation`);
+              return;
+            }
 
             try {
               await github.rest.issues.create({

--- a/.github/workflows/validate-branch-history.yml
+++ b/.github/workflows/validate-branch-history.yml
@@ -1,0 +1,70 @@
+name: Validate Branch History
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate-history:
+    name: Validate Clean History
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check branch ancestry
+        run: |
+          # Valid root commits
+          VALID_ROOTS=(
+            "97e73c5cc4a29296024f23499ef5e60bc7db755b"
+          )
+
+          echo "🔍 Validating branch ancestry..."
+
+          # Get the root commit of the current branch
+          BRANCH_ROOT=$(git rev-list --max-parents=0 HEAD)
+
+          echo "Branch root commit: $BRANCH_ROOT"
+
+          # Check if branch root is one of the valid roots
+          VALID=false
+          for root in "${VALID_ROOTS[@]}"; do
+            if [ "$BRANCH_ROOT" = "$root" ]; then
+              VALID=true
+              break
+            fi
+          done
+
+          if [ "$VALID" = false ]; then
+            echo "❌ ERROR: This branch does not descend from a valid repository initialization"
+            echo ""
+            echo "Expected root commit to be one of:"
+            for root in "${VALID_ROOTS[@]}"; do
+              echo "  - $root"
+            done
+            echo ""
+            echo "Found root commit: $BRANCH_ROOT"
+            echo ""
+            echo "This repository was re-initialized to remove sensitive data from git history."
+            echo "Branches must be created from the current dev/main branches."
+            echo ""
+            echo "To fix this:"
+            echo "1. Save your changes as a patch: git diff origin/dev > my-changes.patch"
+            echo "2. Create a fresh branch from current dev: git checkout -b my-branch origin/dev"
+            echo "3. Apply your patch: git apply my-changes.patch"
+            echo "4. Commit and push the clean branch"
+            echo ""
+            echo "Contact Jake Mahon if you need assistance."
+            exit 1
+          fi
+
+          echo "✅ Branch ancestry validation passed"
+
+permissions:
+  contents: read
+  pull-requests: write

--- a/.github/workflows/validate-branch-history.yml
+++ b/.github/workflows/validate-branch-history.yml
@@ -17,8 +17,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -86,114 +85,7 @@ jobs:
             echo "   git push origin --delete BRANCH_NAME"
             echo ""
             echo "Contact @${{ env.SECURITY_CONTACT }} if you need assistance."
-
-            # Save invalid roots for issue creation
-            echo "invalid_roots=${INVALID_ROOTS[*]}" >> $GITHUB_OUTPUT
             exit 1
           fi
 
           echo "✅ Branch ancestry validation passed"
-
-      - name: Create issue for invalid branch
-        if: failure() && steps.check_ancestry.outcome == 'failure' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const branch = context.eventName === 'pull_request'
-              ? context.payload.pull_request.head.ref
-              : context.ref.replace('refs/heads/', '');
-            const pusher = context.actor;
-            const invalidRoots = '${{ steps.check_ancestry.outputs.invalid_roots }}';
-
-            // Check for existing open issues about this branch
-            const existingIssues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'security',
-              per_page: 100
-            });
-
-            const branchIssueExists = existingIssues.data.some(issue =>
-              issue.title.includes(`Branch ${branch} contains invalid git history`)
-            );
-
-            if (branchIssueExists) {
-              console.log(`Issue already exists for branch ${branch}, skipping creation`);
-              return;
-            }
-
-            try {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: `⚠️ Branch ${branch} contains invalid git history`,
-                assignees: [pusher],
-                labels: ['security', 'urgent'],
-                body: `## ⚠️ URGENT: Invalid Git History Detected
-
-**Branch:** \`${branch}\`
-**Pushed by:** @${pusher}
-**Invalid root commit(s):** \`${invalidRoots}\`
-
-This branch contains git history from before the repository re-initialization and must be deleted immediately to prevent exposure of sensitive data.
-
-### Required Actions:
-
-1. **Save your work:**
-   \`\`\`bash
-   git diff origin/dev > my-changes.patch
-   \`\`\`
-
-2. **Delete this branch:**
-   \`\`\`bash
-   git push origin --delete ${branch}
-   \`\`\`
-
-3. **Create a clean branch:**
-   \`\`\`bash
-   git checkout -b ${branch} origin/dev
-   git apply my-changes.patch
-   git add .
-   git commit -m "Re-apply changes on clean branch"
-   git push -u origin ${branch}
-   \`\`\`
-
-**This branch will be blocked from merging to dev/main.**
-
-Contact @${{ env.SECURITY_CONTACT }} if you need assistance.
-
----
-*Automated alert from [Validate Branch History workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*`
-              });
-
-              console.log('Issue created successfully');
-            } catch (error) {
-              console.error('Failed to create issue:', error.message);
-
-              // Fallback: Create without assignee or labels if they fail
-              try {
-                await github.rest.issues.create({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  title: `⚠️ Branch ${branch} contains invalid git history`,
-                  body: `## ⚠️ URGENT: Invalid Git History Detected
-
-**Branch:** \`${branch}\`
-**Pushed by:** @${pusher}
-**Invalid root commit(s):** \`${invalidRoots}\`
-
-This branch contains git history from before the repository re-initialization and must be deleted immediately to prevent exposure of sensitive data.
-
-Contact @${{ env.SECURITY_CONTACT }} for assistance.
-
----
-*Automated alert from [Validate Branch History workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*
-
-_Note: Failed to assign or add labels due to: ${error.message}_`
-                });
-                console.log('Fallback issue created without assignee/labels');
-              } catch (fallbackError) {
-                console.error('Fallback issue creation also failed:', fallbackError.message);
-              }
-            }

--- a/.github/workflows/validate-branch-history.yml
+++ b/.github/workflows/validate-branch-history.yml
@@ -18,6 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check branch ancestry
+        id: check_ancestry
         run: |
           # Valid root commits
           VALID_ROOTS=(
@@ -26,29 +27,41 @@ jobs:
 
           echo "🔍 Validating branch ancestry..."
 
-          # Get the root commit of the current branch
-          BRANCH_ROOT=$(git rev-list --max-parents=0 HEAD)
+          # Get ALL root commits (handles merged branches with multiple roots)
+          BRANCH_ROOTS=$(git rev-list --max-parents=0 HEAD)
 
-          echo "Branch root commit: $BRANCH_ROOT"
+          echo "Found root commit(s):"
+          echo "$BRANCH_ROOTS"
 
-          # Check if branch root is one of the valid roots
-          VALID=false
-          for root in "${VALID_ROOTS[@]}"; do
-            if [ "$BRANCH_ROOT" = "$root" ]; then
-              VALID=true
-              break
+          # Check each root commit
+          INVALID_ROOTS=()
+          while IFS= read -r branch_root; do
+            VALID=false
+            for valid_root in "${VALID_ROOTS[@]}"; do
+              if [ "$branch_root" = "$valid_root" ]; then
+                VALID=true
+                break
+              fi
+            done
+
+            if [ "$VALID" = false ]; then
+              INVALID_ROOTS+=("$branch_root")
             fi
-          done
+          done <<< "$BRANCH_ROOTS"
 
-          if [ "$VALID" = false ]; then
-            echo "❌ ERROR: This branch does not descend from a valid repository initialization"
+          # If any invalid roots found, fail
+          if [ ${#INVALID_ROOTS[@]} -gt 0 ]; then
+            echo "❌ ERROR: This branch contains invalid root commits"
             echo ""
-            echo "Expected root commit to be one of:"
+            echo "Expected all root commits to be one of:"
             for root in "${VALID_ROOTS[@]}"; do
               echo "  - $root"
             done
             echo ""
-            echo "Found root commit: $BRANCH_ROOT"
+            echo "Found invalid root commit(s):"
+            for invalid in "${INVALID_ROOTS[@]}"; do
+              echo "  - $invalid"
+            done
             echo ""
             echo "This repository was re-initialized to remove sensitive data from git history."
             echo "Branches must be created from the current dev/main branches."
@@ -58,13 +71,73 @@ jobs:
             echo "2. Create a fresh branch from current dev: git checkout -b my-branch origin/dev"
             echo "3. Apply your patch: git apply my-changes.patch"
             echo "4. Commit and push the clean branch"
+            echo "5. Delete this branch: git push origin --delete ${{ github.ref_name }}"
             echo ""
             echo "Contact Jake Mahon if you need assistance."
+
+            # Save invalid roots for issue creation
+            echo "invalid_roots=${INVALID_ROOTS[*]}" >> $GITHUB_OUTPUT
             exit 1
           fi
 
           echo "✅ Branch ancestry validation passed"
 
+      - name: Create issue for invalid branch
+        if: failure() && steps.check_ancestry.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const pusher = context.actor;
+            const invalidRoots = '${{ steps.check_ancestry.outputs.invalid_roots }}';
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `⚠️ Branch ${branch} contains invalid git history`,
+              assignees: [pusher],
+              labels: ['security', 'urgent'],
+              body: `## ⚠️ URGENT: Invalid Git History Detected
+
+**Branch:** \`${branch}\`
+**Pushed by:** @${pusher}
+**Invalid root commit(s):** \`${invalidRoots}\`
+
+This branch contains git history from before the repository re-initialization and must be deleted immediately to prevent exposure of sensitive data.
+
+### Required Actions:
+
+1. **Save your work:**
+   \`\`\`bash
+   git diff origin/dev > my-changes.patch
+   \`\`\`
+
+2. **Delete this branch:**
+   \`\`\`bash
+   git push origin --delete ${branch}
+   \`\`\`
+
+3. **Create a clean branch:**
+   \`\`\`bash
+   git checkout -b ${branch} origin/dev
+   git apply my-changes.patch
+   git add .
+   git commit -m "Re-apply changes on clean branch"
+   git push -u origin ${branch}
+   \`\`\`
+
+**This branch will be blocked from merging to dev/main.**
+
+Contact @jake-mahon-netwrix if you need assistance.
+
+---
+*Automated alert from [Validate Branch History workflow](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})*`
+            });
+
+            console.log('Issue created for invalid branch');
+
+
 permissions:
   contents: read
   pull-requests: write
+  issues: write


### PR DESCRIPTION
## Summary
This workflow prevents branches with old git history from being merged into dev or main by validating that all branches descend from valid repository initialization commits.

## How it works
- Checks ALL root commits of every pushed branch (handles merged branches)
- Compares against a list of valid root commits (currently the December 2025 initialization)
- Fails the check if ANY branch root is invalid
- Displays clear error message with step-by-step remediation instructions
- Prevents merge via branch protection rules (requires setup)

## Why this is needed
After the repository was re-initialized to remove sensitive data, we discovered that branches with old history can still be pushed and potentially merged, re-introducing the sensitive data we removed.

## Features
- **Multi-root detection**: Handles merged branches with multiple root commits
- **Clear error messages**: Detailed remediation instructions in workflow logs
- **Fork PR safe**: Works correctly for both internal and fork PRs
- **Minimal permissions**: Only requires contents:read and pull-requests:read
- **Simple & clean**: No issue clutter, just failed checks that block merges

## Branch Protection Setup (Required)

After this PR is merged, **you must configure branch protection rules**:

1. Go to Settings → Branches → Branch protection rules
2. Edit the `dev` rule:
   - Under "Require status checks to pass before merging"
   - Add required check: **`Validate Clean History`**
3. Repeat for `main` branch

**Status check name**: `Validate Clean History`

Without this setup, the workflow will alert but won't block merges.

## Future-proof
If the repository needs to be re-initialized again, simply add the new root commit to the `VALID_ROOTS` array in the workflow (line 32).

## How developers will be notified
When a branch with invalid history is pushed:
1. The workflow check fails with a clear error message
2. The error message includes step-by-step fix instructions
3. Branch protection prevents merge until the issue is resolved
4. No GitHub issues are created (keeps repo clean)