### PR TITLE
Fix build workflow and broken anchor link

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - dev
+  pull_request:
+    branches:
+      - dev
   workflow_dispatch:
     inputs:
       environment:

--- a/docs/threatprevention/8.0/admin/configuration/epesettings.md
+++ b/docs/threatprevention/8.0/admin/configuration/epesettings.md
@@ -337,3 +337,14 @@ The Substitutions Editor has the following options:
 
 Click **OK** to save the changes and close the window. Click **Cancel** to close the window to
 discard any changes made.
+
+### Download and Configure the Have I Been Pwnd Hash List
+
+If the Administration Console does not have internet access, you can manually download the HIBP
+database.
+
+The Pwned Passwords Downloader is a Dotnet tool used to download all Pwned Passwords hash ranges and
+save them offline so they can be used without a dependency on the k-anonymity API. Use this tool to
+get the latest breached hashes from the Have I Been Pwned (HIBP) database.
+
+See the [Have I Been Pwned](https://haveibeenpwned.com/) website for more information about the HIBP database.


### PR DESCRIPTION
## Summary
- Add `pull_request` trigger to build-and-deploy workflow for dev branch
- Add missing 'Download and Configure the Have I Been Pwnd Hash List' section to epesettings.md

## Problem
1. Build check was required by branch protection but never ran on PRs (only on push)
2. Broken anchor link in threatprevention docs caused build failures

## Fix
1. Workflow now triggers on `pull_request` to dev branch
2. Added missing heading section that was being referenced but didn't exist

## Test Plan
- [ ] Verify build check runs on this PR
- [ ] Verify build passes without broken anchor errors