### PR TITLE
Update Settings > Application overview to add context

### DIFF
--- a/docs/accessanalyzer/12.0/admin/settings/application/overview.md
+++ b/docs/accessanalyzer/12.0/admin/settings/application/overview.md
@@ -47,7 +47,7 @@ available in the Application log level drop-down menu include:
     - Records job completion time
 
 :::info
-Set the log level to **Warning**.
+Set the log level to **Warning**. The log level set at the global level determines what messages are written to the SA_Messages table. If a job has a higher log level than the global setting, those messages will be written to the job log, but will not be written to the database or visible in the NAA Console.
 :::
 
 

--- a/docs/accessanalyzer/12.0/admin/settings/application/overview.md
+++ b/docs/accessanalyzer/12.0/admin/settings/application/overview.md
@@ -47,7 +47,7 @@ available in the Application log level drop-down menu include:
     - Records job completion time
 
 :::info
-Set the log level to **Warning**. The log level set at the global level determines what messages are written to the SA_Messages table. If a job has a higher log level than the global setting, those messages will be written to the job log only. They will not be written to the database or visible in the NAA Console.
+Set the log level to **Warning**. The global log level determines what messages are written to the SA_Messages table and visible in the NAA Console. If a job has a higher log level than the global setting, those additional messages will be written to the job log only and will not appear in the database. For additional information on changing the job log level, see [Job Properties | General tab](https://docs.netwrix.com/docs/accessanalyzer/12_0/admin/jobs/job/properties/general).
 :::
 
 

--- a/docs/accessanalyzer/12.0/admin/settings/application/overview.md
+++ b/docs/accessanalyzer/12.0/admin/settings/application/overview.md
@@ -47,7 +47,7 @@ available in the Application log level drop-down menu include:
     - Records job completion time
 
 :::info
-Set the log level to **Warning**. The log level set at the global level determines what messages are written to the SA_Messages table. If a job has a higher log level than the global setting, those messages will be written to the job log, but will not be written to the database or visible in the NAA Console.
+Set the log level to **Warning**. The log level set at the global level determines what messages are written to the SA_Messages table. If a job has a higher log level than the global setting, those messages will be written to the job log only. They will not be written to the database or visible in the NAA Console.
 :::
 
 


### PR DESCRIPTION
Added additional context as to why Warning is the recommended logging level and to clarify how the product logs errors in the database vs. the job logs.