### PR TITLE
fixed page meta values for kb articles

### DIFF
--- a/src/config/products.js
+++ b/src/config/products.js
@@ -711,7 +711,12 @@ export function getDefaultVersion(product) {
 export function createProductMap() {
   const map = {};
   PRODUCTS.forEach((product) => {
+    const injectSubDir = ['kb'];
     map[`/${product.path}`] = product.name;
+    injectSubDir.forEach((subDir) => {
+      const injectedPath = product.path.replace('docs/', `docs/${subDir}/`);
+      map[`/${injectedPath}`] = product.name;
+    })
   });
   return map;
 }

--- a/src/config/products.js
+++ b/src/config/products.js
@@ -710,8 +710,8 @@ export function getDefaultVersion(product) {
  */
 export function createProductMap() {
   const map = {};
+  const injectSubDir = ['kb'];
   PRODUCTS.forEach((product) => {
-    const injectSubDir = ['kb'];
     map[`/${product.path}`] = product.name;
     injectSubDir.forEach((subDir) => {
       const injectedPath = product.path.replace('docs/', `docs/${subDir}/`);


### PR DESCRIPTION
KB articles weren't properly indexed by algolia because the product meta tags weren't included on those pages. This change will allow you to add any other subdirectories as well