### PR TITLE
Fix homepage crash caused by null/undefined tag values

### DIFF
--- a/src/components/CommunityHighlights/index.js
+++ b/src/components/CommunityHighlights/index.js
@@ -68,7 +68,7 @@ function FeaturedDiscussion({ topic }) {
 
   // Find the first product tag that matches our known product list
   const productTag = topic.tags
-    ? topic.tags.find((tag) => PRODUCT_TAGS.includes(tag.toLowerCase()))
+    ? topic.tags.find((tag) => typeof tag === 'string' && PRODUCT_TAGS.includes(tag.toLowerCase()))
     : null;
 
   return (

--- a/src/components/CommunityShowcase/index.js
+++ b/src/components/CommunityShowcase/index.js
@@ -57,7 +57,7 @@ function TopicItem({ topic, showCategory = false, showVotes = false, showSolved 
 
   // Find product tag for all sections that should show it
   const productTag = topic.tags
-    ? topic.tags.find((tag) => PRODUCT_TAGS.includes(tag.toLowerCase()))
+    ? topic.tags.find((tag) => typeof tag === 'string' && PRODUCT_TAGS.includes(tag.toLowerCase()))
     : null;
 
   return (


### PR DESCRIPTION
The CommunityHighlights and CommunityShowcase components were calling .toLowerCase() on tag array elements without validating they are strings first. This caused crashes when the Discourse API returned null or undefined values in the tags array. Added typeof check to ensure only string tags are processed.