### PR TITLE
Updated 11.6 documentation to match 12.0 for windows fs permissions

### DIFF
--- a/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md
@@ -6,14 +6,36 @@ sidebar_position: 10
 
 # Windows File Server Access & Sensitive Data Auditing Configuration
 
-Permissions required for Enterprise Auditor to execute Access Auditing (SPAA) and/or Sensitive Data
-Discovery Auditing scans on a Windows file server are dependent upon the Scan Mode Option selected.
+Permissions required for Access Analyzer to execute Access Auditing (FSAA) and/or Sensitive Data
+Discovery Auditing (SEEK) scans on a Windows file server are dependent upon the Scan Mode Option selected.
 See the
-[File System Supported Platforms](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/filesystems.md)
-topic for additional information.
+[File System Supported Platforms](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/filesystems.md) topic
+for additional information.
 
 However, additional considerations are needed when targeting a Windows File System Clusters or DFS
 Namespaces.
+
+## Windows File System (Standard)
+
+Configure the credential(s) with the following rights on the Windows host(s):
+
+- For **Local** or **Proxy as a Service Mode** Scans: 
+  - Group membership in both of the following local groups:
+    - Power Users
+    - Backup Operators
+- For **Applet** or **Proxy with Applet Mode** Scans: 
+  - Group membership in the following group:
+    - Local Administrators
+  - Granted the “Log on as a batch” privilege
+  - Remote Registry service must be enabled on the host where the applet is deployed (Applet or Proxy w/ Applet scans) to determine the system platform and where to deploy the applet.
+  - The local policy, “Network access: Do not allow storage of passwords and credentials for network authentication” must be disabled in order for the applet to start.
+  - Sensitive Data Discovery Auditing scans require .NET Framework 4.7.2 or later to be installed on the server where the applet is to be deployed in order for Sensitive Data Discovery collections to successfully occur.
+- Granted the "Network access: Restrict clients allowed to make remote calls to SAM" Local Policies > Security Options privilege
+- Granted the “Backup files and directories” local policy privilege
+
+:::note
+In order to collect data on administrative shares and local policies (logon policies) for a Windows target, the credential must have group membership in the local Administrators group.
+:::
 
 ## Windows File System Clusters
 
@@ -21,64 +43,32 @@ The permissions necessary to collect file system data from a Windows File System
 for all nodes that comprise the cluster.
 
 :::note
-It is necessary to target the Windows File Server Cluster (name of the cluster) of
-interest when running a File System scan against a Windows File System Cluster.
+It is necessary to target the Windows Cluster File Server Role Server (name clients connect to) of interest when running a File System scan against a Windows File System Cluster.
 :::
 
+Configure credentials on all cluster nodes according to the Windows File System (Standard) permissions, with the following additional requirements:
 
-Configure credentials on all cluster nodes according to the Windows Operating Systems required
-permissions for the desired scan mode with these additional considerations:
+* Remote Registry Service must be enabled on all nodes that comprise the cluster
+* Group membership in the local Administrators group
+* Granted the “Log on as a batch” privilege
 
-- For
-  [Applet Mode](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/scanoptions.md#applet-mode)
-  and
-  [Proxy Mode with Applet](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/scanoptions.md#proxy-mode-with-applet):
+### Host List Considerations
 
-    - Applet will be deployed to each node
-    - Credential used in the Connection Profile must have rights to deploy the applet to each node
+It is necessary to target the Windows File Server Cluster (name of the cluster) of interest when running a File System scan against a Windows File System Cluster. Within the Master Host Table, there should be a host entry for the cluster as well as for each node. Additionally, each of these host entries must have the name of the cluster in the `WinCluster` column in the host inventory data. This may need to be updated manually.
 
-- For
-  [Proxy Mode as a Service](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/scanoptions.md#proxy-mode-as-a-service):
+See the View/Edit section of the [Host Management Activities](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/hostmanagement/actions/overview) topic for additional information on host inventory.
 
-    - Proxy Service must be installed on each node
-    - For Sensitive Data Discovery Auditing scans, the Sensitive Data Discovery Add-on must be
-      installed on each node
-
-Additionally, the credential used within the Connection Profile must have rights to remotely access
-the registry on each individual cluster node.
-
-:::tip
-Remember, Remote Registry Service must be enabled on all nodes that comprise the cluster.
-Configure the credential(s) with the following rights on all nodes:
-:::
-
-
-- Group membership in the local Administrators group
-- Granted the “Log on as a batch” privilege
-
-**Host List Consideration**
-
-It is necessary to target the Windows File Server Cluster (name of the cluster) of interest when
-running a File System scan against a Windows File System Cluster. Within the Master Host Table,
-there should be a host entry for the cluster as well as for each node. Additionally, each of these
-host entries must have the name of the cluster in the `WinCluster` column in the host inventory
-data. This may need to be updated manually.
-
-See the View/Edit section of the
-[Host Management Activities](/docs/accessanalyzer/11.6/admin/hostmanagement/actions/overview.md)
-topic for additional information on host inventory.
-
-- For FSAA and SDD scans, configure a custom host list to target the cluster's Role Server.
-- For FSAC scans, configure a custom host list to target the Windows File Server Cluster.
+- For FSAA and SDD scans, configure a custom host list to target the cluster's **Role Server**.
 
 The host targeted by the File System scans is only the host entry for the cluster. For example:
 
-The environment has a Windows File System Cluster named `ExampleCluster1` with three nodes named
-`ExampleNodeA`, `ExampleNodeB`, and `ExampleNodeC`. There would be four host entries in the
-StealthAUDIT Master Host Table: `ExampleCluster1`, `ExampleNodeA`, `ExampleNodeB`, and
-`ExampleNodeC`. Each of these four entries would have the same value of the cluster name in the
-`WinCluster` column: `ExampleCluster1`. Only the `ExampleCluster1` host would be in the host list
-targeted by the File System scans.
+The environment has a Windows File System Cluster named `ExampleCluster1` with three nodes named `ExampleNodeA`, `ExampleNodeB`, and `ExampleNodeC`. There would be four host entries in the Access Analyzer Master Host Table: `ExampleCluster1`, `ExampleNodeA`, `ExampleNodeB`, and `ExampleNodeC`. Each of these four entries would have the same value of the cluster name in the `WinCluster` column: `ExampleCluster1`. An additional entry containing the File Server Role Server name(s) should also be added, including the WinCluster name of the nodes. **This File Server Role Server name will be our target host.**
+
+### Least Privilege Permission Model for Windows Clusters
+
+If a least privilege model is required by the organization, then the credential must have READ access on the following registry key:
+
+* `HKEY_LOCAL_MACHINE\Cluster\Nodes`
 
 **Sensitive Data Discovery Scans**
 
@@ -89,58 +79,18 @@ comprise the cluster:
 - Power Users
 - Backup Operators
 
-**Activity Auditing Scans**
-
-The Netwrix Activity Monitor must deploy an Activity Agent on all nodes that comprise the Windows
-File System Cluster. The Activity Agent generates activity log files stored on each node. Enterprise
-Auditor targets the Windows File Server Cluster (name of the cluster) of interest in order to read
-the activity. See the
-[Windows File Server Activity Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md)
-topic for additional information.
-
-The credential used Enterprise Auditor to read the activity log files must have:
-
-- Membership in the local Administrators group
-
-The FileSystemAccess Data Collector needs to be specially configured to run the
-[1-FSAC System Scans Job](/docs/accessanalyzer/11.6/solutions/filesystem/collection/1-fsac_system_scans.md)
-against a Windows File System Cluster. On the
-[FSAA: Activity Settings](/docs/accessanalyzer/11.6/admin/datacollector/fsaa/activitysettings.md),
-configure the Host Mapping option. This provides a method for mapping between the target host and
-the hosts where activity logs reside. However, this feature requires **advanced SQL scripting
-knowledge** to build the query.
-
-**Membership in the local Administrators group**
-
-### Least Privilege Permission Model for Windows Cluster
-
-If a least privilege model is required by the organization, then the credential must have READ
-access on the following registry keys:
-
-- `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SBTLogging\Parameters`
-- `HKEY_LOCAL_MACHINE\Cluster\Nodes`
-
-Additionally, the credential must have READ access to the path where the activity log files are
-located.
-
 ## DFS Namespaces
 
 The FileSystem > 0.Collection > 0-FSDFS System Scans Job is configured by default to target the
-default domain controller for the domain in which Enterprise Auditor resides. This is the
-appropriate target host for this job when targeting a domain-based namespace. To target a standalone
-namespace or multiple namespaces, create a custom host list of the server(s) hosting the
-namespace(s). Then assign the custom host list to the 0-FSDFS System Scans Job. No additional host
-list is require for the FileSystem > 0.Collection Job Group unless additional file servers are also
-being targeted.
+default domain controller for the domain in which Access Analyzer resides. This is the appropriate
+target host for this job when targeting a domain-based namespace. To target a standalone namespace
+or multiple namespaces, create a custom host list of the server(s) hosting the namespace(s). Then
+assign the custom host list to the 0-FSDFS System Scans Job. No additional host list is require for
+the FileSystem > 0.Collection Job Group unless additional file servers are also being targeted.
 
 **DFS as Part of a Windows Cluster Consideration**
 
 If the DFS hosting server is part of a Windows Cluster, then the Windows File System Clusters
 requirements must be included with the credential.
 
-**DFS and Activity Auditing Consideration**
 
-For activity monitoring, the Netwrix Activity Monitor must have a deployed Activity Agent on all DFS
-servers identified by the 0-FSDFS System Scans Job and populated into the dynamic host list. See the
-[Windows File Server Activity Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md)
-topic for additional information.

--- a/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md
@@ -65,14 +65,14 @@ Host Mapping is only required for multi-role cluster setups. See topic [Windows 
    1. **3 Columns:** LogLocation, HostName, Host
    2. **Data Type:** nvarchar(MAX)
 
-![Host Mapping Table Design](/images/accessanalyzer/11.6/requirements/target/config/HostMapping1.webp)
+![Host Mapping Table Design](/images/accessanalyzer/12.0/requirements/target/config/HostMapping1.webp)
 
 2. Configure the new host mapping table to such:
    1. **LogLocation:** Name of the host/node where activity logs reside.
    2. **HostName:** Name of the configured Report hostname as value in the Activity Monitor.
    3. **Host:** Name of the host being targeted in the FSAC scan and Bulk Import which the activity events will be mapped to (Role Server).
 
-![Host Mapping Table Example](/images/accessanalyzer/11.6/requirements/target/config/HostMapping2.webp)
+![Host Mapping Table Example](/images/accessanalyzer/12.0/requirements/target/config/HostMapping2.webp)
 
 3. Enable host mapping on the *Activity Settings* tab of the FSAC System Scan query configuraton. See topic [FSAA: Activity Settings](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/datacollector/fsaa/activitysettings) for additional information.
 

--- a/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md
@@ -6,45 +6,81 @@ sidebar_position: 20
 
 # Windows File Server Activity Auditing Configuration
 
-In order for the Netwrix Activity Monitor to monitor Windows file server activity, an Activity Agent
-must be deployed to the server. It cannot be deployed to a proxy server. However, additional
-considerations are needed when targeting a Windows File System Clusters or DFS Namespaces.
+In order for Netwrix Access Analyzer to collect and store Windows file server activity, an activity monitor agent for Netwrix Activity Monitor must be deployed to the server and monitoring. See the [Single Activity Agent Deployment](https://docs.netwrix.com/docs/activitymonitor/9_0/admin/agents/overview) topic for additional information.
+
+## Windows File System (Standard)
+
+Configure the credential(s) with the following rights on the Windows host(s):
+
+- For **Local** or **Proxy as a Service Mode** Scans: 
+  - Group membership in both of the following local groups:
+    - Power Users
+    - Backup Operators
+- For **Applet** or **Proxy with Applet Mode** Scans: 
+  - Group membership in the following group:
+    - Local Administrators
+  - Granted the “Log on as a batch” privilege
+  - Remote Registry service must be enabled on the host where the applet is deployed (Applet or Proxy w/ Applet scans) to determine the system platform and where to deploy the applet.
+  - The local policy, “Network access: Do not allow storage of passwords and credentials for network authentication” must be disabled in order for the applet to start.
+- Granted the "Network access: Restrict clients allowed to make remote calls to SAM" Local Policies > Security Options privilege
+- Granted the “Backup files and directories” local policy privilege
+- The service account in the credential profile requires access to the admin share (e.g. `C$`) where the `sbtfilemon.ini` file exists
+- READ access on the following registry key: `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SBTLogging\Parameters`
 
 ## Windows File System Clusters
 
-In order to monitor a Windows File System Cluster, an Activity Agent needs to be deployed on all
-nodes that comprise the Windows File System Cluster. The credential used to deploy the Activity
-Agent must have the following permissions on the server:
-
-- Membership in the local Administrators group
-- READ and WRITE access to the archive location for Archiving feature only
-
-It is also necessary to enable the Remote Registry Service on the Activity Agent server.
-
-For integration between the Activity Monitor and Enterprise Auditor, the credential used by
-Enterprise Auditor to read the activity log files must have also have this permission.
-
-After the agent has been deployed, it is necessary to modify the HOST parameter in the
-`SBTFilemon.ini` file to be the name of the cluster. For integration with Netwrix Enterprise
-Auditor, this must be an exact match to the name of the cluster in the Master Host Table.
-
-## DFS Namespaces
-
-In order to monitor activity on DFS Namespaces, an Activity Agent needs to be deployed on all DFS
-servers.
+In order to monitor a Windows File System Cluster, an Activity Agent needs to be deployed on all nodes that comprise the Windows File System Cluster.
 
 :::note
-The FileSystem > 0.Collection > 0-FSDFS System Scans Job in Netwrix Enterprise Auditor can
-be used to identify all DFS servers.
+It is necessary to target the Windows Cluster File Server Role Server (name clients connect to) when running a File System scan against a Windows File System Cluster.
 :::
 
+Configure credentials according to the Windows File System (Standard) permissions on all cluster nodes that comprise the cluster, with the following additional requirements:
 
-The credential used to deploy the Activity Agent must have the following permissions on the server:
+- Remote Registry Service must be enabled on all nodes that comprise the cluster
+- Group membership in the local Administrators group
+- Granted the “Log on as a batch” privilege
 
-- Membership in the local Administrators group
-- READ and WRITE access to the archive location for Archiving feature only
+### Host List Considerations
 
-It is also necessary to enable the Remote Registry Service on the Activity Agent server.
+It is necessary to target the Windows File Server Cluster (name of the cluster) of interest when running a File System scan against a Windows File System Cluster. Within the Master Host Table, there should be a host entry for the cluster as well as for each node. Additionally, each of these host entries must have the name of the cluster in the `WinCluster` column in the host inventory data. This may need to be updated manually.
 
-For integration between the Activity Monitor and Enterprise Auditor, the credential used by
-Enterprise Auditor to read the activity log files must have also have this permission.
+See the View/Edit section of the [Host Management Activities](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/hostmanagement/actions/overview) topic for additional information on host inventory.
+
+- For FSAC scans, configure a custom host list to target the cluster's **Role Server**.
+
+The host targeted by the File System scans is only the host entry for the cluster. 
+
+:::note Example:
+
+The environment has a Windows File System Cluster named `ExampleCluster1` with three nodes named `ExampleNodeA`, `ExampleNodeB`, and `ExampleNodeC`. There would be four host entries in the Access Analyzer Master Host Table: `ExampleCluster1`, `ExampleNodeA`, `ExampleNodeB`, and `ExampleNodeC`. Each of these four entries would have the same value of the cluster name in the `WinCluster` column: `ExampleCluster1`. An additional entry containing the File Server Role Server name(s) should also be added, including the WinCluster name of the nodes. This File Server Role Server name will be our target host.
+:::
+
+### Host Mapping
+:::note
+Host Mapping is only required for multi-role cluster setups. See topic [Windows File Server Activity Auditing Configuration - Multi-Role (Advanced) Setup](https://docs.netwrix.com/docs/activitymonitor/9_0/requirements/activityagent/windowsfs-activity)
+:::
+
+1. Create new table in the Access Analyzer database to be used as the Host Mapping table. The column names are case sensitive.
+   1. **3 Columns:** LogLocation, HostName, Host
+   2. **Data Type:** nvarchar(MAX)
+
+![Host Mapping Table Design](/images/accessanalyzer/11.6/requirements/target/config/HostMapping1.webp)
+
+2. Configure the new host mapping table to such:
+   1. **LogLocation:** Name of the host/node where activity logs reside.
+   2. **HostName:** Name of the configured Report hostname as value in the Activity Monitor.
+   3. **Host:** Name of the host being targeted in the FSAC scan and Bulk Import which the activity events will be mapped to (Role Server).
+
+![Host Mapping Table Example](/images/accessanalyzer/11.6/requirements/target/config/HostMapping2.webp)
+
+3. Enable host mapping on the *Activity Settings* tab of the FSAC System Scan query configuraton. See topic [FSAA: Activity Settings](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/datacollector/fsaa/activitysettings) for additional information.
+
+### Least Privilege Permission Model for Windows Clusters
+
+If a least privilege model is required by the organization, then the credential must have READ access on the following registry keys:
+
+* `HKEY_LOCAL_MACHINE\Cluster\Nodes`
+* `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\services\SBTLogging\Parameters`
+
+Additionally, the credential must have READ access to the path where the activity log files are located.

--- a/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/overview.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/overview.md
@@ -1,77 +1,56 @@
 ---
 title: "Windows File Server Target Requirements"
 description: "Windows File Server Target Requirements"
-sidebar_position: 110
+sidebar_position: 120
 ---
 
 # Windows File Server Target Requirements
 
-Netwrix Enterprise Auditor can execute Access Auditing (FSAA) and/or Sensitive Data Discovery
-Auditing scans on Windows file servers. The Netwrix Activity Monitor can be configured to monitor
-activity on Windows file servers and make the event data available for Enterprise Auditor Activity
-Auditing (FSAC) scans.
+Netwrix Access Analyzer (formerly Enterprise Auditor) can execute Access Auditing (FSAA) and/or
+Sensitive Data Discovery Auditing (SEEK) scans on Windows file servers. The Netwrix Activity Monitor can be
+configured to monitor activity on Windows file servers and make the event data available for Access
+Analyzer Activity Auditing (FSAC) scans.
 
 ## Access & Sensitive Data Auditing Permissions
 
-- Permissions vary based on the Scan Mode Option selected. See the
+Permissions vary based on the Scan Mode Option selected. See the
   [File System Supported Platforms](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/filesystems.md)
-  topic for additional information.
+  topic for additional information on the various scan modes available and [Windows File Server Access & Sensitive Data Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md).
 
 **Windows File System Cluster Requirements**
 
-See the
-[Windows File Server Access & Sensitive Data Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md)
-topic for instructions.
+See the [Windows File Server Access & Sensitive Data Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md) topic for
+instructions.
 
 **Windows File System DFS Namespaces Requirements**
 
-See the
-[Windows File Server Access & Sensitive Data Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md)
-topic for instructions.
+See the [Windows File Server Access & Sensitive Data Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/access.md) topic for
+instructions.
 
-## Access & Sensitive Data Auditing Port Requirements
+### Access & Sensitive Data Auditing Port Requirements
 
-The firewall ports required by Enterprise Auditor for Access Auditing (FSAA) and/or Sensitive Data
+The firewall ports required by Access Analyzer for Access Auditing (FSAA) and/or Sensitive Data
 Discovery Auditing scans are based on the File System scan mode to be used. See the
 [File System Scan Options](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/scanoptions.md)
 topic for additional information.
 
 ## Activity Auditing Permissions
 
-Requirements to Deploy the Activity Agent on the Windows File Server
-
-The Netwrix Activity Monitor must have an Activity Agent deployed on the Windows file server to be
-monitored. While actively monitoring, the Activity Agent generates activity log files stored on the
-server. The credential used to deploy the Activity Agent must have the following permissions on the
-server:
-
-- Membership in the local Administrators group
-- READ and WRITE access to the archive location for Archiving feature only
-
-It is also necessary to enable the Remote Registry Service on the Activity Agent server.
-
-For integration between the Activity Monitor and Enterprise Auditor, the credential used by
-Enterprise Auditor to read the activity log files must have also have this permission.
+Permissions vary based on the Scan Mode Option selected. See the
+  [File System Supported Platforms](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/filesystems.md)
+  topic for additional information on the various scan modes available and [Windows File Server Activity Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md).
 
 **Windows File System Cluster Requirements**
 
-See the
-[Windows File Server Activity Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md)
-topic for instructions.
-
-**Windows File System DFS Namespaces Requirements**
-
-See the
-[Windows File Server Activity Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md)
-topic for instructions.
+See the [Windows File Server Activity Auditing Configuration](/docs/accessanalyzer/11.6/requirements/filesystem/filesystems/windowsfile/activity.md) topic for instructions.
 
 **Activity Monitor Archive Location**
 
 If the activity log files are being archived, configurable within the Netwrix Activity Monitor
-Console, then the credential used by Enterprise Auditor to read the activity log files must also
-have READ and WRITE permissions on the archive location.
+Console, then the credential used by Access Analyzer to read the activity log files must also have
+READ and WRITE permissions on the archive location.
 
-## Activity Auditing Port Requirements
+### Activity Auditing Port Requirements
 
 Firewall settings depend on the type of environment being targeted. The following firewall settings
 are required for communication between the Agent server and the Netwrix Activity Monitor Console:
@@ -86,12 +65,12 @@ port range, which cannot be specified via an inbound rule. For more information,
 [Connecting to WMI on a Remote Computer](https://msdn.microsoft.com/en-us/library/windows/desktop/aa389290(v=vs.85).aspx)
 article.
 
-Additional Firewall Rules for Integration between Enterprise Auditor and Activity Monitor
+**Additional Firewall Rules for Integration between Access Analyzer and Activity Monitor**
 
 Firewall settings are dependent upon the type of environment being targeted. The following firewall
-settings are required for communication between the agent server and the Enterprise Auditor Console:
+settings are required for communication between the agent server and the Access Analyzer Console:
 
-| Communication Direction            | Protocol | Ports      | Description                    |
-| ---------------------------------- | -------- | ---------- | ------------------------------ |
-| Enterprise Auditor to Agent Server | TCP      | 445        | SMB, used for Agent Deployment |
-| Enterprise Auditor to Agent Server | TCP      | Predefined | WMI, used for Agent Deployment |
+| Communication Direction         | Protocol | Ports      | Description                    |
+| ------------------------------- | -------- | ---------- | ------------------------------ |
+| Access Analyzer to Agent Server | TCP      | 445        | SMB |
+| Access Analyzer to Agent Server | TCP      | Predefined | WMI |

--- a/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/appletmodescans/appletmodepermissions.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/appletmodescans/appletmodepermissions.md
@@ -25,7 +25,7 @@ The local policy, “Network access: Do not allow storage of passwords and crede
 for network authentication” must be disabled in order for the applet to start.
 :::
 
-See the [Applet Mode Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/applet-mode-scans/appletmodeports.md) topic for firewall rule information.
+See the [Applet Mode Port Requirements](https://docs.netwrix.com/docs/accessanalyzer/12_0/requirements/filesystem/scanoptions/applet-mode-scans/appletmodeports) topic for firewall rule information.
 
 ## Accounts Used
 - **Job Execution:** Scheduled Task or Console User (launches the job)

--- a/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/appletmodescans/appletmodepermissions.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/appletmodescans/appletmodepermissions.md
@@ -6,27 +6,13 @@ sidebar_position: 10
 
 # Applet Mode Permissions
 
-When File System scans are run in applet mode, it means the File System applet is deployed to the
-target host when the job is executed to conduct data collection. However, the applet can only be
-deployed to a server with a Windows operating system. The data is collected on the Windows target
-host where the applet is deployed. The final step in data collection is to compress and transfer the
-data collected in the SQLite database(s), or Tier 2 database(s), back to the Enterprise Auditor
-Console server. If the target host is a NAS device, the File System scans will default to local mode
-for that host.
+When File System scans are run in applet mode, it means the File System applet is deployed to the target host when the job is executed to conduct data collection. However, the applet can only be deployed to a server with a Windows operating system. The data is collected on the Windows target host where the applet is deployed. The final step in data collection is to compress and transfer the data collected in the SQLite database(s), or Tier 2 database(s), back to the Access Analyzer Console server. If the target host is a NAS device, the File System scans will default to local mode for that host.
 
-Configure the credential(s) with the following rights on the Windows target host(s):
 
-- Group membership in the local Administrators group
-- Granted the “Backup files and directories” local policy privilege
-- Granted the “Log on as a batch” privilege
-- Granted the "Network access: Restrict clients allowed to make remote calls to SAM" Local
-  Policies > Security Options privilege
+Additionally, the credential must have `WRITE` access to the `…\StealthAUDIT\FSAA` folder in the installation directory on the target host/proxy server as well as on the Access Analyzer Console server. This is required by either the user account running the Access Analyzer application, when manually executing jobs within the console, or the Schedule Service Account assigned within Access Analyzer, when running jobs as a scheduled tasks.
 
-Additionally, the credential must have `WRITE` access to the `…\StealthAUDIT\FSAA` folder in the
-installation directory on the target host/proxy server as well as on the Enterprise Auditor Console
-server. This is required by either the user account running the Enterprise Auditor application, when
-manually executing jobs within the console, or the Schedule Service Account assigned within
-Enterprise Auditor, when running jobs as a scheduled tasks.
+
+Sensitive Data Discovery Auditing scans require .NET Framework 4.7.2 or later to be installed on the server where the applet is to be deployed in order for Sensitive Data Discovery collections to successfully occur.
 
 :::tip
 Remember, Remote Registry Service must be enabled on the host where the applet is deployed (for
@@ -34,23 +20,25 @@ Applet Mode or Proxy Mode with Applet scans) to determine the system platform an
 the applet.
 :::
 
-
 :::warning
 The local policy, “Network access: Do not allow storage of passwords and credentials
 for network authentication” must be disabled in order for the applet to start.
 :::
 
+See the [Applet Mode Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/applet-mode-scans/appletmodeports.md) topic for firewall rule information.
 
-Sensitive Data Discovery Auditing scans also require .NET Framework 4.7.2 or later. to be installed
-on the server where the applet is to be deployed in order for Sensitive Data Discovery collections
-to successfully occur. The Sensitive Data Discovery Add-On must be installed on the Enterprise
-Auditor Console server, which enables Sensitive Data criteria for scans.
+## Accounts Used
+- **Job Execution:** Scheduled Task or Console User (launches the job)
+- **Target Access:** Connection Profile Account (always used for scanning)
 
-When running Access Auditing (FSAA) and/or Sensitive Data Discovery Auditing scans, the credentials
-within the Connection Profile assigned to the File System scans must be properly configured as
-explained above. Also the firewall rules must be configured to allow for communication between the
-applicable servers.
+:::note
+By default, the Applet will run as the connection profile account unless an additional credential is added to the connection profile using either **Task (Local)** or **Task (Domain)**.
+:::
 
-See the
-[Applet Mode Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/appletmodescans/appletmodeports.md)
-topic for firewall rule information.
+The account used in the connection profile associated with the File System scan jobs, should have the appropriate permissions required to access the target host. See the [File System Supported Platforms](https://docs.netwrix.com/docs/accessanalyzer/11_6/requirements/filesystem/filesystems/) page for specific requirements per target file system.
+
+## How do I determine if I’m using Applet Mode scanning?
+
+The best way to verify if you’re using Applet Mode scanning is via the FSAA Data Collector Query Settings > [Scan Server Selection](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/datacollector/fsaa/scanserverselection) page:
+
+- **Automatic** — If the target host being scanned is a Windows host, NEA will deploy for FS scanning.

--- a/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/localmodescans/localmodepermissions.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/localmodescans/localmodepermissions.md
@@ -6,51 +6,35 @@ sidebar_position: 10
 
 # Local Mode Permissions
 
-When File System scans are run in local mode, it means all of the data collection processing is
-conducted by the Enterprise Auditor Console server across the network. The data is collected in the
-SQLite database(s), or Tier 2 database(s), on the Enterprise Auditor Console server, and then
-imported into theEnterprise Auditor database, or Tier 1 database, on the SQL Server.
+When File System scans are run in local mode, it means all of the data collection processing is conducted by the Access Analyzer Console server across the network. The data is collected in the SQLite database(s), or Tier 2 database(s), on the Access Analyzer Console server, and then imported into the Access Analyzer database, or Tier 1 database, on the SQL Server.
 
-The account used to run either a manual execution or a scheduled execution of the File System scans,
-must have the following permissions on the StealthAUDIT Console server:
+
+The account used to run either a manual execution or a scheduled execution of the File System scans, must have the following permissions on the Access Analyzer Console server:
 
 - Group membership in either of the following local groups:
-    - Backup Operators
-    - Administrators
+  - Backup Operators
+  - Administrators
 
-Configure the credential(s) with the following rights on the Windows host(s):
 
-- Group membership in both of the following local groups:
-    - Power Users
-    - Backup Operators
-- Granted the “Backup files and directories” local policy privilege
+Additionally, the credential must have `WRITE` access to the `…\StealthAUDIT\FSAA` folder in the installation directory on the Access Analyzer Console server. This is required by either the user account running the Access Analyzer application, when manually executing jobs within the console, or the Schedule Service Account assigned within Access Analyzer, when running jobs as a scheduled tasks.
 
-For Windows Server target hosts, the credential also requires:
 
-- Granted the "Network access: Restrict clients allowed to make remote calls to SAM" Local
-  Policies > Security Options privilege
+If running Sensitive Data Discovery (SDD) scans, it will be necessary to increase the minimum amount of RAM. Each thread requires a minimum of 2 additional GB of RAM per host.  By default, SDD scans are configured to run two concurrent threads. For example, if the job is configured to scan 8 hosts at a time with two concurrent SDD threads, then an extra 32 GB of RAM are required (8x2x2=32).
 
-In order to collect data on administrative shares and local policies (logon policies) for a Windows
-target, the credential must have group membership in the local Administrators group.
 
-Additionally, the credential must have `WRITE` access to the `…\StealthAUDIT\FSAA` folder in the
-installation directory on the Enterprise Auditor Console server. This is required by either the user
-account running the Enterprise Auditor application, when manually executing jobs within the console,
-or the Schedule Service Account assigned within Enterprise Auditor, when running jobs as a scheduled
-tasks.
+Firewall rules must be configured to allow for communication between the applicable servers. See the [Local Mode Port Requirements](https://docs.netwrix.com/docs/accessanalyzer/11_6/requirements/filesystem/scanoptions/local-mode-scans/localmodeports) topic for firewall rule information.
 
-The Sensitive Data Discovery Add-On must be installed on the Enterprise Auditor Console server,
-which enables Sensitive Data criteria for scans. If running Sensitive Data Discovery (SDD) scans, it
-will be necessary to increase the minimum amount of RAM. Each thread requires a minimum of 2
-additional GB of RAM per host.  By default, SDD scans are configured to run two concurrent threads.
-For example, if the job is configured to scan 8 hosts at a time with two concurrent SDD threads,
-then an extra 32 GB of RAM are required (8x2x2=32).
+See the [Local Mode Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/local-mode-scans/localmodeports.md) topic for firewall rule information.
 
-When running Access Auditing (FSAA) and/or Sensitive Data Discovery Auditing scans, the credentials
-within the Connection Profile assigned to the File System scans must be properly configured as
-explained above. Also the firewall rules must be configured to allow for communication between the
-applicable servers.
+## Accounts Used
+- **Job Execution:** Scheduled Task Account or Console User (launches the job)
+- **Target Access:** Connection Profile Account (always used for scanning)
 
-See the
-[Local Mode Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/localmodescans/localmodeports.md)
-topic for firewall rule information.
+The account used in the connection profile associated with the File System scan jobs, should have the appropriate permissions required to access the target host. See the [File System Supported Platforms](https://docs.netwrix.com/docs/accessanalyzer/11_6/requirements/filesystem/filesystems/) page for specific requirements per target file system.
+
+## How do I determine if I’m using Local Mode scanning?
+
+The best way to verify if you’re using Local Mode scanning is via the FSAA Data Collector Query Settings > [Scan Server Selection](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/datacollector/fsaa/scanserverselection) page:
+
+- **Automatic** — If the target host being scanned is a NAS/Non-Windows host, a Local Mode scan will be utilized.
+- **Local Server** — This will utilize a Local Mode scan, regardless of the OSType of the target host.

--- a/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/localmodescans/localmodepermissions.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/localmodescans/localmodepermissions.md
@@ -24,8 +24,6 @@ If running Sensitive Data Discovery (SDD) scans, it will be necessary to increas
 
 Firewall rules must be configured to allow for communication between the applicable servers. See the [Local Mode Port Requirements](https://docs.netwrix.com/docs/accessanalyzer/11_6/requirements/filesystem/scanoptions/local-mode-scans/localmodeports) topic for firewall rule information.
 
-See the [Local Mode Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/local-mode-scans/localmodeports.md) topic for firewall rule information.
-
 ## Accounts Used
 - **Job Execution:** Scheduled Task Account or Console User (launches the job)
 - **Target Access:** Connection Profile Account (always used for scanning)

--- a/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxymodescans/withapplet/proxymodeappletpermissions.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxymodescans/withapplet/proxymodeappletpermissions.md
@@ -6,33 +6,15 @@ sidebar_position: 10
 
 # Proxy Mode with Applet Permissions
 
-When File System scans are run in proxy mode with applet, it means the File System applet is
-deployed to the Windows proxy server when the job is executed to conduct data collection. The data
-collection processing is initiated by the proxy server where the applet is deployed and leverages a
-local mode-type scan to each of the target hosts. The final step in data collection is to compress
-and transfer the data collected in the SQLite databases, or Tier 2 databases, back to the Enterprise
-Auditor Console server.
+When File System scans are run in proxy mode with applet, it means the File System applet is deployed to the Windows proxy server when the job is executed to conduct data collection. The data collection processing is initiated by the proxy server where the applet is deployed and leverages a local mode-type scan to each of the target hosts. The final step in data collection is to compress and transfer the data collected in the SQLite databases, or Tier 2 databases, back to the Access Analyzer Console server.
 
 Configure the credential(s) with the following rights on the proxy server(s):
 
 - Group membership in the local Administrators group
 - Granted the Backup files and directories local policy privilege
 - Granted the Log on as a batch privilege
-- If the applet is deployed as a service, the service account requires the Log on as a service
-  privilege
 
-    - See the
-      [FSAA: Applet Settings](/docs/accessanalyzer/11.6/admin/datacollector/fsaa/appletsettings.md)
-      topic for additional information on the applet launch mechanism
-
-- If running FSAC, the service account in the credential profile requires access to the admin share
-  (e.g. `C$`) where the `sbtfilemon.ini` file exists
-
-Additionally, the credential must have `WRITE` access to the `…\StealthAUDIT\FSAA` folder in the
-installation directory on the proxy server as well as on the Enterprise Auditor Console server. This
-is required by either the user account running the Enterprise Auditor application, when manually
-executing jobs within the console, or the Schedule Service Account assigned within Enterprise
-Auditor, when running jobs as a scheduled tasks.
+Additionally, the credential must have `WRITE` access to the `…\StealthAUDIT\FSAA` folder in the installation directory on the proxy server as well as on the Access Analyzer Console server. This is required by either the user account running the Access Analyzer application, when manually executing jobs within the console, or the Schedule Service Account assigned within Access Analyzer, when running jobs as a scheduled tasks.
 
 :::tip
 Remember, Remote Registry Service must be enabled on the host where the applet is deployed (for
@@ -47,31 +29,13 @@ for network authentication” must be disabled in order for the applet to start.
 :::
 
 
-Configure the credential(s) with the following rights on the Windows host(s):
+Sensitive Data Discovery Auditing scans require .NET Framework 4.7.2 or later to be installed on the
+server where the applet is to be deployed in order for Sensitive Data Discovery collections to
+successfully occur.
 
-- Group membership in both of the following local groups:
-    - Power Users
-    - Backup Operators
-- Granted the “Backup files and directories” local policy privilege
 
-For Windows Server target hosts, the credential also requires:
-
-- Granted the "Network access: Restrict clients allowed to make remote calls to SAM" Local
-  Policies > Security Options privilege
-
-Sensitive Data Discovery Auditing scans also require .NET Framework 4.7.2 or later. to be installed
-on the server where the applet is to be deployed in order for Sensitive Data Discovery collections
-to successfully occur. The Sensitive Data Discovery Add-On must be installed on the Enterprise
-Auditor Console server, which enables Sensitive Data criteria for scans.
-
-When running Access Auditing (FSAA) and/or Sensitive Data Discovery Auditing scans, the credentials
-within the Connection Profile assigned to the File System scans must be properly configured as
-explained above. Also the firewall rules must be configured to allow for communication between the
-applicable servers.
-
-See the
-[Proxy Mode with Applet Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxymodescans/withapplet/proxymodeappletports.md)
-topic for firewall rule information.
+See the [Proxy Mode with Applet Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxy-mode-scans/with-applet/proxymodeappletports.md) topic for firewall rule
+information.
 
 **Secure Proxy Communication Considerations**
 
@@ -80,3 +44,20 @@ must be configured via the File System Access Auditing Data Collector Wizard pri
 scan. See the
 [FSAA Applet Certificate Management Overview](/docs/accessanalyzer/11.6/admin/datacollector/fsaa/certificatemanagement/certificatemanagement.md)
 topic for additional information.
+
+## Accounts Used
+- **Job Execution:** Scheduled Task or Console User (launches the job)
+- Console ↔ Applet: **NAA** **Computer Account (Kerberos)**
+- Target Access (Applet ↔ Targets): Connection Profile Account
+
+:::note
+By default, the Applet will run as the connection profile account unless an additional credential is added to the connection profile using either **Task (Local)** or **Task (Domain)**.
+:::
+
+The account used in the connection profile associated with the File System scan jobs, should have the appropriate permissions required to access the target host. See the [File System Supported Platforms](https://docs.netwrix.com/docs/accessanalyzer/11_6/requirements/filesystem/filesystems/) page for specific requirements per target file system.
+
+## **How do I determine if I’m using Proxy Mode with Applet scanning?**
+
+The best way to verify if you’re using Proxy Mode with Applet scanning is via the FSAA Data Collector Query Settings below:
+1. [Applet Settings](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/datacollector/fsaa/appletsettings) > Applet Launch Mechanism: MSTask Task Scheduler
+2. [Scan Server Selection](https://docs.netwrix.com/docs/accessanalyzer/11_6/admin/datacollector/fsaa/scanserverselection) > “Specific Remote Server: “ **OR** “Specific Remote Servers by Host List”

--- a/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxymodescans/withapplet/proxymodeappletpermissions.md
+++ b/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxymodescans/withapplet/proxymodeappletpermissions.md
@@ -34,7 +34,7 @@ server where the applet is to be deployed in order for Sensitive Data Discovery 
 successfully occur.
 
 
-See the [Proxy Mode with Applet Port Requirements](/docs/accessanalyzer/11.6/requirements/filesystem/scanoptions/proxy-mode-scans/with-applet/proxymodeappletports.md) topic for firewall rule
+See the [Proxy Mode with Applet Port Requirements](https://docs.netwrix.com/docs/accessanalyzer/11_6/requirements/filesystem/scanoptions/proxy-mode-scans/with-applet/proxymodeappletports) topic for firewall rule
 information.
 
 **Secure Proxy Communication Considerations**

--- a/docs/accessanalyzer/12.0/requirements/filesystem/filesystems/windowsfile/overview.md
+++ b/docs/accessanalyzer/12.0/requirements/filesystem/filesystems/windowsfile/overview.md
@@ -72,5 +72,5 @@ settings are required for communication between the agent server and the Access 
 
 | Communication Direction         | Protocol | Ports      | Description                    |
 | ------------------------------- | -------- | ---------- | ------------------------------ |
-| Access Analyzer to Agent Server | TCP      | 445        | SMB, used for Agent Deployment |
-| Access Analyzer to Agent Server | TCP      | Predefined | WMI, used for Agent Deployment |
+| Access Analyzer to Agent Server | TCP      | 445        | SMB |
+| Access Analyzer to Agent Server | TCP      | Predefined | WMI |


### PR DESCRIPTION
- Updated 11.6 documentation to match 12.0 for windows fs permissions (location change only)
- Fixed misleading table that made it look like NAA would deploy NAM agents