### PR TITLE
Add multi-stage issue processing workflow

### DIFF
--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -2,7 +2,7 @@ name: Claude Issue Labeler
 
 on:
   issues:
-    types: [opened]
+    types: []  # Disabled - replaced by claude-issue-processor.yml
 
 jobs:
   label-issue:

--- a/.github/workflows/claude-issue-processor.yml
+++ b/.github/workflows/claude-issue-processor.yml
@@ -1,0 +1,220 @@
+name: Claude Issue Processor
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  template-validation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    outputs:
+      template_type: ${{ steps.validate.outputs.template_type }}
+      validation_failed: ${{ steps.validate.outputs.validation_failed }}
+
+    steps:
+      - name: Checkout repository (Issue templates only)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/ISSUE_TEMPLATE
+          sparse-checkout-cone-mode: false
+
+      - name: Validate and correct template usage
+        id: validate
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+
+            A new issue has been opened. Your task is to validate that the correct issue template was used.
+
+            STEPS:
+            1. Read the issue using `gh issue view ${{ github.event.issue.number }} --json title,body,labels`
+            2. Read the available issue templates from .github/ISSUE_TEMPLATE/ directory
+            3. Analyze the issue content to determine which template SHOULD have been used:
+               - Keywords "site", "navigation", "docusaurus", "search", "layout", "menu" → site templates
+               - Keywords "documentation", "content", "tutorial", "guide", "missing", "incorrect" → content templates
+               - Labels or title containing "fix", "bug", "broken", "error" → fix templates
+               - Labels or title containing "add", "feature", "enhancement", "new" → add templates
+            4. Compare the issue structure to the templates to see which was actually used
+            5. If the wrong template was used:
+               - Extract the user's information from the current issue body
+               - Map it to the correct template structure
+               - Update the issue body using `gh issue edit ${{ github.event.issue.number }} --body "..."`
+               - Add a comment explaining the correction
+            6. Output the template type by running:
+               echo "template_type=[content_fix|content_add|site_fix|site_add]" >> $GITHUB_OUTPUT
+               echo "validation_failed=[true|false]" >> $GITHUB_OUTPUT
+
+            IMPORTANT:
+            - Preserve all user-provided information during template correction
+            - Be conservative - only change the template if it's clearly wrong
+            - Always set both output variables
+          claude_args: '--allowed-tools "Bash(gh issue:*),Read,Grep,Glob"'
+
+  primary-labeling:
+    runs-on: ubuntu-latest
+    needs: template-validation
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    outputs:
+      primary_label: ${{ steps.label.outputs.primary_label }}
+      should_continue: ${{ steps.label.outputs.should_continue }}
+
+    steps:
+      - name: Assign primary AI label
+        id: label
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+            TEMPLATE TYPE: ${{ needs.template-validation.outputs.template_type }}
+
+            Your task is to assign the primary "AI:" label to this issue.
+
+            STEPS:
+            1. Read the issue using `gh issue view ${{ github.event.issue.number }} --json title,body,labels`
+            2. Analyze the issue to determine the primary label:
+
+               DECISION TREE:
+               a) If TEMPLATE_TYPE contains "site" → Assign "AI:docusaurus"
+               b) Else if TEMPLATE_TYPE contains "content" → Assign "AI:docs"
+               c) Else check for SPECIAL CASES:
+
+                  DUPLICATE: Search for similar issues
+                  - Run: gh search issues --repo ${{ github.repository }} --match title --state all --limit 5 --json number,title,state,url --jq '.[] | select(.number != ${{ github.event.issue.number }})'
+                  - If similar issue found:
+                    * Add label "duplicate"
+                    * Comment: "This appears to be a duplicate of #[NUMBER]. Please see that issue for discussion."
+                    * Close: gh issue close ${{ github.event.issue.number }} --reason "not planned"
+                    * Set should_continue=false
+
+                  PRODUCT BUG: Keywords "crash", "error code", "software bug", "application error" AND mentions specific product behavior
+                  - Add label "bug"
+                  - Comment: "This appears to be a product bug rather than a documentation issue. Please report this to Netwrix Support: https://netwrix.com/en/support/"
+                  - Close: gh issue close ${{ github.event.issue.number }} --reason "not planned"
+                  - Set should_continue=false
+
+                  FEATURE PROPOSAL: Keywords "should add", "feature request", "enhancement", "please implement"
+                  - Add label "proposal"
+                  - Comment: "This appears to be a feature request. Please share your ideas on the Netwrix Community: https://community.netwrix.com/"
+                  - Close: gh issue close ${{ github.event.issue.number }} --reason "not planned"
+                  - Set should_continue=false
+
+            3. If NOT a special case, assign the appropriate AI label:
+               - gh issue edit ${{ github.event.issue.number }} --add-label "[AI:docs|AI:docusaurus]"
+               - Set should_continue=true
+
+            4. Output the results:
+               echo "primary_label=[LABEL]" >> $GITHUB_OUTPUT
+               echo "should_continue=[true|false]" >> $GITHUB_OUTPUT
+
+            IMPORTANT:
+            - Only close issues for special cases (duplicate, bug, proposal)
+            - For normal documentation issues, just add the AI label and continue
+            - Always set both output variables
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh search:*),Read"'
+
+  secondary-labeling:
+    runs-on: ubuntu-latest
+    needs: [template-validation, primary-labeling]
+    if: needs.primary-labeling.outputs.should_continue == 'true'
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository (CODEOWNERS only)
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/CODEOWNERS
+          sparse-checkout-cone-mode: false
+
+      - name: Assign product labels and notify teams
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            ISSUE NUMBER: ${{ github.event.issue.number }}
+
+            Your task is to identify relevant product(s) and notify the appropriate teams.
+
+            STEPS:
+            1. Read the issue using `gh issue view ${{ github.event.issue.number }} --json body`
+            2. Read .github/CODEOWNERS to understand product-to-team mappings
+            3. Parse CODEOWNERS to extract product-team relationships:
+               - Look for lines like: /docs/productname/ @netwrix/team-docs
+               - Extract the product directory name and team handle
+            4. Analyze the issue body for product mentions:
+               - Check for product names in dropdown selections (if preserved in body)
+               - Scan for product names mentioned in text
+               - Common products: Password Secure, Auditor, Access Analyzer, Privilege Secure, etc.
+            5. For each detected product:
+               a) Normalize product name to label format:
+                  - "Password Secure 9.3" → "password-secure"
+                  - "Access Analyzer 12.0" → "access-analyzer"
+                  - "Auditor 10.8" → "auditor"
+                  - Remove spaces, convert to lowercase, keep hyphens
+               b) Add product label: gh issue edit ${{ github.event.issue.number }} --add-label "PRODUCT_LABEL"
+               c) Look up team from CODEOWNERS:
+                  - Normalize label for directory match (remove hyphens): "password-secure" → "passwordsecure"
+                  - Find line in CODEOWNERS: /docs/passwordsecure/ @netwrix/passwordsecure-docs
+                  - Extract team handle
+               d) Notify team with comment:
+                  gh issue comment ${{ github.event.issue.number }} --body "This issue appears to be related to [PRODUCT NAME]. Notifying [TEAM] for review."
+
+            6. Handle multiple products (repeat step 5 for each)
+
+            PRODUCT NAME NORMALIZATION:
+            - "1Secure" → "1secure"
+            - "Access Analyzer" → "access-analyzer" (directory: accessanalyzer)
+            - "Access Information Center" → "access-information-center" (directory: accessinformationcenter)
+            - "Activity Monitor" → "activity-monitor" (directory: activitymonitor)
+            - "Auditor" → "auditor"
+            - "Change Tracker" → "change-tracker" (directory: changetracker)
+            - "Data Classification" → "data-classification" (directory: dataclassification)
+            - "Directory Manager" → "directory-manager" (directory: directorymanager)
+            - "Endpoint Policy Manager" → "endpoint-policy-manager" (directory: endpointpolicymanager)
+            - "Endpoint Protector" → "endpoint-protector" (directory: endpointprotector)
+            - "Identity Manager" → "identity-manager" (directory: identitymanager)
+            - "Identity Recovery" → "identity-recovery" (directory: identityrecovery)
+            - "Password Policy Enforcer" → "password-policy-enforcer" (directory: passwordpolicyenforcer)
+            - "Password Reset" → "password-reset" (directory: passwordreset)
+            - "Password Secure" → "password-secure" (directory: passwordsecure)
+            - "PingCastle" → "pingcastle"
+            - "Platform Governance for NetSuite" → "platform-governance-netsuite" (directory: platgovnetsuite)
+            - "Privilege Secure" → "privilege-secure" (directory: privilegesecure)
+            - "Recovery for Active Directory" → "recovery-for-active-directory" (directory: recoveryforactivedirectory)
+            - "Threat Manager" → "threat-manager" (directory: threatmanager)
+            - "Threat Prevention" → "threat-prevention" (directory: threatprevention)
+
+            IMPORTANT:
+            - Multiple products may be mentioned - handle all of them
+            - Be case-insensitive when matching product names
+            - If no products are clearly identified, skip labeling (don't guess)
+          claude_args: '--allowed-tools "Bash(gh issue:*),Read,Grep"'
+
+      - name: Handle labeling failures
+        if: failure()
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "⚠️ Automated product labeling failed. Manual review may be needed."
+          gh issue edit ${{ github.event.issue.number }} --add-label "automation-failed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a comprehensive 3-stage GitHub Actions workflow to automatically process new issues:

- **Template validation**: Detects and corrects incorrect template usage, preserving all user information
- **Primary labeling**: Assigns AI:docs or AI:docusaurus labels, and handles special cases (duplicates redirect to existing issues, product bugs redirect to support, feature proposals redirect to community)
- **Secondary labeling**: Identifies mentioned products, adds product labels, and notifies relevant teams based on CODEOWNERS mappings

The new workflow replaces the previous claude-issue-labeler.yml, which has been disabled. When the AI:docusaurus label is added, the existing claude-docusaurus-developer.yml workflow will automatically trigger to implement the fix.

## Test plan

- [ ] Create issue with wrong template to verify template correction
- [ ] Create issue mentioning "Password Secure" to verify product labeling and team notification
- [ ] Create duplicate issue to verify duplicate detection and closing
- [ ] Create site issue to verify AI:docusaurus label triggers developer workflow
- [ ] Create issue with multiple products to verify multiple labels and notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)