### PR TITLE
Use gh pr diff for valid-line filter; fix preexisting issue format

### DIFF
--- a/.github/workflows/claude-documentation-reviewer.yml
+++ b/.github/workflows/claude-documentation-reviewer.yml
@@ -92,12 +92,13 @@ jobs:
             - Issues in PR changes: the issue is on a line that was added or modified in this PR
             - Preexisting issues: the issue exists on a line that was not changed by this PR
 
-            Write your complete review to `/tmp/review-summary.md` using this exact structure:
+            Write your complete review to `/tmp/review-summary.md` using this exact structure — two sections, each containing a flat list of issues in the format from your instructions, with no subheadings, groupings, or extra nesting:
+
             ## Issues in PR changes
-            <list each issue using the format from your instructions, or "None." if there are none>
+            <flat list of issues in the format from your instructions, or "None." if there are none>
 
             ## Preexisting issues
-            <list each issue using the format from your instructions, or "None." if there are none>
+            <flat list of issues in the format from your instructions, or "None." if there are none>
 
             Then fix ALL issues directly in the files using the Write and Edit tools. Do not post a PR comment. Do not commit or push.
 
@@ -111,7 +112,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
         run: |
@@ -221,10 +221,10 @@ jobs:
                   comment['start_side'] = 'RIGHT'
               return comment
 
-          def get_pr_diff_valid_lines(base_sha, head_sha):
-              """Return the set of (file, line_number) in HEAD visible in the PR diff."""
+          def get_pr_diff_valid_lines(pr_number):
+              """Return the set of (file, line_number) visible in GitHub's PR diff."""
               result = subprocess.run(
-                  ['git', 'diff', '--unified=10', base_sha, head_sha],
+                  ['gh', 'pr', 'diff', pr_number, '--patch'],
                   capture_output=True, text=True,
               )
               valid = set()
@@ -260,7 +260,6 @@ jobs:
 
           pr_number = os.environ['PR_NUMBER']
           head_sha = os.environ['HEAD_SHA']
-          base_sha = os.environ['BASE_SHA']
           repo = os.environ['REPO']
 
           # Get diff of Claude's local edits vs HEAD
@@ -270,7 +269,7 @@ jobs:
 
           # Filter to only lines visible in the PR diff — GitHub rejects suggestions
           # on lines outside the diff context with HTTP 422.
-          pr_valid_lines = get_pr_diff_valid_lines(base_sha, head_sha)
+          pr_valid_lines = get_pr_diff_valid_lines(pr_number)
           suggestions = []
           for s in all_suggestions:
               start = s.get('start_line', s['line'])


### PR DESCRIPTION
- Replace local git diff (--unified=10) with gh pr diff to get the exact diff GitHub uses. Local unified=10 was accepting lines 4-10 away from changes that GitHub's 3-line context window excludes, causing "Line could not be resolved" 422 errors.
- Clarify prompt: both review sections must use a flat list with no subheadings or extra nesting, matching the format in instructions.
