### PR TITLE
Handle both file and direct-post cases for preexisting issues footer

### DIFF
--- a/.github/workflows/claude-documentation-fixer.yml
+++ b/.github/workflows/claude-documentation-fixer.yml
@@ -95,14 +95,11 @@ jobs:
         run: |
           python3 << 'PYTHON_EOF'
           import os
+          import json
           import subprocess
 
-          summary_path = '/tmp/preexisting-issues.md'
-          if not os.path.exists(summary_path):
-              exit(0)
-
-          with open(summary_path) as f:
-              body = f.read().strip()
+          pr_number = os.environ['PR_NUMBER']
+          repo = os.environ['REPO']
 
           FOOTER = (
               "\n\n---\n\n"
@@ -111,13 +108,32 @@ jobs:
               "Note: Automated fixes are only available for branches in this repository, not forks."
           )
 
-          body += FOOTER
+          FOOTER_MARKER = "Automated fixes are only available"
 
-          pr_number = os.environ['PR_NUMBER']
-          repo = os.environ['REPO']
-
-          subprocess.run(
-              ['gh', 'pr', 'comment', pr_number, '--repo', repo, '--body', body],
-              check=True,
-          )
+          summary_path = '/tmp/preexisting-issues.md'
+          if os.path.exists(summary_path):
+              # Claude wrote to the file as instructed — post a new comment with footer
+              with open(summary_path) as f:
+                  body = f.read().strip()
+              subprocess.run(
+                  ['gh', 'pr', 'comment', pr_number, '--repo', repo, '--body', body + FOOTER],
+                  check=True,
+              )
+          else:
+              # Claude posted directly — find that comment and edit it to add the footer
+              result = subprocess.run(
+                  ['gh', 'api', f'repos/{repo}/issues/{pr_number}/comments',
+                   '--jq', '[.[] | select(.user.login == "github-actions[bot]")]'],
+                  capture_output=True, text=True, check=True,
+              )
+              comments = json.loads(result.stdout)
+              for comment in reversed(comments):
+                  body = comment['body']
+                  if '## Preexisting issues' in body and FOOTER_MARKER not in body:
+                      subprocess.run(
+                          ['gh', 'api', f'repos/{repo}/issues/comments/{comment["id"]}',
+                           '-X', 'PATCH', '-f', f'body={body.rstrip()}{FOOTER}'],
+                          check=True,
+                      )
+                      break
           PYTHON_EOF


### PR DESCRIPTION
If Claude writes to /tmp/preexisting-issues.md, post a new comment with the hardcoded footer. If Claude posts directly (bypassing the file), find that comment via the API and edit it to append the footer.
