### PR TITLE
Fix preexisting issues post-processing: strip intro and fix PATCH call

### DIFF
--- a/.github/workflows/claude-documentation-fixer.yml
+++ b/.github/workflows/claude-documentation-fixer.yml
@@ -110,17 +110,33 @@ jobs:
 
           FOOTER_MARKER = "Automated fixes are only available"
 
+          def normalize_body(body):
+              """Strip any intro text before the ## Preexisting issues header."""
+              idx = body.find('## Preexisting issues')
+              if idx > 0:
+                  body = body[idx:]
+              return body.strip()
+
+          def patch_comment(comment_id, new_body):
+              payload = {'body': new_body}
+              subprocess.run(
+                  ['gh', 'api', f'repos/{repo}/issues/comments/{comment_id}',
+                   '-X', 'PATCH', '--input', '-'],
+                  input=json.dumps(payload),
+                  capture_output=True, text=True, check=True,
+              )
+
           summary_path = '/tmp/preexisting-issues.md'
           if os.path.exists(summary_path):
               # Claude wrote to the file as instructed — post a new comment with footer
               with open(summary_path) as f:
-                  body = f.read().strip()
+                  body = normalize_body(f.read())
               subprocess.run(
                   ['gh', 'pr', 'comment', pr_number, '--repo', repo, '--body', body + FOOTER],
                   check=True,
               )
           else:
-              # Claude posted directly — find that comment and edit it to add the footer
+              # Claude posted directly — find that comment, strip any intro, and add the footer
               result = subprocess.run(
                   ['gh', 'api', f'repos/{repo}/issues/{pr_number}/comments',
                    '--jq', '[.[] | select(.user.login == "github-actions[bot]")]'],
@@ -130,10 +146,6 @@ jobs:
               for comment in reversed(comments):
                   body = comment['body']
                   if '## Preexisting issues' in body and FOOTER_MARKER not in body:
-                      subprocess.run(
-                          ['gh', 'api', f'repos/{repo}/issues/comments/{comment["id"]}',
-                           '-X', 'PATCH', '-f', f'body={body.rstrip()}{FOOTER}'],
-                          check=True,
-                      )
+                      patch_comment(comment['id'], normalize_body(body) + FOOTER)
                       break
           PYTHON_EOF


### PR DESCRIPTION
- normalize_body() strips any text before ## Preexisting issues header, making output correct regardless of whether Claude adds intro text
- Fix PATCH call to use --input - with JSON instead of -f, which broke on special characters (newlines, backticks) in the comment body
