### PR TITLE
Split fixer into separate fix and preexisting-detection action steps

### DIFF
--- a/.github/workflows/claude-documentation-fixer.yml
+++ b/.github/workflows/claude-documentation-fixer.yml
@@ -67,25 +67,26 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Install Vale
+      - name: Detect command type
+        id: cmd-type
         if: steps.pr-info.outputs.is_fork == 'false'
+        run: |
+          COMMENT="${{ github.event.comment.body }}"
+          if echo "$COMMENT" | grep -qi 'preexisting'; then
+            echo "is_preexisting=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_preexisting=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install Vale
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.cmd-type.outputs.is_preexisting == 'false'
         run: |
           VERSION=$(curl -s "https://api.github.com/repos/errata-ai/vale/releases/latest" | jq -r '.tag_name')
           curl -sfL "https://github.com/errata-ai/vale/releases/download/${VERSION}/vale_${VERSION#v}_Linux_64-bit.tar.gz" \
             | sudo tar -xz -C /usr/local/bin vale
 
-      - name: Record last comment ID
-        id: pre-claude
-        if: steps.pr-info.outputs.is_fork == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          LAST_ID=$(gh api repos/${{ github.repository }}/issues/${{ steps.pr-info.outputs.number }}/comments \
-            --jq 'if length > 0 then .[-1].id else 0 end' 2>/dev/null || echo "0")
-          echo "last_comment_id=$LAST_ID" >> "$GITHUB_OUTPUT"
-
       - name: Apply fixes
-        if: steps.pr-info.outputs.is_fork == 'false'
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.cmd-type.outputs.is_preexisting == 'false'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -96,13 +97,24 @@ jobs:
             --allowedTools "Read,Write,Edit,Bash(vale:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git config:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*)"
             --append-system-prompt "${{ steps.read-prompt.outputs.prompt }}"
 
+      - name: Detect preexisting issues
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.cmd-type.outputs.is_preexisting == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: false
+          claude_args: |
+            --model claude-sonnet-4-5-20250929
+            --allowedTools "Read,Write,Edit,Bash(gh pr view:*),Bash(gh pr diff:*)"
+            --append-system-prompt "${{ steps.read-prompt.outputs.prompt }}"
+
       - name: Post preexisting issues comment
-        if: steps.pr-info.outputs.is_fork == 'false'
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.cmd-type.outputs.is_preexisting == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.pr-info.outputs.number }}
           REPO: ${{ github.repository }}
-          LAST_COMMENT_ID: ${{ steps.pre-claude.outputs.last_comment_id }}
         run: |
           python3 << 'PYTHON_EOF'
           import os
@@ -111,7 +123,6 @@ jobs:
 
           pr_number = os.environ['PR_NUMBER']
           repo = os.environ['REPO']
-          last_comment_id = int(os.environ.get('LAST_COMMENT_ID', '0'))
 
           FOOTER = (
               "\n\n---\n\n"
@@ -139,38 +150,15 @@ jobs:
                   clean_lines.pop()
               return '\n'.join(clean_lines)
 
-          # Only run for @claude detect preexisting issues
           summary_path = '/tmp/preexisting-issues.md'
-          if not os.path.exists(summary_path):
-              exit(0)
-
-          with open(summary_path) as f:
-              clean_body = normalize_body(f.read()) + FOOTER
-
-          # Find all comments posted during this workflow run (ID > last recorded ID)
-          result = subprocess.run(
-              ['gh', 'api', f'repos/{repo}/issues/{pr_number}/comments'],
-              capture_output=True, text=True, check=True,
-          )
-          comments = json.loads(result.stdout)
-          new_comments = [c for c in comments
-                          if c['id'] > last_comment_id
-                          and c['user']['login'] == 'github-actions[bot]']
-
-          if new_comments:
-              # Replace the most recent new comment (the action's auto-posted output)
-              target_id = new_comments[-1]['id']
-              payload = {'body': clean_body}
-              subprocess.run(
-                  ['gh', 'api', f'repos/{repo}/issues/comments/{target_id}',
-                   '-X', 'PATCH', '--input', '-'],
-                  input=json.dumps(payload),
-                  capture_output=True, text=True, check=True,
-              )
+          if os.path.exists(summary_path):
+              with open(summary_path) as f:
+                  clean_body = normalize_body(f.read()) + FOOTER
           else:
-              # No new comment found — post one directly
-              subprocess.run(
-                  ['gh', 'pr', 'comment', pr_number, '--repo', repo, '--body', clean_body],
-                  check=True,
-              )
+              clean_body = '## Preexisting issues\nNone.' + FOOTER
+
+          subprocess.run(
+              ['gh', 'pr', 'comment', pr_number, '--repo', repo, '--body', clean_body],
+              check=True,
+          )
           PYTHON_EOF


### PR DESCRIPTION
For preexisting issues commands, use a dedicated action step with show_full_output: false and limited tools, then always post a clean formatted comment. For fix commands, use show_full_output: true with the full toolset. Removes the fragile PATCH-based comment replacement.