### PR TITLE
Speed up doc reviewer by using shallow checkout

### DIFF
--- a/.github/workflows/claude-documentation-reviewer.yml
+++ b/.github/workflows/claude-documentation-reviewer.yml
@@ -23,7 +23,10 @@ jobs:
         with:
           # Check out by SHA to prevent TOCTOU attacks from forks.
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
+
+      - name: Fetch base commit for diff
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
 
       - name: Get changed markdown files
         id: changed-files


### PR DESCRIPTION
Replace fetch-depth: 0 (full clone) with fetch-depth: 1 plus a targeted fetch of just the base commit. This gives git everything it needs for the PR diff without downloading the entire repository history.

Generated with AI