### PR TITLE
Fix Vale rule messages and remove overly broad tokens

### DIFF
--- a/.vale/styles/Netwrix/BoilerplateCrossRef.yml
+++ b/.vale/styles/Netwrix/BoilerplateCrossRef.yml
@@ -3,5 +3,4 @@ message: "Avoid '%s'. Write specific cross-reference text that describes what th
 level: suggestion
 ignorecase: true
 tokens:
-  - '\bfor additional information\b'
   - '\bfor more information\b'

--- a/.vale/styles/Netwrix/Checkbox.yml
+++ b/.vale/styles/Netwrix/Checkbox.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'checkbox' (one word) instead of '%s'."
+message: "Use '%s' instead of 'check box'."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/CondescendingWords.yml
+++ b/.vale/styles/Netwrix/CondescendingWords.yml
@@ -6,6 +6,5 @@ nonword: true
 tokens:
   - '\bsimply\b'
   - '\beasily\b'
-  - '\bjust\b'
   - '\bbasically\b'
   - '\bobviously\b'

--- a/.vale/styles/Netwrix/Dropdown.yml
+++ b/.vale/styles/Netwrix/Dropdown.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'drop-down' (hyphenated) instead of '%s'."
+message: "Use 'drop-down' (hyphenated). Avoid 'dropdown' and 'drop down'."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/InOrderTo.yml
+++ b/.vale/styles/Netwrix/InOrderTo.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'to' instead of '%s'."
+message: "Use '%s' instead of 'in order to'."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/IsAbleTo.yml
+++ b/.vale/styles/Netwrix/IsAbleTo.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'can' instead of '%s'."
+message: "Use '%s' instead of the 'able to' construction."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/LoginVerb.yml
+++ b/.vale/styles/Netwrix/LoginVerb.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'log in' (two words) as a verb instead of '%s'."
+message: "Use '%s' — 'login' as a verb should be two words."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/MakeSure.yml
+++ b/.vale/styles/Netwrix/MakeSure.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'ensure' instead of '%s'."
+message: "Use '%s' instead of 'make sure'."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/ProvidesAbilityTo.yml
+++ b/.vale/styles/Netwrix/ProvidesAbilityTo.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'lets you' or 'can' instead of '%s'."
+message: "Use '%s' instead of 'provides the ability to'."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/Utilize.yml
+++ b/.vale/styles/Netwrix/Utilize.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'use' instead of '%s'."
+message: "Use '%s' — avoid 'utilize' and its variants."
 level: warning
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/WishTo.yml
+++ b/.vale/styles/Netwrix/WishTo.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use 'want to' instead of '%s', or rewrite as a direct imperative."
+message: "Use '%s' instead of 'wish to', or rewrite as a direct imperative."
 level: suggestion
 ignorecase: true
 swap:

--- a/.vale/styles/Netwrix/WordyPhrases.yml
+++ b/.vale/styles/Netwrix/WordyPhrases.yml
@@ -1,5 +1,5 @@
 extends: substitution
-message: "Use a concise alternative instead of '%s'."
+message: "Use '%s' instead of this wordy phrase."
 level: warning
 ignorecase: true
 swap:


### PR DESCRIPTION
- Fix %s position in substitution rule messages so they show matched text correctly
- Remove 'for additional information' from BoilerplateCrossRef
- Remove 'just' from CondescendingWords to avoid false positives
