### PR TITLE
Fix review footer causing last issue line to render as H2 heading

### DIFF
--- a/.github/workflows/claude-documentation-reviewer.yml
+++ b/.github/workflows/claude-documentation-reviewer.yml
@@ -133,7 +133,7 @@ jobs:
           import sys
 
           FOOTER = (
-              "\n---\n\n"
+              "\n\n* * *\n\n"
               "To apply suggested fixes to the updated documentation, individually or in bulk, comment `@claude`"
               " on this PR followed by your instructions (`@claude fix all issues`"
               " or `@claude fix all linting issues` or `@claude fix only the spelling errors`).\n\n"


### PR DESCRIPTION
## Summary

- `pull_request_target` always runs the workflow from the **base branch** (`dev`), not the PR branch — so footer fixes in feature branches have no effect until merged
- The `---` separator in `FOOTER` collapses to appear immediately after the last issue line (GitHub normalizes blank lines in review body storage)
- In CommonMark, a line of text immediately followed by `---` renders as a setext H2 heading — making the last reported issue appear as a section header
- Replace `---` with `* * *` (asterisk thematic break), which is a valid horizontal rule but **cannot** be a setext heading marker (only `=` and `-` qualify)

## Test plan

- [ ] Open any PR with markdown changes
- [ ] Confirm the last issue line renders as plain text, not as an H2 heading
- [ ] Confirm the separator (horizontal rule) still appears between the issues list and the footer