### PR TITLE
Fix broken KB link in Auditor licensing FAQs KB article

### DIFF
--- a/docs/kb/auditor/features-and-operations/glossaries-and-faqs/netwrix-auditor-licensing-faqs.md
+++ b/docs/kb/auditor/features-and-operations/glossaries-and-faqs/netwrix-auditor-licensing-faqs.md
@@ -145,6 +145,6 @@ You may choose to no longer audit a data source, and thus not renew the license 
 - [How to count the number of your network devices in your configuration?](/docs/kb/auditor/features-and-operations/glossaries-and-faqs/how-to-count-the-number-of-your-network-devices-in-your-configuration)
 - [Oracle Processor Core Factor Table](http://www.oracle.com/us/corporate/contracts/processor-core-factor-table-070634.pdf)
 - [How to Count Number of CPU Cores on Your Oracle Database Deployment](/docs/kb/auditor/system-administration/database-management/how-to-count-number-of-cpu-cores-on-your-oracle-database-deployment)
-- [How to Determine the Count of Enabled Microsoft Entra ID Accounts](../../configuration-and-setup/microsoft-365-integration/determining-the-number-of-enabled-microsoft-entra-id-accounts#instructions)
+- [How to Determine the Count of Enabled Microsoft Entra ID Accounts](/docs/kb/auditor/configuration-and-setup/microsoft-365-integration/determining-the-number-of-enabled-microsoft-entra-id-accounts#instructions)
 - [How to count number of licenses required for auditing a Microsoft Office 365 tenant?](/docs/kb/auditor/configuration-and-setup/microsoft-365-integration/how-to-count-number-of-licenses-required-for-auditing-a-microsoft-office-365-tenant)
 


### PR DESCRIPTION
## Summary
Fixed a broken link in the Auditor licensing FAQs article that was pointing to "How to Determine the Count of Enabled Microsoft Entra ID Accounts".                                                                                                                                                                      

## Problem
The licensing FAQs article (`netwrix-auditor-licensing-faqs.md`) contained a link using a relative path (`../../`) which broke when KB files were copied to versioned directories (10.6, 10.7, 10.8) during the build process.

## Solution
Changed the link format from relative path to `/docs/kb/auditor/` format so the KB copy script can properly rewrite links when copying to versioned directories.

## Testing
✅ Build successful - no errors
✅ Manually tested the link in all three versions

## Files Changed
- `docs/kb/auditor/features-and-operations/glossaries-and-faqs/netwrix-auditor-licensing-faqs.md`