### PR TITLE
fix: correct glob pattern in doc-pr workflow path filter

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - dev
     paths:
-      - 'docs/**.md'
+      - 'docs/**/*.md'
       - '!docs/**/CLAUDE.md'
       - '!docs/**/SKILL.md'
 


### PR DESCRIPTION
docs/**.md only matches files directly in docs/, not in subdirectories. docs/**/*.md correctly matches markdown files at any depth.