### PR TITLE
fix: expression parse error in doc-pr workflow

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -122,11 +122,11 @@ jobs:
   # Job 2: @claude follow-up on PR comments
   # ──────────────────────────────────────────────
   doc-followup:
-    if: |
+    if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude') &&
-      github.event.comment.user.login != 'github-actions[bot]'
+      !startsWith(github.event.comment.user.login, 'github-actions')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The square brackets in 'github-actions[bot]' were interpreted as an index accessor in the GitHub Actions expression parser, causing "An expression was expected" at line 141. Replace with startsWith() to avoid the bracket issue.