### PR TITLE
fix: change review output path from /tmp to repo root

### DIFF
--- a/.claude/skills/doc-pr/SKILL.md
+++ b/.claude/skills/doc-pr/SKILL.md
@@ -64,7 +64,7 @@ Only report issues on lines that were added or modified in this PR. Do not flag 
 
 ## Output
 
-Write the complete review to `/tmp/doc-pr-review.md` using this exact structure:
+Write the complete review to `.doc-pr-review.md` in the repository root using this exact structure:
 
 ```markdown
 ## Documentation PR Review

--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -95,7 +95,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          REVIEW_FILE="/tmp/doc-pr-review.md"
+          REVIEW_FILE=".doc-pr-review.md"
           FOOTER=$'\n\n---\n\n'
           FOOTER+=$'**What to do next:**\n\n'
           FOOTER+=$'Comment `@claude` on this PR followed by your instructions to get help:\n\n'


### PR DESCRIPTION
Claude Code's Write tool is sandboxed to the working directory and cannot write to /tmp. Changed output path to .doc-pr-review.md in the repo root, which is within the sandbox.