### PR TITLE
fix: allow unrestricted Bash and Write for doc-pr review step

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -83,7 +83,7 @@ jobs:
             - REPO: ${{ github.repository }}
             - PR_NUMBER: ${{ github.event.pull_request.number }}
             - CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
-          claude_args: '--allowedTools "Bash(vale:*),Bash(gh:*),Read,Glob,Grep,Skill(doc-pr),Skill(dale)"'
+          claude_args: '--allowedTools "Bash,Read,Write,Glob,Grep,Skill(doc-pr),Skill(dale)"'
 
   doc-followup:
     if: >-


### PR DESCRIPTION
The skill needs to write a temp file for the review body before posting via gh pr comment. With only Bash(vale:*) and Bash(gh:*) allowed, Claude couldn't create the temp file. Added unrestricted Bash and Write — security is enforced by permissions: contents: read.