### PR TITLE
fix: simplify doc-pr followup to avoid turn exhaustion

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -259,10 +259,24 @@ jobs:
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
         uses: anthropics/claude-code-action@v1
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
           prompt: |
-            /doc-pr-fix ${{ steps.pr-info.outputs.number }} $COMMENT_BODY
-          claude_args: '--allowedTools "Bash(vale:*),Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep,Skill(doc-pr-fix),Skill(dale)"'
+            A writer commented on PR ${{ steps.pr-info.outputs.number }} with: $COMMENT_BODY
+
+            Your job:
+            1. Read docs/CLAUDE.md for Netwrix writing standards
+            2. Run gh pr diff ${{ steps.pr-info.outputs.number }} to see what changed
+            3. Read the changed files and the existing "Documentation PR Review" comment on the PR
+            4. Apply the requested fixes using Edit/Write tools
+            5. Run vale on each edited file and fix any new issues
+            6. Commit and push: git add <files> && git commit -m "docs: apply fixes from PR review" && git push
+            7. Post a PR comment summarizing what you fixed:
+               gh pr comment ${{ steps.pr-info.outputs.number }} --repo ${{ github.repository }} --body-file /tmp/fix-summary.md
+
+            IMPORTANT: You MUST commit, push, and post a summary comment. Your task is NOT done until all three happen.
+          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep"'


### PR DESCRIPTION
Same fix pattern as the review job: skip skill invocations (doc-pr-fix, dale) that eat turns reading rule files, use unrestricted Bash, and give Claude direct step-by-step instructions.

Changes:
- Replace Skill(doc-pr-fix) invocation with inline instructions
- Use unrestricted Bash instead of Bash(vale:*), Bash(gh:*), etc.
- Add show_full_output for debugging
- Add GH_TOKEN env var
- Drop Skill(dale) — verify with Vale only