### PR TITLE
fix: revert doc-pr followup to skill-based approach

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -266,17 +266,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: true
           prompt: |
-            A writer commented on PR ${{ steps.pr-info.outputs.number }} with: $COMMENT_BODY
-
-            Your job:
-            1. Read docs/CLAUDE.md for Netwrix writing standards
-            2. Run gh pr diff ${{ steps.pr-info.outputs.number }} to see what changed
-            3. Read the changed files and the existing "Documentation PR Review" comment on the PR
-            4. Apply the requested fixes using Edit/Write tools
-            5. Run vale on each edited file and fix any new issues
-            6. Commit and push: git add <files> && git commit -m "docs: apply fixes from PR review" && git push
-            7. Post a PR comment summarizing what you fixed:
-               gh pr comment ${{ steps.pr-info.outputs.number }} --repo ${{ github.repository }} --body-file /tmp/fix-summary.md
-
-            IMPORTANT: You MUST commit, push, and post a summary comment. Your task is NOT done until all three happen.
-          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep"'
+            /doc-pr-fix ${{ steps.pr-info.outputs.number }} $COMMENT_BODY
+          claude_args: '--allowedTools "Bash(vale:*),Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep,Skill(doc-pr-fix),Skill(dale)"'


### PR DESCRIPTION
The skill-based approach with doc-pr-fix worked on PR 460. Revert to that pattern but keep show_full_output and GH_TOKEN for debugging. The inline instructions approach failed because Claude still discovered and invoked Dale via Skill tool, burning all turns.