### PR TITLE
fix: remove Dale from doc-pr-fix verification step

### DIFF
--- a/.claude/skills/doc-pr-fix/SKILL.md
+++ b/.claude/skills/doc-pr-fix/SKILL.md
@@ -52,7 +52,7 @@ When editing:
 
 ## Step 4: Verify
 
-After all edits, run both linters on every file you changed:
+After all edits, run Vale on every file you changed:
 
 ```bash
 vale <file>
@@ -60,15 +60,7 @@ vale <file>
 
 Fix any new Vale errors. Re-run until zero errors remain.
 
-Then run Dale:
-
-```
-/dale <file>
-```
-
-Fix any Dale violations.
-
-Repeat the vale-then-dale cycle until both are clean.
+Do NOT run Dale or any other skills during verification — just Vale.
 
 ## Step 5: Commit and push
 


### PR DESCRIPTION
Dale skill invocation consistently exhausts Claude's turn budget by reading all rule files (Glob + Read x4), leaving no turns for git commit, push, or posting a summary. Every followup attempt (PRs 470, 473, 476) hit this exact pattern.

Remove Dale from the verification step — verify with Vale only.