### PR TITLE
fix: resolve Vale review threads after fixes to unblock merge

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -277,6 +277,27 @@ jobs:
           PR_NUMBER=${{ steps.pr-info.outputs.number }}
           REPO=${{ github.repository }}
 
+          # Resolve all Vale inline comment threads so they don't block merge
+          OWNER="${REPO%%/*}"
+          NAME="${REPO##*/}"
+          THREAD_IDS=$(gh api graphql -f query='
+            query($owner:String!,$name:String!,$pr:Int!) {
+              repository(owner:$owner,name:$name) {
+                pullRequest(number:$pr) {
+                  reviewThreads(first:100) {
+                    nodes { id isResolved comments(first:1) { nodes { body } } }
+                  }
+                }
+              }
+            }' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER" \
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and (.comments.nodes[0].body | contains("**Vale**"))) | .id' 2>/dev/null || true)
+          for TID in $THREAD_IDS; do
+            gh api graphql -f query='
+              mutation($tid:ID!) {
+                resolveReviewThread(input:{threadId:$tid}) { thread { isResolved } }
+              }' -f tid="$TID" 2>/dev/null || true
+          done
+
           # Dismiss all previous Vale reviews
           REVIEW_IDS=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
             --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Vale found"))) | .id] | .[]' 2>/dev/null || true)


### PR DESCRIPTION
Use GraphQL resolveReviewThread mutation to mark Vale inline comment threads as resolved after Claude applies fixes, preventing them from blocking PR merge.