### PR TITLE
feat: add Dale linting as inline PR review comments

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -123,6 +123,73 @@ jobs:
             echo "No Vale issues found"
           fi
 
+      - name: Run Dale linting
+        id: dale
+        if: steps.changed-files.outputs.count > 0
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          prompt: |
+            You are Dale, a documentation linter. Your ONLY job is to check files against Dale rules and write results to a JSON file.
+
+            CHANGED FILES: ${{ steps.changed-files.outputs.files }}
+
+            INSTRUCTIONS:
+
+            Step 1: Read each Dale rule file:
+            - .claude/skills/dale/rules/minimizing-difficulty.yml
+            - .claude/skills/dale/rules/negative-assumptions.yml
+            - .claude/skills/dale/rules/xy-slop.yml
+
+            Step 2: Read each changed file listed above (split on commas).
+
+            Step 3: For each file, check every line against each rule's "reason" field. When a line triggers a rule, record it.
+
+            Step 4: Write results to /tmp/dale-results.json as a JSON array. Each entry must have:
+            - "path": the file path exactly as given above
+            - "line": the line number (integer)
+            - "rule": the rule filename without extension (e.g. "minimizing-difficulty")
+            - "message": the rule's "message" field value
+
+            If no issues found, write an empty array: []
+
+            Example output:
+            [{"path":"docs/foo/bar.md","line":7,"rule":"minimizing-difficulty","message":"Do not minimize the difficulty of tasks users are performing."}]
+
+            IMPORTANT: Write ONLY the JSON file. Do not post comments, do not run any other tools. Your task is done when /tmp/dale-results.json exists.
+          claude_args: '--allowedTools "Read,Write"'
+
+      - name: Post Dale inline comments
+        id: dale-post
+        if: steps.changed-files.outputs.count > 0
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DALE_COUNT=0
+          if [ -f /tmp/dale-results.json ]; then
+            DALE_COUNT=$(jq 'length' /tmp/dale-results.json 2>/dev/null || echo "0")
+          fi
+
+          echo "dale_count=$DALE_COUNT" >> "$GITHUB_OUTPUT"
+
+          if [ "$DALE_COUNT" -gt 0 ]; then
+            echo "Posting $DALE_COUNT Dale inline comments"
+            # Transform Dale results into PR review comment format
+            COMMENTS_JSON=$(jq '[.[] | {"path": .path, "line": .line, "body": ("**Dale** (`" + .rule + "`): " + .message)}]' /tmp/dale-results.json)
+            jq -n \
+              --arg body "**Dale found ${DALE_COUNT} issue(s).** See inline comments below." \
+              --argjson comments "$COMMENTS_JSON" \
+              '{"body": $body, "event": "COMMENT", "comments": $comments}' \
+              | gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+                  --input - 2>&1
+          else
+            echo "No Dale issues found"
+          fi
+
       - name: Get PR diff
         id: diff
         if: steps.changed-files.outputs.count > 0
@@ -153,6 +220,7 @@ jobs:
             - PR number: ${{ github.event.pull_request.number }}
             - Changed files: ${{ steps.changed-files.outputs.files }}
             - Vale issues: ${{ steps.vale.outputs.vale_count }} (already posted as inline comments)
+            - Dale issues: ${{ steps.dale-post.outputs.dale_count }} (already posted as inline comments)
             - PR diff is at: /tmp/pr-diff.txt
 
             INSTRUCTIONS:
@@ -163,6 +231,7 @@ jobs:
             - Voice: passive voice, first person, impersonal phrases
             - Clarity: hard-to-parse sentences, ambiguous references
             - Surface: wordiness, redundancy
+            Do NOT duplicate issues already caught by Vale or Dale — focus on what linters miss.
 
             Step 3: Write the review to /tmp/doc-pr-review.md with this EXACT structure:
 
@@ -173,12 +242,12 @@ jobs:
             (if no issues found, write "No editorial issues found.")
 
             ### Summary
-            N Vale issues (see inline comments), N editorial suggestions across N files.
+            N Vale issues, N Dale issues (see inline comments), N editorial suggestions across N files.
 
             ---
             **What to do next:**
             Comment `@claude` on this PR followed by your instructions to get help:
-            - `@claude fix all issues` — fix all Vale and editorial issues
+            - `@claude fix all issues` — fix all Vale, Dale, and editorial issues
             - `@claude fix only the Vale issues` — fix just the linting problems
             - `@claude help improve the flow of this document` — get writing assistance
             > Automated fixes are only available for branches in this repository, not forks.
@@ -290,7 +359,7 @@ jobs:
                 }
               }
             }' -f owner="$OWNER" -f name="$NAME" -F pr="$PR_NUMBER" \
-            --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and (.comments.nodes[0].body | contains("**Vale**"))) | .id' 2>/dev/null || true)
+            --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false and ((.comments.nodes[0].body | contains("**Vale**")) or (.comments.nodes[0].body | contains("**Dale**")))) | .id' 2>/dev/null || true)
           for TID in $THREAD_IDS; do
             gh api graphql -f query='
               mutation($tid:ID!) {
@@ -298,9 +367,9 @@ jobs:
               }' -f tid="$TID" 2>/dev/null || true
           done
 
-          # Dismiss all previous Vale reviews
+          # Dismiss all previous Vale and Dale reviews
           REVIEW_IDS=$(gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Vale found"))) | .id] | .[]' 2>/dev/null || true)
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and ((.body | contains("Vale found")) or (.body | contains("Dale found")))) | .id] | .[]' 2>/dev/null || true)
           for ID in $REVIEW_IDS; do
             gh api repos/${REPO}/pulls/${PR_NUMBER}/reviews/${ID}/dismissals \
               -f message="Superseded after fixes applied" -f event="DISMISS" 2>/dev/null || true


### PR DESCRIPTION
Run Dale in a separate claude-code-action step with its own turn budget, write results to JSON, then post as inline comments via a shell step. Editorial review updated to reference Dale count and avoid duplicating linter findings. Followup job resolves and dismisses both Vale and Dale threads after fixes.