### PR TITLE
fix: use POSIX-compatible file redirection in pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -58,6 +58,10 @@ echo ""
 
 VALE_FAILED=0
 
+# Write file list to a temp file so we can iterate without a subshell
+TMPFILE=$(mktemp)
+echo "$CHANGED_MD_FILES" > "$TMPFILE"
+
 while IFS= read -r FILE; do
   if [ -f "$FILE" ]; then
     OUTPUT=$(vale "$FILE" 2>&1)
@@ -68,7 +72,9 @@ while IFS= read -r FILE; do
       VALE_FAILED=1
     fi
   fi
-done <<< "$CHANGED_MD_FILES"
+done < "$TMPFILE"
+
+rm -f "$TMPFILE"
 
 if [ "$VALE_FAILED" -eq 1 ]; then
   echo "Vale found errors in the files above."


### PR DESCRIPTION
The <<<  here-string syntax is bash-only. Replace with a temp file redirect that works under sh.