### PR TITLE
fix: detect Vale warnings by checking output instead of exit code

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -64,9 +64,8 @@ echo "$CHANGED_MD_FILES" > "$TMPFILE"
 
 while IFS= read -r FILE; do
   if [ -f "$FILE" ]; then
-    OUTPUT=$(vale --minAlertLevel=warning "$FILE" 2>&1)
-    EXIT_CODE=$?
-    if [ $EXIT_CODE -ne 0 ]; then
+    OUTPUT=$(vale "$FILE" 2>&1)
+    if echo "$OUTPUT" | grep -q "warning\|error"; then
       echo "$OUTPUT"
       echo ""
       VALE_FAILED=1


### PR DESCRIPTION
Vale only returns non-zero exit codes for error-level violations. Check the output for 'warning' or 'error' strings instead.