### PR TITLE
fix: exclude docs/kb/ from Vale, Dale, and editorial review

### DIFF
--- a/.claude/hooks/post-edit-dale.sh
+++ b/.claude/hooks/post-edit-dale.sh
@@ -29,6 +29,11 @@ if [ "$BASENAME" = "CLAUDE.md" ] || [ "$BASENAME" = "SKILL.md" ] || [ "$BASENAME
   exit 0
 fi
 
+# Skip KB articles — they have their own style conventions
+if [[ "$FILE_PATH" == */docs/kb/* ]] || [[ "$FILE_PATH" == docs/kb/* ]]; then
+  exit 0
+fi
+
 # Output a context message that Claude will see
 jq -n --arg file "$FILE_PATH" '{
   hookSpecificOutput: {

--- a/.claude/skills/doc-pr/SKILL.md
+++ b/.claude/skills/doc-pr/SKILL.md
@@ -26,6 +26,8 @@ If the environment variables are empty, check for positional arguments (`$1` = f
 
 Split the comma-separated file list into individual file paths for processing.
 
+**Exclude KB files:** Skip any file under `docs/kb/`. KB articles have their own style conventions and are not subject to Dale linting or editorial review. If the file list contains only KB files, post a comment noting that no reviewable files were found and exit.
+
 ## Stage 1: Dale Linting
 
 For each changed file, invoke the Dale linter skill:

--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**/*.md'
       - '!docs/**/CLAUDE.md'
       - '!docs/**/SKILL.md'
+      - '!docs/kb/**'
 
   issue_comment:
     types: [created]
@@ -35,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          CHANGED_MD_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep -E '^docs/.*\.md$' | grep -v '/CLAUDE\.md$' | grep -v '/SKILL\.md$' || true)
+          CHANGED_MD_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep -E '^docs/.*\.md$' | grep -v '/CLAUDE\.md$' | grep -v '/SKILL\.md$' | grep -v '^docs/kb/' || true)
           if [ -z "$CHANGED_MD_FILES" ]; then
             echo "No docs markdown files changed"
             echo "files=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/vale-linter.yml
+++ b/.github/workflows/vale-linter.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**/*.md'
       - '!docs/**/CLAUDE.md'
       - '!docs/**/SKILL.md'
+      - '!docs/kb/**'
 
 jobs:
   vale-lint:
@@ -29,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          CHANGED_MD_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep -E '^docs/.*\.md$' | grep -v '/CLAUDE\.md$' | grep -v '/SKILL\.md$' || true)
+          CHANGED_MD_FILES=$(gh pr diff "$PR_NUMBER" --name-only | grep -E '^docs/.*\.md$' | grep -v '/CLAUDE\.md$' | grep -v '/SKILL\.md$' | grep -v '^docs/kb/' || true)
           if [ -z "$CHANGED_MD_FILES" ]; then
             echo "No docs markdown files changed"
             echo "count=0" >> "$GITHUB_OUTPUT"

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,3 +3,6 @@ MinAlertLevel = suggestion
 
 [*.md]
 BasedOnStyles = Netwrix
+
+[docs/kb/**/*.md]
+BasedOnStyles =


### PR DESCRIPTION
KB articles have their own style conventions and should not be linted or reviewed by the product documentation pipeline.