### PR TITLE
fix: add concurrency group to doc-pr workflow

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -14,6 +14,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: doc-pr-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   doc-review:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Prevents duplicate reviews when vale-autofix pushes a commit back to the PR branch, triggering a second synchronize event.