### PR TITLE
fix: skip vale-autofix when triggered by bot commit

### DIFF
--- a/.github/workflows/vale-autofix.yml
+++ b/.github/workflows/vale-autofix.yml
@@ -13,7 +13,6 @@ on:
 
 concurrency:
   group: vale-autofix-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
 
 jobs:
   vale-autofix:
@@ -22,7 +21,22 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check if triggered by bot commit
+        id: bot-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the latest commit author on the PR head
+          AUTHOR=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '.commit.author.name')
+          echo "Latest commit author: $AUTHOR"
+          if [ "$AUTHOR" = "github-actions[bot]" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout PR branch
+        if: steps.bot-check.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -30,12 +44,14 @@ jobs:
           fetch-depth: 0
 
       - name: Configure git identity
+        if: steps.bot-check.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Get changed markdown files
         id: changed-files
+        if: steps.bot-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -179,7 +195,7 @@ jobs:
           claude_args: '--allowedTools "Bash(git:*),Read,Write,Edit,Glob,Grep"'
 
       - name: Build and post summary comment
-        if: steps.vale-initial.outputs.total > 0
+        if: steps.bot-check.outputs.skip != 'true' && steps.vale-initial.outputs.total > 0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
When Phase 1 pushes a fix commit, the synchronize event triggers a second workflow run. This run would cancel the first (losing the Phase 1 summary) or produce an incomplete summary.

Now the workflow checks if the latest commit author is github-actions[bot] and skips all steps if so. Also removes cancel-in-progress so queued runs complete instead of cancelling.