### PR TITLE
fix: allow unrestricted Bash for content-fix jobs

### DIFF
--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -144,7 +144,7 @@ jobs:
             - REPO: ${{ github.repository }}
             - ISSUE_NUMBER: ${{ github.event.issue.number }}
             - ISSUE_TITLE: ${{ github.event.issue.title }}
-          claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Bash(vale:*),Read,Write,Edit,Glob,Grep,Skill(content-fix),Skill(dale)"'
+          claude_args: '--max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill(content-fix),Skill(dale)"'
 
   content-fix-followup:
     needs: process-issue
@@ -199,4 +199,4 @@ jobs:
 
             This is a follow-up invocation. A user replied with @claude on a content_fix issue.
             Read the full issue body AND all comments to understand the complete context.
-          claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Bash(vale:*),Read,Write,Edit,Glob,Grep,Skill(content-fix),Skill(dale)"'
+          claude_args: '--max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill(content-fix),Skill(dale)"'


### PR DESCRIPTION
The Bash(gh:*) pattern doesn't match multi-line commands with HEREDOCs, causing permission denials when the skill tries to post progress comments or create PRs. Switch to unrestricted Bash since these jobs already have scoped permissions at the job level.