### PR TITLE
fix: use gh auth login to authenticate with PUSH_TOKEN

### DIFF
--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -153,8 +153,9 @@ jobs:
             - ISSUE_NUMBER: ${{ github.event.issue.number }}
             - ISSUE_TITLE: ${{ github.event.issue.title }}
 
-            IMPORTANT: Before running any `gh` command that creates or modifies resources (gh pr create, gh issue comment), first run: export GH_TOKEN=$PUSH_TOKEN
-            This ensures PRs trigger downstream workflows.
+            IMPORTANT: Before running `gh pr create` or `gh issue comment`, you MUST first authenticate with the push token by running:
+            echo $PUSH_TOKEN | gh auth login --with-token
+            This ensures PRs are created with the correct identity to trigger downstream workflows.
           claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill(content-fix)"'
 
   content-fix-followup:
@@ -219,6 +220,7 @@ jobs:
             This is a follow-up invocation. A user replied with @claude on a content_fix issue.
             Read the full issue body AND all comments to understand the complete context.
 
-            IMPORTANT: Before running any `gh` command that creates or modifies resources (gh pr create, gh issue comment), first run: export GH_TOKEN=$PUSH_TOKEN
-            This ensures PRs trigger downstream workflows.
+            IMPORTANT: Before running `gh pr create` or `gh issue comment`, you MUST first authenticate with the push token by running:
+            echo $PUSH_TOKEN | gh auth login --with-token
+            This ensures PRs are created with the correct identity to trigger downstream workflows.
           claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill(content-fix)"'


### PR DESCRIPTION
Setting GH_TOKEN env var wasn't enough — claude-code-action sets up gh CLI auth at a global level. Use gh auth login --with-token to explicitly re-authenticate before creating PRs and posting comments.