### PR TITLE
fix: separate PR creation from claude-code-action

### DIFF
--- a/.claude/skills/content-fix/SKILL.md
+++ b/.claude/skills/content-fix/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: content-fix
-description: "Autonomous fixer for documentation content issues. Triggered by content_fix issues (documentation + fix labels) or @claude comments on those issues. Reads the issue, identifies affected files, applies fixes following Netwrix writing standards, and opens a PR. Asks clarifying questions if the request is ambiguous."
+description: "Autonomous fixer for documentation content issues. Triggered by content_fix issues (documentation + fix labels) or @claude comments on those issues. Reads the issue, identifies affected files, applies fixes following Netwrix writing standards, and pushes a branch. A separate workflow step creates the PR. Asks clarifying questions if the request is ambiguous."
 argument-hint: "[issue-number]"
 ---
 
 # Content Fix
 
-You are a documentation fixer running in GitHub Actions. A user reported a documentation issue. Find the right file, fix it, and open a PR. If the request is ambiguous, ask a clarifying question and stop.
+You are a documentation fixer running in GitHub Actions. A user reported a documentation issue. Find the right file, fix it, and push a branch. If the request is ambiguous, ask a clarifying question and stop.
 
 Read `docs/CLAUDE.md` before starting — it has the writing standards.
 
@@ -17,7 +17,7 @@ Read `docs/CLAUDE.md` before starting — it has the writing standards.
 
 ## Workflow
 
-Follow these steps in order. Do NOT stop until you have either opened a PR or posted a clarifying question.
+Follow these steps in order. Do NOT stop until you have either pushed a branch or posted a clarifying question.
 
 ### 1. Read the issue
 
@@ -52,7 +52,7 @@ git checkout -b fix/issue-$1-<short-slug>
 
 Read the file, apply the fix using the Edit tool. Follow `docs/CLAUDE.md` standards. Only fix what the issue asks about.
 
-### 5. Open a PR
+### 5. Commit and push
 
 ```bash
 git add <changed-files>
@@ -62,26 +62,25 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 git push -u origin fix/issue-$1-<short-slug>
 ```
 
-```bash
-ISSUE_NUM=$1
-gh pr create --base dev --title "docs: fix #${ISSUE_NUM} — <brief description>" --body "$(cat <<EOF
-Closes #${ISSUE_NUM}
+Do NOT create a PR — a separate workflow step handles that.
 
-## What changed
-- <describe the fix>
+### 6. Write output
 
-## Files modified
-- \`path/to/file.md\`
-EOF
-)"
+After pushing, output a summary as your final message. This MUST include the branch name on its own line in this exact format:
+
+```
+BRANCH_NAME=fix/issue-<number>-<slug>
 ```
 
-### 6. Comment on the issue
+Also include a brief description of what was changed and which files were modified. Example:
 
-Post a comment confirming the fix with a link to the PR.
+```
+Removed redundant word "currently" from certification availability sentence.
 
-```bash
-gh issue comment $1 --repo $REPO --body "Fix submitted in PR #<pr-number>."
+Files modified:
+- docs/partner/implementation/change-tracker.md
+
+BRANCH_NAME=fix/issue-42-redundant-wording
 ```
 
 ## Rules
@@ -89,6 +88,7 @@ gh issue comment $1 --repo $REPO --body "Fix submitted in PR #<pr-number>."
 - **Confident = act, uncertain = ask.** If you can find the file, fix it. If not, ask.
 - **Fix only what was reported.** Don't rewrite unrelated content.
 - **Do not run Vale or Dale.** The PR will be reviewed by other workflows automatically.
-- **If a fix would change meaning**, skip it and explain in your comment.
+- **Do not create PRs or comment on the issue.** The workflow handles that after you push.
+- **If a fix would change meaning**, skip it and explain in your output.
 - **Each invocation is stateless.** Always read the full issue + comments.
 - **Missing images cannot be fixed.** Tell the team in a comment.

--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -136,11 +136,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Run content-fix skill
+        id: content-fix
         if: steps.check-issue.outputs.issue_state == 'OPEN' && steps.check-issue.outputs.has_content_fix == 'true'
         uses: anthropics/claude-code-action@v1
         env:
           REPO: ${{ github.repository }}
-          PUSH_TOKEN: ${{ secrets.VALE_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -152,11 +152,53 @@ jobs:
             - REPO: ${{ github.repository }}
             - ISSUE_NUMBER: ${{ github.event.issue.number }}
             - ISSUE_TITLE: ${{ github.event.issue.title }}
-
-            IMPORTANT: Before running `gh pr create` or `gh issue comment`, you MUST first authenticate with the push token by running:
-            echo $PUSH_TOKEN | gh auth login --with-token
-            This ensures PRs are created with the correct identity to trigger downstream workflows.
           claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill(content-fix)"'
+
+      - name: Create PR and comment on issue
+        if: steps.check-issue.outputs.issue_state == 'OPEN' && steps.check-issue.outputs.has_content_fix == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.VALE_TOKEN }}
+        run: |
+          # Extract branch name from Claude's output
+          CLAUDE_OUTPUT=$(cat /home/runner/work/_temp/claude-execution-output.json 2>/dev/null | jq -r '.result // empty' 2>/dev/null || echo "")
+          BRANCH_NAME=$(echo "$CLAUDE_OUTPUT" | grep -oP 'BRANCH_NAME=\K.*' | head -1)
+
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "No branch name found in Claude output — skill likely asked a clarifying question"
+            exit 0
+          fi
+
+          # Check if branch exists on remote
+          if ! git ls-remote --exit-code origin "$BRANCH_NAME" > /dev/null 2>&1; then
+            echo "Branch $BRANCH_NAME not found on remote — skipping PR creation"
+            exit 0
+          fi
+
+          # Extract description from Claude's output (everything before BRANCH_NAME line)
+          DESCRIPTION=$(echo "$CLAUDE_OUTPUT" | sed '/BRANCH_NAME=/d' | sed '/^$/d')
+          ISSUE_NUM=${{ github.event.issue.number }}
+
+          # Create PR using VALE_TOKEN so it triggers downstream workflows
+          PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
+            --base dev \
+            --head "$BRANCH_NAME" \
+            --title "docs: fix #${ISSUE_NUM} — $(echo "$BRANCH_NAME" | sed 's|fix/issue-[0-9]*-||' | tr '-' ' ')" \
+            --body "$(cat <<EOF
+          Closes #${ISSUE_NUM}
+
+          ## What changed
+          ${DESCRIPTION}
+          EOF
+          )")
+
+          echo "Created PR: $PR_URL"
+
+          # Comment on the issue
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          gh issue comment "$ISSUE_NUM" \
+            --repo ${{ github.repository }} \
+            --body "Fix submitted in PR #${PR_NUMBER}."
 
   content-fix-followup:
     needs: process-issue
@@ -198,12 +240,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Run content-fix skill
+        id: content-fix-followup
         if: steps.check-issue.outputs.issue_state == 'OPEN' && steps.check-issue.outputs.has_content_fix == 'true'
         uses: anthropics/claude-code-action@v1
         env:
           REPO: ${{ github.repository }}
           COMMENT_BODY: ${{ github.event.comment.body }}
-          PUSH_TOKEN: ${{ secrets.VALE_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -219,8 +261,50 @@ jobs:
 
             This is a follow-up invocation. A user replied with @claude on a content_fix issue.
             Read the full issue body AND all comments to understand the complete context.
-
-            IMPORTANT: Before running `gh pr create` or `gh issue comment`, you MUST first authenticate with the push token by running:
-            echo $PUSH_TOKEN | gh auth login --with-token
-            This ensures PRs are created with the correct identity to trigger downstream workflows.
           claude_args: '--model claude-opus-4-6 --max-turns 50 --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill(content-fix)"'
+
+      - name: Create PR and comment on issue
+        if: steps.check-issue.outputs.issue_state == 'OPEN' && steps.check-issue.outputs.has_content_fix == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.VALE_TOKEN }}
+        run: |
+          # Extract branch name from Claude's output
+          CLAUDE_OUTPUT=$(cat /home/runner/work/_temp/claude-execution-output.json 2>/dev/null | jq -r '.result // empty' 2>/dev/null || echo "")
+          BRANCH_NAME=$(echo "$CLAUDE_OUTPUT" | grep -oP 'BRANCH_NAME=\K.*' | head -1)
+
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "No branch name found in Claude output — skill likely asked a clarifying question"
+            exit 0
+          fi
+
+          # Check if branch exists on remote
+          if ! git ls-remote --exit-code origin "$BRANCH_NAME" > /dev/null 2>&1; then
+            echo "Branch $BRANCH_NAME not found on remote — skipping PR creation"
+            exit 0
+          fi
+
+          # Extract description from Claude's output (everything before BRANCH_NAME line)
+          DESCRIPTION=$(echo "$CLAUDE_OUTPUT" | sed '/BRANCH_NAME=/d' | sed '/^$/d')
+          ISSUE_NUM=${{ github.event.issue.number }}
+
+          # Create PR using VALE_TOKEN so it triggers downstream workflows
+          PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
+            --base dev \
+            --head "$BRANCH_NAME" \
+            --title "docs: fix #${ISSUE_NUM} — $(echo "$BRANCH_NAME" | sed 's|fix/issue-[0-9]*-||' | tr '-' ' ')" \
+            --body "$(cat <<EOF
+          Closes #${ISSUE_NUM}
+
+          ## What changed
+          ${DESCRIPTION}
+          EOF
+          )")
+
+          echo "Created PR: $PR_URL"
+
+          # Comment on the issue
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+          gh issue comment "$ISSUE_NUM" \
+            --repo ${{ github.repository }} \
+            --body "Fix submitted in PR #${PR_NUMBER}."


### PR DESCRIPTION
claude-code-action controls the gh CLI identity (github-actions[bot]), so PRs created inside the action don't trigger downstream workflows regardless of which token is used.

Fix: The skill now only pushes the branch and outputs BRANCH_NAME=... A separate workflow step creates the PR using VALE_TOKEN directly, which authenticates as the PAT owner and triggers vale-linter, doc-pr, and build-and-deploy workflows.