### PR TITLE
docs: fix #645 — redundant wording

### DIFF
--- a/docs/partner/implementation/change-tracker.md
+++ b/docs/partner/implementation/change-tracker.md
@@ -13,7 +13,7 @@ import { Company, NCT } from '@site/src/training/products';
 
 Estimated length: 2.5 hours
 
-This learning path offers training to <Company /> partner Professional Services engineers on the <NCT /> product. However, certification is not currently available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
+This learning path offers training to <Company /> partner Professional Services engineers on the <NCT /> product. However, certification is not available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
 
 * 1900 <NCT /> – Valuable Features
 * 2902 <NCT /> – Architecture

--- a/docs/partner/implementation/change-tracker.md
+++ b/docs/partner/implementation/change-tracker.md
@@ -13,7 +13,7 @@ import { Company, NCT } from '@site/src/training/products';
 
 Estimated length: 2.5 hours
 
-This learning path offers training to <Company /> partner Professional Services engineers on the <NCT /> product. However, certification is not available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
+This learning path offers training to <Company /> partner Professional Services engineers on the <NCT /> product. However, certification isn't available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
 
 * 1900 <NCT /> – Valuable Features
 * 2902 <NCT /> – Architecture

--- a/docs/partner/implementation/change-tracker.md
+++ b/docs/partner/implementation/change-tracker.md
@@ -13,7 +13,7 @@ import { Company, NCT } from '@site/src/training/products';
 
 Estimated length: 2.5 hours
 
-This learning path offers training to <Company /> partner Professional Services engineers on the <NCT /> product. However, certification isn't available at this time. When the final courses are available to grant certification, they will be added to this learning path. You will be able to pick up where you left off. It contains the following courses:
+This learning path offers training to <Company /> partner Professional Services engineers on the <NCT /> product. However, certification isn't available at this time. When the final courses are available to grant certification, this learning path will include them. You can resume from your last completed course. It contains the following courses:
 
 * 1900 <NCT /> – Valuable Features
 * 2902 <NCT /> – Architecture


### PR DESCRIPTION
Closes #645

## What changed
fix/issue-645-redundant-wording