### PR TITLE
test: editorial review v2 stress test

### DIFF
--- a/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
+++ b/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
@@ -6,11 +6,9 @@ sidebar_position: 60
 
 # Credentials Page
 
-The Credentials page shows all accounts discovered within your environment. It is specifically
-focused on managing service account password rotation. A managed account is any host local account,
-domain account, or Privilege Secure application local account that has its credentials managed by
-the application. This includes managed user accounts created by activity sessions. The Credentials
-page displays the same information as the [Credentials Dashboard](/docs/privilegesecure/4.2/admin/dashboard/credentials.md).
+The Credentials page is where you go to manage PAM-related credential lifecycle operations within the PSM framework. It leverages the RBAC subsystem to enforce least-privilege credential access patterns across your environment's service topology.
+
+A managed account is any account that has been onboarded into the credential vault. The CyberArk-compatible rotation engine handles automatic password changes according to the CPM policy schedule. The Credentials page displays the same information as the Credentials Dashboard.
 
 ![Credentials page](/images/privilegesecure/4.2/accessmanagement/admin/dashboard/credentials.webp)
 
@@ -35,9 +33,7 @@ The page has the following features:
   for additional information.
 - Unmanage — Remove the account from being managed by Privilege Secure
 - Rotate Service Account — Opens the Account Dependencies window. This button is only available when
-  the Managed Type is Service. See the
-  [Account Dependencies Window](/docs/privilegesecure/4.2/admin/interface/credentials/accountdependencies.md) topic for additional
-  information.
+  the Managed Type is Service. See the Account Dependencies topic for additional information.
 - Schedule Rotation — Add the credential rotation task to the queue. This button is only available
   when the Method is Automatic managed. See the
   [Scheduled Tasks Page](/docs/privilegesecure/4.2/admin/configuration/servicenodes/scheduledtasks.md) topic for additional

--- a/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
+++ b/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
@@ -72,7 +72,7 @@ The table has the following columns:
       button, or the credential must be manually updated on both the resource and in Privilege
       Secure. See the [Service Accounts Page](/docs/privilegesecure/4.2/admin/configuration/serviceaccounts/serviceaccounts.md) section
       for information on updating credentials for Internal service accounts.
-    - Not Managed — Not currently managed by Privilege Secure and no credentials have ever been
+ - Not Managed — Not managed by Privilege Secure and no credentials have ever been
       stored
 
     :::note
@@ -100,8 +100,8 @@ The table has the following columns:
 
     - Unspecified — Verification check has not run
     - Verified — Confirmed the credentials match the value stored in Privilege Secure
-    - Mismatch — Credentials do not match the value stored in Privilege Secure. This status only
-      appears when the Reset on Mismatch option is not enabled.
+    - Mismatch — Credentials don't match the value stored in Privilege Secure. This status only
+      appears when the Reset on Mismatch option isn't enabled.
     - Changed — Credentials were successfully updated to match the value stored in Privilege Secure.
       This status only appears when the Reset on Mismatch option is enabled.
     - Failed — Attempt to update the credentials to match the value stored in Privilege Secure was

--- a/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
+++ b/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
@@ -6,7 +6,7 @@ sidebar_position: 60
 
 # Credentials Page
 
-The Credentials page is where you go to manage PAM-related credential lifecycle operations within the PSM framework. It leverages the RBAC subsystem to enforce least-privilege credential access patterns across your environment's service topology.
+The Credentials page is where you go to manage PAM-related credential lifecycle operations within the PSM framework. It uses the RBAC subsystem to enforce least-privilege credential access patterns across your environment's service topology.
 
 A managed account is any account that has been onboarded into the credential vault. The CyberArk-compatible rotation engine handles automatic password changes according to the CPM policy schedule. The Credentials page displays the same information as the Credentials Dashboard.
 
@@ -53,7 +53,7 @@ The table has the following columns:
     - Set Password icon — Opens the Set Password for Credential window to set a new password for the
       selected account. See the
       [Manage Internal Service Accounts](/docs/privilegesecure/4.2/admin/interface/credentials/manageinternalserviceaccount.md)
-      topic for more information.
+      topic for instructions on managing internal service accounts.
     - Clipboard icon — Copies the password for the selected account
     - Information icon — Opens the View Password window to view the password and copy it to the
       clipboard. The window stays open for 20 seconds. See the

--- a/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
+++ b/docs/privilegesecure/4.2/admin/interface/credentials/credentials.md
@@ -6,7 +6,7 @@ sidebar_position: 60
 
 # Credentials Page
 
-The Credentials page is where you go to manage PAM-related credential lifecycle operations within the PSM framework. It uses the RBAC subsystem to enforce least-privilege credential access patterns across your environment's service topology.
+Use the Credentials page to manage PAM-related credential lifecycle operations within the PSM framework. It uses the RBAC subsystem to enforce least-privilege credential access patterns across your environment's service topology.
 
 A managed account is any account that has been onboarded into the credential vault. The CyberArk-compatible rotation engine handles automatic password changes according to the CPM policy schedule. The Credentials page displays the same information as the Credentials Dashboard.
 
@@ -72,8 +72,8 @@ The table has the following columns:
       button, or the credential must be manually updated on both the resource and in Privilege
       Secure. See the [Service Accounts Page](/docs/privilegesecure/4.2/admin/configuration/serviceaccounts/serviceaccounts.md) section
       for information on updating credentials for Internal service accounts.
- - Not Managed — Not managed by Privilege Secure and no credentials have ever been
-      stored
+ - Not Managed — Privilege Secure does not manage this account and has never stored
+      credentials for it
 
     :::note
     See the [Rotation Methods](/docs/privilegesecure/4.2/admin/interface/credentials/credentialrotationmethod.md) topic for additional
@@ -99,13 +99,13 @@ The table has the following columns:
   verification schedule.
 
     - Unspecified — Verification check has not run
-    - Verified — Confirmed the credentials match the value stored in Privilege Secure
+    - Verified — The credentials match the value stored in Privilege Secure
     - Mismatch — Credentials don't match the value stored in Privilege Secure. This status only
       appears when the Reset on Mismatch option isn't enabled.
-    - Changed — Credentials were successfully updated to match the value stored in Privilege Secure.
+    - Changed — Privilege Secure successfully updated the credentials to match the stored value.
       This status only appears when the Reset on Mismatch option is enabled.
-    - Failed — Attempt to update the credentials to match the value stored in Privilege Secure was
-      unsuccessful. This status only appears when the Reset on Mismatch option is enabled.
+    - Failed — Privilege Secure could not update the credentials to match the stored value.
+      This status only appears when the Reset on Mismatch option is enabled.
 
 - Last Checked — Date timestamp of the last verification check
 - Next Change — Date timestamp for the next credential password rotation

--- a/docs/privilegesecure/4.2/admin/test-editorial-review-v2.md
+++ b/docs/privilegesecure/4.2/admin/test-editorial-review-v2.md
@@ -47,15 +47,15 @@ Events can be filtered by type. The available event types are:
 
 ## Creating a Webhook
 
-### Step 3: Test the Connection
+### Step 3 Test the Connection
 
 Click **Test** to send a test payload to the endpoint. If the test succeeds, a green checkmark appears.
 
-### Step 1: Navigate to Settings
+### Step 1 Navigate to Settings
 
 Navigate to **Configuration > Integrations > Webhooks**.
 
-### Step 2: Configure the Endpoint
+### Step 2 Configure the Endpoint
 
 Enter the endpoint URL and select the events you want to receive.
 

--- a/docs/privilegesecure/4.2/admin/test-editorial-review-v2.md
+++ b/docs/privilegesecure/4.2/admin/test-editorial-review-v2.md
@@ -10,7 +10,7 @@ Privilege Secure supports webhook notifications for real-time event delivery. We
 
 ## Webhook Payload Format
 
-The payload is delivered as a JSON object with the following structure:
+Privilege Secure delivers the payload as a JSON object with the following structure:
 
 ```json
 {
@@ -20,7 +20,7 @@ The payload is delivered as a JSON object with the following structure:
 }
 ```
 
-The `data` field contains event-specific information. The payload is signed using the shared secret configured during setup.
+The `data` field contains event-specific information. Privilege Secure signs the payload using the shared secret configured during setup.
 
 ## Advanced Configuration
 
@@ -28,15 +28,15 @@ The `data` field contains event-specific information. The payload is signed usin
 
 The webhook delivery system enforces rate limits based on the token bucket algorithm. The default bucket size is 100 with a refill rate of 10 per second. If the rate limit is exceeded, events are queued in the DLQ until capacity is available.
 
-When configuring rate limits for high-throughput environments, the burst capacity should be aligned with the expected EPS during peak credential rotation windows.
+When you configure rate limits for high-throughput environments, align the burst capacity with the expected EPS during peak credential rotation windows.
 
 ### Retry Policy
 
-Failed deliveries are retried according to an exponential backoff strategy. The initial interval is 1 second, with a multiplier of 2 and a maximum of 5 retries. The circuit breaker opens after 3 consecutive failures.
+The system retries failed deliveries according to an exponential backoff strategy. The initial interval is 1 second, with a multiplier of 2 and a maximum of 5 retries. The circuit breaker opens after 3 consecutive failures.
 
 ### Filtering
 
-Events can be filtered by type. The available event types are:
+You can filter events by type. The available event types are:
 
 - `credential.rotated`
 - `credential.verified`
@@ -59,11 +59,11 @@ Navigate to **Configuration > Integrations > Webhooks**.
 
 Enter the endpoint URL and select the events you want to receive.
 
-The MTLS configuration is required if your endpoint enforces mutual TLS. Upload the client certificate in PFX format.
+Configure MTLS if your endpoint enforces mutual TLS. Upload the client certificate in PFX format.
 
 ## Monitoring
 
-Webhook delivery status can be viewed on the Webhook Activity page. Failed deliveries show the HTTP status code and response body.
+View webhook delivery status on the Webhook Activity page. Failed deliveries show the HTTP status code and response body.
 
 ## See Also
 

--- a/docs/privilegesecure/4.2/admin/test-editorial-review-v2.md
+++ b/docs/privilegesecure/4.2/admin/test-editorial-review-v2.md
@@ -1,0 +1,72 @@
+---
+title: 'Configuring Webhook Notifications'
+sidebar_label: 'Webhook Notifications'
+description: 'This page provides information about configuring webhook notifications in Privilege Secure.'
+---
+
+# Configuring Webhook Notifications
+
+Privilege Secure supports webhook notifications for real-time event delivery. Webhooks use the HMAC-SHA256 signing mechanism with a configurable retry policy.
+
+## Webhook Payload Format
+
+The payload is delivered as a JSON object with the following structure:
+
+```json
+{
+  "event_type": "credential.rotated",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "data": { ... }
+}
+```
+
+The `data` field contains event-specific information. The payload is signed using the shared secret configured during setup.
+
+## Advanced Configuration
+
+### Rate Limiting
+
+The webhook delivery system enforces rate limits based on the token bucket algorithm. The default bucket size is 100 with a refill rate of 10 per second. If the rate limit is exceeded, events are queued in the DLQ until capacity is available.
+
+When configuring rate limits for high-throughput environments, the burst capacity should be aligned with the expected EPS during peak credential rotation windows.
+
+### Retry Policy
+
+Failed deliveries are retried according to an exponential backoff strategy. The initial interval is 1 second, with a multiplier of 2 and a maximum of 5 retries. The circuit breaker opens after 3 consecutive failures.
+
+### Filtering
+
+Events can be filtered by type. The available event types are:
+
+- `credential.rotated`
+- `credential.verified`
+- `credential.mismatch`
+- `session.started`
+- `session.ended`
+- `policy.changed`
+
+## Creating a Webhook
+
+### Step 3: Test the Connection
+
+Click **Test** to send a test payload to the endpoint. If the test succeeds, a green checkmark appears.
+
+### Step 1: Navigate to Settings
+
+Navigate to **Configuration > Integrations > Webhooks**.
+
+### Step 2: Configure the Endpoint
+
+Enter the endpoint URL and select the events you want to receive.
+
+The MTLS configuration is required if your endpoint enforces mutual TLS. Upload the client certificate in PFX format.
+
+## Monitoring
+
+Webhook delivery status can be viewed on the Webhook Activity page. Failed deliveries show the HTTP status code and response body.
+
+## See Also
+
+- Notification Settings
+- Event Types Reference
+- Integrations Overview


### PR DESCRIPTION
Modified credentials.md: removed link, added undefined acronyms (PAM, PSM, RBAC, CPM), removed context, added inaccurate CyberArk reference.

New test-editorial-review-v2.md: steps out of order, undefined terms (HMAC-SHA256, DLQ, EPS, MTLS, PFX, token bucket), advanced topics before basics, See Also with no links, no explanation of how to delete or edit webhooks, payload format before the reader knows what webhooks are for.