### PR TITLE
Fix deploy cancellation on dev/main pushes

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,7 @@ on:
 
 concurrency:
   group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   determine-environment:


### PR DESCRIPTION
Only cancel in-progress runs for PRs, not for push events to dev/main. Rapid-fire merges were cancelling each other before deploy could run.