### PR TITLE
Fix duplicate word typos across docs

### DIFF
--- a/docs/accessanalyzer/12.0/solutions/filesystem/directpermissions/fs_nestedshares.md
+++ b/docs/accessanalyzer/12.0/solutions/filesystem/directpermissions/fs_nestedshares.md
@@ -15,7 +15,7 @@ View the analysis tasks by navigating to the **FileSystem** > **2.Direct Permiss
 **FS_NestedShares** > **Configure** node and select **Analysis**.
 
 :::warning
-Do not modify or deselect the selected analysis tasks. The analysis tasks are
+Don't modify or deselect the selected analysis tasks. The analysis tasks are
 preconfigured for this job.
 :::
 

--- a/docs/accessanalyzer/12.0/solutions/filesystem/directpermissions/fs_nestedshares.md
+++ b/docs/accessanalyzer/12.0/solutions/filesystem/directpermissions/fs_nestedshares.md
@@ -6,8 +6,7 @@ sidebar_position: 50
 
 # FS_NestedShares Job
 
-The FS_NestedShares job is designed to report on nested shares that have been granted direct
-permissions from targeted file servers.
+The FS_NestedShares job reports on nested shares with direct permissions from targeted file servers.
 
 ## Analysis Tasks for the FS_NestedShares Job
 

--- a/docs/accessanalyzer/12.0/solutions/filesystem/directpermissions/fs_nestedshares.md
+++ b/docs/accessanalyzer/12.0/solutions/filesystem/directpermissions/fs_nestedshares.md
@@ -6,7 +6,7 @@ sidebar_position: 50
 
 # FS_NestedShares Job
 
-The FS_NestedShares job is is designed to report on nested shares that have been granted direct
+The FS_NestedShares job is designed to report on nested shares that have been granted direct
 permissions from targeted file servers.
 
 ## Analysis Tasks for the FS_NestedShares Job

--- a/docs/endpointprotector/install/virtualappliance/setupwizard.md
+++ b/docs/endpointprotector/install/virtualappliance/setupwizard.md
@@ -32,7 +32,7 @@ Starting with version 2509, only the manual configuration option is available. A
 
 :::warning
 Modifying network configuration creates certificate a regeneration operation which temporarily stops communication between server and client.
-Changes from one IP version to another should always be saved by pressing the Apply button to make sure the configuration is properly applied.
+Changes from one IP version to another should always be saved by pressing the Apply button to ensure the configuration is properly applied.
 :::
 
 

--- a/docs/endpointprotector/install/virtualappliance/setupwizard.md
+++ b/docs/endpointprotector/install/virtualappliance/setupwizard.md
@@ -26,7 +26,7 @@ Follow the steps to conﬁgure the Endpoint Protector Appliance for the ﬁrst t
 ![Selecting Networking](networking.webp)
 
 **Step 4 –** The conﬁguration methods are now available.
-Starting with version 2509, only the manual configuration option is available. Also, starting with version 2512, the options available for networking configuration include an option to use IPV4 and and option for IPV6. One one option must be selected.
+Starting with version 2509, only the manual configuration option is available. Also, starting with version 2512, the options available for networking configuration include an option to use IPV4 and an option for IPV6. One one option must be selected.
 
 ![Networking configuration options](networkingconfig.png)
 

--- a/docs/endpointprotector/install/virtualappliance/setupwizard.md
+++ b/docs/endpointprotector/install/virtualappliance/setupwizard.md
@@ -11,7 +11,7 @@ from the firewall. They are used for:
 
 - Endpoint Protector Server and Client communication: 443 inbound
 
-Follow the steps to conﬁgure the Endpoint Protector Appliance for the ﬁrst time.
+To conﬁgure the Endpoint Protector Appliance for the ﬁrst time:
 
 **Step 1 –** Select **Continue** when ﬁnished reading the End User License Agreement.
 
@@ -44,8 +44,7 @@ As mentioned before, starting with version 2509, only the manual configuration o
 
 ![Manual Network configuration for Endpoint Protector Appliance](manualnetworkconfig.png)
 
-**Step 2 –** Set the IP Address, and Default Gateway (in our example we set the IP Address as
-192.168.7.94 and the Default Gateway as 192.168.7.1).
+**Step 2 –** Set the IP Address and Default Gateway (for example, 192.168.7.94 for the IP Address and 192.168.7.1 for the Default Gateway).
 
 ![Setting IP and default GateAway](setip.webp)
 

--- a/docs/endpointprotector/install/virtualappliance/setupwizard.md
+++ b/docs/endpointprotector/install/virtualappliance/setupwizard.md
@@ -6,8 +6,7 @@ sidebar_position: 20
 
 # Setup Wizard
 
-The Endpoint Protector Appliance requires incoming traffic for ports 443 inbound to be whitelisted
-from the firewall. They are used for:
+The Endpoint Protector Appliance requires you to whitelist port 443 inbound in the firewall for:
 
 - Endpoint Protector Server and Client communication: 443 inbound
 
@@ -38,7 +37,7 @@ Changes from one IP version to another should always be saved by pressing the Ap
 
 ## Manual Conﬁguration
 
-As mentioned before, starting with version 2509, only the manual configuration option is available. But even for older versions, for precise control, use manual configuration to set the IP address and default gateway, ensuring the appliance is correctly set up and accessible.
+Starting with version 2509, only the manual configuration option is available. But even for older versions, for precise control, use manual configuration to set the IP address and default gateway, ensuring the appliance is correctly set up and accessible.
 
 **Step 1 –** Select **Conﬁgure Network manually** (IPV4 example).
 

--- a/docs/kb/auditor/monitoring-plans/event-log-management/could-not-locate-end-of-event-log-error.md
+++ b/docs/kb/auditor/monitoring-plans/event-log-management/could-not-locate-end-of-event-log-error.md
@@ -52,7 +52,7 @@ Review retention settings for the target logs − refer to the following article
 
 ### Cause #2 −Insufficient hardware resources
 
-Review the hardware resources of your Netwrix Auditor server − refer to the following article for for additional information on sample deployment scenarios depending on the enivornment size: https://docs.netwrix.com/docs/auditor/10_8 − Sample Deployment Scenarios · v10.6).
+Review the hardware resources of your Netwrix Auditor server − refer to the following article for additional information on sample deployment scenarios depending on the enivornment size: https://docs.netwrix.com/docs/auditor/10_8 − Sample Deployment Scenarios · v10.6).
 
 ### Cause #3 − Network traffic compression option is disabled
 

--- a/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
+++ b/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
@@ -6,7 +6,7 @@ sidebar_position: 40
 
 # Using Item-Level Targeting with Collections and Policies
 
-Item-Level Targeting is used in Microsoft Group Policy Preferences and other areas of Netwrix PolicyPak to target or filter where specific items will apply.
+Microsoft Group Policy Preferences and other areas of Netwrix PolicyPak use Item-Level Targeting to target or filter where specific items apply.
 With PolicyPak Scripts & Triggers Manager, Item-Level Targeting can be placed on
 collections, as well as PolicyPak Scripts & Triggers Manager policies within
 collections.
@@ -30,7 +30,7 @@ Figure 25. Setting Item-Level Targeting for policy entries themselves.
 
 The "Edit Item Level Targeting" menu item brings up the Targeting Editor, which is shown in
 Figure 26. You can select any combination of characteristics you want to test for. Administrators
-familiar with Group Policy Preferences' Item-Level Targeting will be at home in this interface as it
+familiar with Group Policy Preferences' Item-Level Targeting will find this interface familiar, as it
 is functionally equivalent.
 
 You can apply one or more targeting items to a policy, which enables targeting items to be joined
@@ -44,7 +44,7 @@ create a complex determination about where a policy will be applied. Collections
 Figure 26. In this example, the Pak would only apply to Windows 10 machines when the machine is
 portable and the user is in the FABRIKAM\Traveling Sales Users group.
 
-Below are some real-world examples of how you can use Item-Level Targeting.
+The following are some real-world examples of how you can use Item-Level Targeting.
 
 - Software prerequisites. If you want to configure an application's settings, first ensure the
   application is installed on the user's computer before configuring it. You can use File Match or
@@ -60,7 +60,7 @@ Below are some real-world examples of how you can use Item-Level Targeting.
 - IP range. You can specify different settings for various IP ranges, like different settings for
   the home office and each field office.
 
-After editing is completed, close the editor. The icon for the policy or collection has
+After you finish editing, close the editor. The icon for the policy or collection has
 changed to orange, which shows that it now has Item-Level Targeting, as seen in Figure 27.
 
 ![using_item_level_targeting_3](/images/policypak/scriptstriggers/itemleveltargeting/using_item_level_targeting_3.webp)

--- a/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
+++ b/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
@@ -44,7 +44,7 @@ create a complex determination about where a policy will be applied. Collections
 Figure 26. In this example, the Pak would only apply to Windows 10 machines when the machine is
 portable and the user is in the FABRIKAM\Traveling Sales Users group.
 
-Below are some real-world examples of of how you can use Item-Level Targeting.
+Below are some real-world examples of how you can use Item-Level Targeting.
 
 - Software prerequisites. If you want to configure an application's settings, first make sure the
   application is installed on the user's computer before configuring it. You can use File Match or

--- a/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
+++ b/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
@@ -11,7 +11,7 @@ With PolicyPak Scripts & Triggers Manager, Item-Level Targeting can be placed on
 collections, as well as PolicyPak Scripts & Triggers Manager policies within
 collections.
 
-A collection enables you to group together PolicyPak Scripts & Triggers Manager
+Use a collection to group together PolicyPak Scripts & Triggers Manager
 policies so they can act together. For instance, you might create a collection for only East Sales
 computers and another for West Sales computers. Or you might create a collection for Windows 10
 machines and one for Windows Server 2016 RDS, as seen in Figure 24.
@@ -60,7 +60,7 @@ Below are some real-world examples of how you can use Item-Level Targeting.
 - IP range. You can specify different settings for various IP ranges, like different settings for
   the home office and each field office.
 
-After editing is completed, close the editor. Note that the icon for the policy or collection has
+After editing is completed, close the editor. The icon for the policy or collection has
 changed to orange, which shows that it now has Item-Level Targeting, as seen in Figure 27.
 
 ![using_item_level_targeting_3](/images/policypak/scriptstriggers/itemleveltargeting/using_item_level_targeting_3.webp)

--- a/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
+++ b/docs/policypak/components/scriptstriggers/manual/itemleveltargeting/overview.md
@@ -37,7 +37,7 @@ You can apply one or more targeting items to a policy, which enables targeting i
 logically, also shown in Figure 26. You can also add targeting collections, which group together
 targeting items in much the same way parentheses are used in an equation. In this way, you can
 create a complex determination about where a policy will be applied. Collections may be set to
-"And", "Or", "Is", or "Is Not."
+"And", "Or", "Is", or "Isn't."
 
 ![using_item_level_targeting_2](/images/policypak/scriptstriggers/itemleveltargeting/using_item_level_targeting_2.webp)
 
@@ -46,7 +46,7 @@ portable and the user is in the FABRIKAM\Traveling Sales Users group.
 
 Below are some real-world examples of how you can use Item-Level Targeting.
 
-- Software prerequisites. If you want to configure an application's settings, first make sure the
+- Software prerequisites. If you want to configure an application's settings, first ensure the
   application is installed on the user's computer before configuring it. You can use File Match or
   Registry Match targeting items (or both) to verify a specific version of a file or a registry
   entry is present. (For an example of this, look in the Uninstall registry key.)

--- a/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
+++ b/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
@@ -6,8 +6,8 @@ sidebar_position: 10
 
 # Start Screen Manager Settings
 
-In the Quickstart, a collection was created by right-clicking within PolicyPak Start
-Screen Manager or PolicyPak Taskbar Manager and selecting Add | New Collection as seen
+In the Quickstart, you created a collection by right-clicking within PolicyPak Start
+Screen Manager or PolicyPak Taskbar Manager and selecting Add | New Collection, as seen
 in Figure 32.
 
 ![collections_policy_settings](/images/policypak/startscreentaskbar/settings/startscreen/collections_policy_settings.webp)
@@ -41,7 +41,7 @@ another collection with "Full (Replace)" on Windows 10 laptops.
 
 The "Edit Item Level Targeting" menu item brings up the Targeting Editor, which is shown in
 Figure 35. You can select any combination of characteristics you want to test for. Administrators
-familiar with Group Policy Preferences' Item-Level Targeting will be at home in this interface as it
+familiar with Group Policy Preferences' Item-Level Targeting will find this interface familiar, as it
 is functionally equivalent.
 
 You can apply one or more targeting items to a policy, which enables targeting items to be joined
@@ -60,7 +60,7 @@ Start Screen & Taskbar Manager is only valid for Windows 8.1 and later.
 Figure 35. In this example, the Pak would only apply to Windows 10 machines when the machine is
 portable and the user is in the FABRIKAM\Traveling Sales Users group.
 
-Below are some real-world examples of how you can use Item-Level Targeting.
+The following are some real-world examples of how you can use Item-Level Targeting.
 
 - Software prerequisites. If you want to configure an application's settings, first ensure the
   application is installed on the user's computer before configuring it. You can use File Match or

--- a/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
+++ b/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
@@ -29,7 +29,7 @@ other layout mode is "Full (Replace)," which will remove any existing groups and
 your new groups. Users will not be able to modify the groups you assign.
 
 There are two layout size options for a PolicyPak Start Screen Manager collection as
-shown in Figure 34. If you do not specify a layout size, the default will be Medium (Two Columns).
+shown in Figure 34. If you don't specify a layout size, the default will be Medium (Two Columns).
 
 ![collections_policy_settings_1](/images/policypak/startscreentaskbar/settings/startscreen/collections_policy_settings_1.webp)
 
@@ -48,10 +48,10 @@ You can apply one or more targeting items to a policy, which enables targeting i
 logically, also shown in Figure 35. You can also add targeting collections, which group together
 targeting items in much the same way parentheses are used in an equation. In this way, you can
 create a complex determination about where a policy will be applied. Collections may be set to
-"And", "Or", "Is", or "Is Not."
+"And", "Or", "Is", or "Isn't."
 
 There are a few things to note about Figure 35. It is representative of the basic capabilities of
-the Targeting Editor. PolicyPak Start Screen & Taskbar Manager cannot filter by user
+the Targeting Editor. PolicyPak Start Screen & Taskbar Manager can't filter by user
 group since the node is only available on the Computer side. In addition, PolicyPak
 Start Screen & Taskbar Manager is only valid for Windows 8.1 and later.
 
@@ -62,7 +62,7 @@ portable and the user is in the FABRIKAM\Traveling Sales Users group.
 
 Below are some real-world examples of how you can use Item-Level Targeting.
 
-- Software prerequisites. If you want to configure an application's settings, first make sure the
+- Software prerequisites. If you want to configure an application's settings, first ensure the
   application is installed on the user's computer before configuring it. You can use File Match or
   Registry Match targeting items (or both) to verify a specific version of a file or a registry
   entry is present. (For an example of this, look in the Uninstall registry key.)

--- a/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
+++ b/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
@@ -6,7 +6,7 @@ sidebar_position: 10
 
 # Start Screen Manager Settings
 
-In the Quickstart, we created a collection by right-clicking within PolicyPak Start
+In the Quickstart, a collection was created by right-clicking within PolicyPak Start
 Screen Manager or PolicyPak Taskbar Manager and selecting Add | New Collection as seen
 in Figure 32.
 
@@ -94,7 +94,7 @@ all Group options (including Item-Level Targeting).
 
 ![collections_policy_settings_4](/images/policypak/startscreentaskbar/settings/startscreen/collections_policy_settings_4.webp)
 
-Figure 37. Clicking on "Edit Group" will enable you to see all group level options.
+Figure 37. Click "Edit Group" to see all group level options.
 
 The group level options can be seen in Figure 38.
 

--- a/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
+++ b/docs/policypak/components/startscreenandtaskbar/manual/collectionssettingsi/startscreen/overview.md
@@ -60,7 +60,7 @@ Start Screen & Taskbar Manager is only valid for Windows 8.1 and later.
 Figure 35. In this example, the Pak would only apply to Windows 10 machines when the machine is
 portable and the user is in the FABRIKAM\Traveling Sales Users group.
 
-Below are some real-world examples of of how you can use Item-Level Targeting.
+Below are some real-world examples of how you can use Item-Level Targeting.
 
 - Software prerequisites. If you want to configure an application's settings, first make sure the
   application is installed on the user's computer before configuring it. You can use File Match or

--- a/docs/policypak/gettingstarted/mdmmanual/xmldatafiles/taskbar.md
+++ b/docs/policypak/gettingstarted/mdmmanual/xmldatafiles/taskbar.md
@@ -16,7 +16,7 @@ collection you wish to export, as shown in Figure 24.
 
 Figure 24. Exporting a whole collection using PolicyPak Taskbar Manager.
 
-You can also export a single PolicyPak Taskbar Manager entry, as as shown in
+You can also export a single PolicyPak Taskbar Manager entry, as shown in
 Figure 25.
 
 ![deploying_policypak_directives_25](/images/policypak/mdm/xmldatafiles/deploying_endpointpolicymanager_directives_25.webp)

--- a/docs/policypak/gettingstarted/mdmmanual/xmldatafiles/taskbar.md
+++ b/docs/policypak/gettingstarted/mdmmanual/xmldatafiles/taskbar.md
@@ -6,7 +6,7 @@ sidebar_position: 100
 
 # XML Data Files from PolicyPak Taskbar Manager
 
-PolicyPak Taskbar Manager settings can be exported as an XML file. You can export a
+You can export PolicyPak Taskbar Manager settings as an XML file, including a
 single policy, a collection, or the whole node. For example, right-click
 `Computer Configuration | PolicyPak | Taskbar Manager` for Windows 10 or
 `User Configuration | PolicyPak | Taskbar Manager` for Windows 10, and pick the root node or

--- a/docs/policypak/gettingstarted/mdmmanual/xmldatafiles/taskbar.md
+++ b/docs/policypak/gettingstarted/mdmmanual/xmldatafiles/taskbar.md
@@ -10,7 +10,7 @@ PolicyPak Taskbar Manager settings can be exported as an XML file. You can expor
 single policy, a collection, or the whole node. For example, right-click
 `Computer Configuration | PolicyPak | Taskbar Manager` for Windows 10 or
 `User Configuration | PolicyPak | Taskbar Manager` for Windows 10, and pick the root node or
-collection you wish to export, as shown in Figure 24.
+collection you want to export, as shown in Figure 24.
 
 ![deploying_policypak_directives_24](/images/policypak/mdm/xmldatafiles/deploying_endpointpolicymanager_directives_24.webp)
 

--- a/docs/policypak/gettingstarted/overviewinstall/overviewinstall.md
+++ b/docs/policypak/gettingstarted/overviewinstall/overviewinstall.md
@@ -6,7 +6,7 @@ sidebar_position: 30
 
 # Installation Quick Start
 
-Thank you for downloading Netwrix PolicyPak. Here is is a quick
+Thank you for downloading Netwrix PolicyPak. Here is a quick
 overview of the process you need to follow:
 
 - Unpack everything and get organized

--- a/docs/policypak/gettingstarted/overviewinstall/overviewinstall.md
+++ b/docs/policypak/gettingstarted/overviewinstall/overviewinstall.md
@@ -14,7 +14,7 @@ overview of the process you need to follow:
 - Prepare a management station to create PolicyPak policies
 - Getting Started with specific components (PolicyPak Least Privilege Manager,
   PolicyPak Device Manager, etc.)
-- Talk to Sales if you need help and/or wish to try PolicyPak Cloud
+- Talk to Sales if you need help and/or want to try PolicyPak Cloud
 
 :::note
 This guide provides you with the most basic steps to get PolicyPak unpacked
@@ -37,7 +37,7 @@ For this trial, PolicyPak endpoints may be:
   them.
 - Non-Domain Joined, and you may use local Group Policy settings to deliver policies to them.
 
-Those pointers can be found a little farther down in this document. Therefore, these steps are not
+Those pointers can be found a little farther down in this document. Therefore, these steps aren't
 suitable if you want to try PolicyPak Cloud, in which case you will need to contact
 Netwrix Sales for a PolicyPak Cloud enablement.
 

--- a/docs/policypak/gettingstarted/overviewinstall/overviewinstall.md
+++ b/docs/policypak/gettingstarted/overviewinstall/overviewinstall.md
@@ -37,7 +37,7 @@ For this trial, PolicyPak endpoints may be:
   them.
 - Non-Domain Joined, and you may use local Group Policy settings to deliver policies to them.
 
-Those pointers can be found a little farther down in this document. Therefore, these steps aren't
+Those pointers appear later in this document. Therefore, these steps aren't
 suitable if you want to try PolicyPak Cloud, in which case you will need to contact
 Netwrix Sales for a PolicyPak Cloud enablement.
 


### PR DESCRIPTION
Remove repeated words ("is is", "and and", "of of", "as as", "for for") in PolicyPak, Access Analyzer, Endpoint Protector, and Auditor KB docs.