### PR TITLE
fix: consolidate vale-autofix pushes to prevent build cancellation

### DIFF
--- a/.github/workflows/vale-autofix.yml
+++ b/.github/workflows/vale-autofix.yml
@@ -118,7 +118,6 @@ jobs:
           else
             git add -A docs/
             git commit -m "fix(vale): auto-fix substitutions and removals"
-            git push
             echo "committed=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -188,10 +187,9 @@ jobs:
             ```bash
             git add -A docs/
             git commit -m "fix(vale): auto-fix rewrites (AI-assisted)"
-            git push
             ```
 
-            IMPORTANT: Write the summary JSON file BEFORE committing. Do not post any PR comments.
+            IMPORTANT: Write the summary JSON file BEFORE committing. Do NOT run git push — the workflow handles pushing. Do not post any PR comments.
           claude_args: '--allowedTools "Bash(git:*),Read,Write,Edit,Glob,Grep"'
 
       - name: Phase 3 — Dale fixes
@@ -237,11 +235,20 @@ jobs:
             ```bash
             git add -A docs/
             git commit -m "fix(dale): auto-fix documentation issues (AI-assisted)"
-            git push
             ```
 
-            IMPORTANT: Write the summary JSON file BEFORE committing. Do not post any PR comments.
+            IMPORTANT: Write the summary JSON file BEFORE committing. Do NOT run git push — the workflow handles pushing. Do not post any PR comments.
           claude_args: '--allowedTools "Bash(git:*),Read,Write,Edit,Glob,Grep"'
+
+      - name: Push all fixes
+        if: steps.bot-check.outputs.skip != 'true' && steps.changed-files.outputs.count > 0
+        run: |
+          if [ "$(git rev-list @{u}..HEAD --count 2>/dev/null)" -gt 0 ]; then
+            echo "Pushing $(git rev-list @{u}..HEAD --count) commit(s)..."
+            git push
+          else
+            echo "No new commits to push"
+          fi
 
       - name: Build and post summary comment
         if: steps.bot-check.outputs.skip != 'true' && steps.changed-files.outputs.count > 0


### PR DESCRIPTION
Phases 1-3 each pushed separately, causing the build-and-deploy concurrency group to cancel in-progress builds. Only the Phase 1 push (using VALE_TOKEN) triggered new workflows — Phase 2/3 pushes via GITHUB_TOKEN were silently ignored, leaving the build on stale code.

Now all phases commit locally and a single push runs after all fixes.