### PR TITLE
fix: include claude[bot] in vale-autofix bot-check to prevent re-trigger loop

### DIFF
--- a/.github/workflows/vale-autofix.yml
+++ b/.github/workflows/vale-autofix.yml
@@ -29,7 +29,7 @@ jobs:
           # Get the latest commit author on the PR head
           AUTHOR=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '.commit.author.name')
           echo "Latest commit author: $AUTHOR"
-          if [ "$AUTHOR" = "github-actions[bot]" ]; then
+          if [ "$AUTHOR" = "github-actions[bot]" ] || [ "$AUTHOR" = "claude[bot]" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Phase 2/3 commits authored by claude[bot] were not recognized by the bot-check guard, causing the workflow to re-trigger on its own pushes.