### PR TITLE
fix: use VALE_TOKEN for doc-followup push and refine bot-check to mat…

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -151,6 +151,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr-info.outputs.branch }}
+          token: ${{ secrets.VALE_TOKEN }}
           fetch-depth: 0
 
       - name: Handle @claude request
@@ -166,3 +167,18 @@ jobs:
           prompt: |
             /doc-pr-fix ${{ steps.pr-info.outputs.number }} $COMMENT_BODY
           claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep,Skill(doc-pr-fix),Skill(doc-help)"'
+
+      - name: Push with VALE_TOKEN to trigger workflows
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        env:
+          VALE_TOKEN: ${{ secrets.VALE_TOKEN }}
+        run: |
+          # Re-configure git credentials with VALE_TOKEN (claude-code-action
+          # overrides credentials with GITHUB_TOKEN, which doesn't trigger workflows)
+          git remote set-url origin "https://x-access-token:${VALE_TOKEN}@github.com/${{ github.repository }}.git"
+          if [ "$(git rev-list @{u}..HEAD --count 2>/dev/null)" -gt 0 ]; then
+            echo "Pushing $(git rev-list @{u}..HEAD --count) commit(s) with VALE_TOKEN..."
+            git push
+          else
+            echo "No new commits to push"
+          fi

--- a/.github/workflows/vale-autofix.yml
+++ b/.github/workflows/vale-autofix.yml
@@ -26,10 +26,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get the latest commit author on the PR head
-          AUTHOR=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '.commit.author.name')
+          # Get the latest commit on the PR head
+          COMMIT=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '{author: .commit.author.name, message: .commit.message}')
+          AUTHOR=$(echo "$COMMIT" | jq -r '.author')
+          MESSAGE=$(echo "$COMMIT" | jq -r '.message')
           echo "Latest commit author: $AUTHOR"
-          if [ "$AUTHOR" = "github-actions[bot]" ] || [ "$AUTHOR" = "claude[bot]" ]; then
+          echo "Latest commit message: $MESSAGE"
+
+          # Skip if this is a commit from the vale-autofix workflow itself
+          # (prevents re-trigger loops) but allow other bot commits through
+          # so they still get linted
+          if echo "$MESSAGE" | grep -qE '^fix\((vale|dale)\):'; then
+            echo "Skipping: commit is from vale-autofix workflow"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
…ch commit messages

doc-followup pushes with GITHUB_TOKEN don't trigger build-and-deploy. Switch to VALE_TOKEN so editorial fix commits trigger downstream workflows.

Refine vale-autofix bot-check to match commit message prefixes (fix(vale):, fix(dale):) instead of author name, so editorial fix commits from doc-followup still get linted.