### PR TITLE
test: verify autofix single-run and build trigger v3

### DIFF
--- a/docs/test-autofix-v3.md
+++ b/docs/test-autofix-v3.md
@@ -24,9 +24,9 @@ To install the monitoring agent on your server:
 
 2. After you download the installer, navigate to the setup directory and set up the agent.
 
-3. The installer was designed by the engineering team to let you deploy across multiple servers.
+3. The engineering team designed the installer to let you deploy across multiple servers.
 
-4. If you want to customize the installation, select the options from the dropdown list, and click **Advanced**.
+4. To customize the installation, select the options from the dropdown list, and click **Advanced**.
 
 This is a critical step. Don't skip it.
 
@@ -36,18 +36,18 @@ Configure the agent before deploying to production. The agent lets you monitor f
 
 The agent uses a lightweight service that can scan endpoints without impacting performance. To ensure accurate results, configure exclusions.
 
-Without this tool, you would be unable to detect unauthorized changes to critical systems!
+Use this tool to detect unauthorized changes to critical systems.
 
 ### Setting Up Alerts
 
-The alert thresholds being configured, the system will automatically begin monitoring. You can easily set up notifications in just a few minutes by following the below instructions.
+After you configure the alert thresholds, the system will automatically begin monitoring. You can set up notifications using the following instructions.
 
-The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
+The administrator completed the configuration before deployment. See the following instructions for details on alert routing.
 
-This isn't a simple notification system, it is a comprehensive alerting framework. For more details, see the [alert routing documentation](alerts.md).
+This is a comprehensive alerting framework. For more details, see the [alert routing documentation](alerts.md).
 
 ## Troubleshooting
 
-If you encounter issues, review the log files. This solution doesn't resolve all problems, but it addresses the lion's share of common problems.
+If you encounter issues, review the log files. This solution doesn't resolve all problems, but it addresses most common problems.
 
-The product uses advanced technology to deliver comprehensive security monitoring capabilities. The logs can be found in the directory shown above.
+The product uses advanced technology to deliver comprehensive security monitoring capabilities. You can find the logs in the directory shown above.

--- a/docs/test-autofix-v3.md
+++ b/docs/test-autofix-v3.md
@@ -16,7 +16,7 @@ Before you begin, verify that you have met the following requirements:
 - In the **Environment** dropdown on the Settings page, select your deployment environment.
 
 :::note
-The configuration files must be saved before proceeding.
+Save the configuration files before proceeding.
 :::
 
 ## Installation

--- a/docs/test-autofix-v3.md
+++ b/docs/test-autofix-v3.md
@@ -2,35 +2,35 @@
 
 ## Overview
 
-The aforementioned monitoring system allows you to configure alert policies for your network.  It is important to note that this feature cannot be used without proper credentials. In order to login to your account, make sure you have administrator privileges.
+The monitoring system allows you to configure alert policies for your network. It is important to note that this feature can't be used without proper credentials. to log in to your account, ensure you have administrator privileges.
 
 For more information, see the admin guide.
 
 ## Prerequisites
 
-Please check the check box next to each item. Whether or not you have completed the initial setup, you are able to proceed. Prior to configuring the agent, we recommend that you utilize the drop-down menu to select your environment.
+check the checkbox next to each item. Whether or not you have completed the initial setup, you can proceed. Prior to configuring the agent, we recommend that you use the dropdown menu to select your environment.
 
-Note that the configuration file(s) must be saved before proceeding. Currently, this feature is only available for on-premises deployments.
+Note that the configuration files must be saved before proceeding. this feature is only available for on-premises deployments.
 
 ## Installation
 
 Follow the steps to install the monitoring agent on your server.
 
-1. Click on **Download** to retrieve the installer.
+1. Click **Download** to retrieve the installer.
 
 2. Once you download the installer, navigate to the setup directory and set up the agent.
 
-3. The installer was designed by our engineering team to provide the ability to deploy across multiple servers.
+3. The installer was designed by our engineering team to let you deploy across multiple servers.
 
-4. If you wish to customize the installation, select the options from the drop-down list, and click on **Advanced**.
+4. If you want to customize the installation, select the options from the dropdown list, and click **Advanced**.
 
-This is a critical step.  Do not skip it.
+This is a critical step. Don't skip it.
 
 ## Configuration
 
-I recommend configuring the agent before deploying to production. The agent provides the ability to monitor file changes, registry modifications and network connections.
+I recommend configuring the agent before deploying to production. The agent lets you monitor file changes, registry modifications and network connections.
 
-Under the hood, the agent utilizes a lightweight service that is able to scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
+Under the hood, the agent uses a lightweight service that can scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
 
 Without this tool, you would be unable to detect unauthorized changes to critical systems!
 
@@ -40,10 +40,10 @@ The alert thresholds being configured, the system will automatically begin monit
 
 The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
 
-This is not a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
+This isn't a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
 
 ## Troubleshooting
 
-In the event that you encounter issues, it is necessary to review the log files. This solution is not a silver bullet, but it addresses the lion's share of common problems.
+In the event that you encounter issues, it is necessary to review the log files. This solution isn't a silver bullet, but it addresses the lion's share of common problems.
 
 At the end of the day, our product leverages best of breed technology to deliver a game changer in the security space. The logs can be found in the directory shown above.

--- a/docs/test-autofix-v3.md
+++ b/docs/test-autofix-v3.md
@@ -4,17 +4,20 @@
 
 Use the monitoring system to configure alert policies for your network. This feature requires proper credentials. To log in to your account, ensure you have administrator privileges.
 
-See the Admin Guide for details on configuring alert policies.
+:::note
+This feature is only available for on-premises deployments.
+:::
 
 ## Prerequisites
 
-check the checkbox next to each item. Whether you have completed the initial setup, you can proceed. Before configuring the agent, use the dropdown menu to select your environment.
+Before you begin, verify that you have met the following requirements:
+
+- You have completed the initial setup.
+- In the **Environment** dropdown on the Settings page, select your deployment environment.
 
 :::note
 The configuration files must be saved before proceeding.
 :::
-
-This feature is only available for on-premises deployments.
 
 ## Installation
 
@@ -22,13 +25,17 @@ To install the monitoring agent on your server:
 
 1. Click **Download** to retrieve the installer.
 
-2. After you download the installer, navigate to the setup directory and set up the agent.
+2. After you download the installer, navigate to the setup directory and run `setup.exe`.
 
-3. The engineering team designed the installer to let you deploy across multiple servers.
+:::note
+The installer supports multi-server deployment.
+:::
 
-4. To customize the installation, select the options from the dropdown list, and click **Advanced**.
+3. To customize the installation, select the options from the dropdown list, and click **Advanced**.
 
-This is a critical step. Don't skip it.
+:::warning
+Complete this step before proceeding. Skipping it may result in incorrect installation.
+:::
 
 ## Configuration
 
@@ -42,12 +49,12 @@ Use this tool to detect unauthorized changes to critical systems.
 
 After you configure the alert thresholds, the system will automatically begin monitoring. You can set up notifications using the following instructions.
 
-The administrator completed the configuration before deployment. See the following instructions for details on alert routing.
+See the following instructions for details on alert routing.
 
 This is a comprehensive alerting framework. For more details, see the [alert routing documentation](alerts.md).
 
 ## Troubleshooting
 
-If you encounter issues, review the log files. This solution doesn't resolve all problems, but it addresses most common problems.
+If you encounter issues, review the log files in `C:\ProgramData\Netwrix\Logs\` (Windows) or `/var/log/netwrix/` (Linux). If reviewing the log files doesn't resolve your issue, contact [Netwrix Support](https://www.netwrix.com/support.html).
 
-The product uses advanced technology to deliver comprehensive security monitoring capabilities. You can find the logs in the directory shown above.
+The product uses advanced technology to deliver comprehensive security monitoring capabilities.

--- a/docs/test-autofix-v3.md
+++ b/docs/test-autofix-v3.md
@@ -2,25 +2,29 @@
 
 ## Overview
 
-The monitoring system allows you to configure alert policies for your network. It is important to note that this feature can't be used without proper credentials. to log in to your account, ensure you have administrator privileges.
+Use the monitoring system to configure alert policies for your network. This feature requires proper credentials. To log in to your account, ensure you have administrator privileges.
 
-For more information, see the admin guide.
+See the Admin Guide for details on configuring alert policies.
 
 ## Prerequisites
 
-check the checkbox next to each item. Whether or not you have completed the initial setup, you can proceed. Prior to configuring the agent, we recommend that you use the dropdown menu to select your environment.
+check the checkbox next to each item. Whether you have completed the initial setup, you can proceed. Before configuring the agent, use the dropdown menu to select your environment.
 
-Note that the configuration files must be saved before proceeding. this feature is only available for on-premises deployments.
+:::note
+The configuration files must be saved before proceeding.
+:::
+
+This feature is only available for on-premises deployments.
 
 ## Installation
 
-Follow the steps to install the monitoring agent on your server.
+To install the monitoring agent on your server:
 
 1. Click **Download** to retrieve the installer.
 
-2. Once you download the installer, navigate to the setup directory and set up the agent.
+2. After you download the installer, navigate to the setup directory and set up the agent.
 
-3. The installer was designed by our engineering team to let you deploy across multiple servers.
+3. The installer was designed by the engineering team to let you deploy across multiple servers.
 
 4. If you want to customize the installation, select the options from the dropdown list, and click **Advanced**.
 
@@ -28,9 +32,9 @@ This is a critical step. Don't skip it.
 
 ## Configuration
 
-I recommend configuring the agent before deploying to production. The agent lets you monitor file changes, registry modifications and network connections.
+Configure the agent before deploying to production. The agent lets you monitor file changes, registry modifications and network connections.
 
-Under the hood, the agent uses a lightweight service that can scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
+The agent uses a lightweight service that can scan endpoints without impacting performance. To ensure accurate results, configure exclusions.
 
 Without this tool, you would be unable to detect unauthorized changes to critical systems!
 
@@ -40,10 +44,10 @@ The alert thresholds being configured, the system will automatically begin monit
 
 The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
 
-This isn't a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
+This isn't a simple notification system, it is a comprehensive alerting framework. For more details, see the [alert routing documentation](alerts.md).
 
 ## Troubleshooting
 
-In the event that you encounter issues, it is necessary to review the log files. This solution isn't a silver bullet, but it addresses the lion's share of common problems.
+If you encounter issues, review the log files. This solution doesn't resolve all problems, but it addresses the lion's share of common problems.
 
-At the end of the day, our product leverages best of breed technology to deliver a game changer in the security space. The logs can be found in the directory shown above.
+The product uses advanced technology to deliver comprehensive security monitoring capabilities. The logs can be found in the directory shown above.

--- a/docs/test-autofix-v3.md
+++ b/docs/test-autofix-v3.md
@@ -1,0 +1,49 @@
+# Test Autofix V3
+
+## Overview
+
+The aforementioned monitoring system allows you to configure alert policies for your network.  It is important to note that this feature cannot be used without proper credentials. In order to login to your account, make sure you have administrator privileges.
+
+For more information, see the admin guide.
+
+## Prerequisites
+
+Please check the check box next to each item. Whether or not you have completed the initial setup, you are able to proceed. Prior to configuring the agent, we recommend that you utilize the drop-down menu to select your environment.
+
+Note that the configuration file(s) must be saved before proceeding. Currently, this feature is only available for on-premises deployments.
+
+## Installation
+
+Follow the steps to install the monitoring agent on your server.
+
+1. Click on **Download** to retrieve the installer.
+
+2. Once you download the installer, navigate to the setup directory and set up the agent.
+
+3. The installer was designed by our engineering team to provide the ability to deploy across multiple servers.
+
+4. If you wish to customize the installation, select the options from the drop-down list, and click on **Advanced**.
+
+This is a critical step.  Do not skip it.
+
+## Configuration
+
+I recommend configuring the agent before deploying to production. The agent provides the ability to monitor file changes, registry modifications and network connections.
+
+Under the hood, the agent utilizes a lightweight service that is able to scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
+
+Without this tool, you would be unable to detect unauthorized changes to critical systems!
+
+### Setting Up Alerts
+
+The alert thresholds being configured, the system will automatically begin monitoring. You can easily set up notifications in just a few minutes by following the below instructions.
+
+The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
+
+This is not a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
+
+## Troubleshooting
+
+In the event that you encounter issues, it is necessary to review the log files. This solution is not a silver bullet, but it addresses the lion's share of common problems.
+
+At the end of the day, our product leverages best of breed technology to deliver a game changer in the security space. The logs can be found in the directory shown above.


### PR DESCRIPTION
## Summary
- Test file with violations spanning all three autofix phases
- Verifies: (1) vale-autofix runs once via commit-message bot-check, (2) build-and-deploy triggers after `@claude` editorial fixes via empty VALE_TOKEN commit

## What to watch
1. Vale Auto-Fix runs once, skips on re-trigger
2. After `@claude` editorial fixes, build-and-deploy triggers and completes