### PR TITLE
fix: skip doc-review on autofix commits to prevent redundant runs

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -28,7 +28,22 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Check if triggered by autofix commit
+        id: bot-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MESSAGE=$(gh api repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }} --jq '.commit.message')
+          echo "Latest commit message: $MESSAGE"
+          if echo "$MESSAGE" | grep -qE '^fix\((vale|dale)\):|^ci: trigger build'; then
+            echo "Skipping: commit is from autofix workflow"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.bot-check.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -36,6 +51,7 @@ jobs:
 
       - name: Get changed markdown files
         id: changed-files
+        if: steps.bot-check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
Add bot-check to doc-review job matching the same commit-message prefixes as vale-autofix (fix(vale):, fix(dale):, ci: trigger build). Prevents a wasted Claude API call re-reviewing content that was just auto-fixed.