### PR TITLE
fix: use VALE_TOKEN as github_token in doc-followup so pushes trigger workflows

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -178,33 +178,8 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.VALE_TOKEN }}
           show_full_output: true
           prompt: |
             /doc-pr-fix ${{ steps.pr-info.outputs.number }} $COMMENT_BODY
           claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep,Skill(doc-pr-fix),Skill(doc-help)"'
-
-      - name: Trigger workflows via VALE_TOKEN push
-        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        env:
-          VALE_TOKEN: ${{ secrets.VALE_TOKEN }}
-        run: |
-          # claude-code-action already pushed with GITHUB_TOKEN, which doesn't
-          # trigger workflows. If Claude made commits, push an empty commit
-          # with VALE_TOKEN to produce a new SHA that triggers build-and-deploy.
-          BRANCH="${{ steps.pr-info.outputs.branch }}"
-          git remote set-url origin "https://x-access-token:${VALE_TOKEN}@github.com/${{ github.repository }}.git"
-          git fetch origin "$BRANCH"
-          git reset --hard "origin/$BRANCH"
-
-          # Check if Claude actually pushed new commits
-          LATEST_AUTHOR=$(git log -1 --format='%an')
-          if [ "$LATEST_AUTHOR" = "claude[bot]" ]; then
-            echo "Claude pushed editorial fixes — triggering build..."
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit --allow-empty -m "ci: trigger build after editorial fixes"
-            git push origin "HEAD:$BRANCH"
-          else
-            echo "No Claude commits found — skipping"
-          fi


### PR DESCRIPTION
Replace the empty commit workaround with the simpler approach of passing VALE_TOKEN directly to claude-code-action. Its internal push uses this token, so GitHub treats it as a PAT push and triggers downstream workflows (build-and-deploy, vale-autofix) natively.