### PR TITLE
test: verify autofix single-run and VALE_TOKEN build trigger v4

### DIFF
--- a/docs/test-autofix-v4.md
+++ b/docs/test-autofix-v4.md
@@ -12,7 +12,7 @@ For configuration details, see the *Netwrix Administration Guide*.
 
 ## Prerequisites
 
-Check the checkbox next to each item. Complete the initial setup described in the *Netwrix Installation Guide* before proceeding. Before configuring the agent, use the dropdown menu to select your environment.
+Select each item. Complete the initial setup described in the *Netwrix Installation Guide* before proceeding. Before configuring the agent, use the dropdown menu to select your environment.
 
 :::note
 Save the configuration files before proceeding. This feature is only available for on-premises deployments.
@@ -54,6 +54,6 @@ For step-by-step alert routing instructions, see [Alert Configuration](alerts.md
 
 ## Troubleshooting
 
-If you encounter issues, review the log files. This solution isn't a guaranteed fix for all problems, but it addresses most common problems.
+If you encounter issues, review the log files. This solution addresses most common problems.
 
 Ultimately, the product uses leading technology to deliver significant advancements in the security space. Find the logs in the directory configured during installation.

--- a/docs/test-autofix-v4.md
+++ b/docs/test-autofix-v4.md
@@ -2,17 +2,17 @@
 
 ## Overview
 
-Use the monitoring system to configure alert policies for your network.
+The monitoring agent lets you configure alert policies and track security events across your network.
 
 :::note
 This feature requires proper credentials. To log in to your account, ensure you have administrator privileges.
 :::
 
-See the admin guide for configuration details.
+For configuration details, see the *Netwrix Administration Guide*.
 
 ## Prerequisites
 
-check the checkbox next to each item. Whether you have completed the initial setup, you can proceed. Before configuring the agent, use the dropdown menu to select your environment.
+Check the checkbox next to each item. Complete the initial setup described in the *Netwrix Installation Guide* before proceeding. Before configuring the agent, use the dropdown menu to select your environment.
 
 :::note
 Save the configuration files before proceeding. This feature is only available for on-premises deployments.
@@ -26,11 +26,13 @@ Install the monitoring agent on your server.
 
 2. After you download the installer, navigate to the setup directory and set up the agent.
 
-3. The installer lets you deploy across multiple servers.
+3. Select the target servers when prompted, then click **Next**.
 
 4. If you want to customize the installation, select the options from the dropdown list, and click **Advanced**.
 
-This is a critical step. Don't skip it.
+:::warning
+Complete all installation steps before proceeding. Skipping steps may cause configuration errors.
+:::
 
 ## Configuration
 
@@ -42,11 +44,13 @@ This agent detects unauthorized changes to critical systems.
 
 ### Setting Up Alerts
 
-After you configure the alert thresholds, the system will automatically begin monitoring. Set up notifications using the following steps.
+After you configure the alert thresholds, the system automatically begins monitoring.
 
-The administrator completed the configuration before the deployment. See the following instructions for details on alert routing.
+An administrator must complete the configuration before deployment.
 
-This is a comprehensive alerting framework. See [Alert Configuration](alerts.md) for details.
+:::note
+For step-by-step alert routing instructions, see [Alert Configuration](alerts.md).
+:::
 
 ## Troubleshooting
 

--- a/docs/test-autofix-v4.md
+++ b/docs/test-autofix-v4.md
@@ -2,25 +2,31 @@
 
 ## Overview
 
-The monitoring system allows you to configure alert policies for your network. It is important to note that this feature can't be used without proper credentials. to log in to your account, ensure you have administrator privileges.
+Use the monitoring system to configure alert policies for your network.
 
-For more information, see the admin guide.
+:::note
+This feature requires proper credentials. To log in to your account, ensure you have administrator privileges.
+:::
+
+See the admin guide for configuration details.
 
 ## Prerequisites
 
-check the checkbox next to each item. Whether or not you have completed the initial setup, you can proceed. Prior to configuring the agent, we recommend that you use the dropdown menu to select your environment.
+check the checkbox next to each item. Whether you have completed the initial setup, you can proceed. Before configuring the agent, use the dropdown menu to select your environment.
 
-Note that the configuration files must be saved before proceeding. this feature is only available for on-premises deployments.
+:::note
+The configuration files must be saved before proceeding. This feature is only available for on-premises deployments.
+:::
 
 ## Installation
 
-Follow the steps to install the monitoring agent on your server.
+Install the monitoring agent on your server.
 
 1. Click **Download** to retrieve the installer.
 
-2. Once you download the installer, navigate to the setup directory and set up the agent.
+2. After you download the installer, navigate to the setup directory and set up the agent.
 
-3. The installer was designed by our engineering team to let you deploy across multiple servers.
+3. The installer lets you deploy across multiple servers.
 
 4. If you want to customize the installation, select the options from the dropdown list, and click **Advanced**.
 
@@ -28,9 +34,9 @@ This is a critical step. Don't skip it.
 
 ## Configuration
 
-I recommend configuring the agent before deploying to production. The agent lets you monitor file changes, registry modifications and network connections.
+Configure the agent before deploying to production. The agent lets you monitor file changes, registry modifications and network connections.
 
-Under the hood, the agent uses a lightweight service that can scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
+Internally, the agent uses a lightweight service that can scan endpoints without impacting performance. To ensure accurate results, configure exclusions.
 
 Without this tool, you would be unable to detect unauthorized changes to critical systems!
 
@@ -40,10 +46,10 @@ The alert thresholds being configured, the system will automatically begin monit
 
 The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
 
-This isn't a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
+This isn't a simple notification system, it is a comprehensive alerting framework. See [Alert Configuration](alerts.md) for details.
 
 ## Troubleshooting
 
-In the event that you encounter issues, it is necessary to review the log files. This solution isn't a silver bullet, but it addresses the lion's share of common problems.
+If you encounter issues, review the log files. This solution isn't a guaranteed fix for all problems, but it addresses the lion's share of common problems.
 
-At the end of the day, our product leverages best of breed technology to deliver a game changer in the security space. The logs can be found in the directory shown above.
+Ultimately, the product uses leading technology to deliver significant advancements in the security space. The logs can be found in the directory shown above.

--- a/docs/test-autofix-v4.md
+++ b/docs/test-autofix-v4.md
@@ -2,35 +2,35 @@
 
 ## Overview
 
-The aforementioned monitoring system allows you to configure alert policies for your network.  It is important to note that this feature cannot be used without proper credentials. In order to login to your account, make sure you have administrator privileges.
+The monitoring system allows you to configure alert policies for your network. It is important to note that this feature can't be used without proper credentials. to log in to your account, ensure you have administrator privileges.
 
 For more information, see the admin guide.
 
 ## Prerequisites
 
-Please check the check box next to each item. Whether or not you have completed the initial setup, you are able to proceed. Prior to configuring the agent, we recommend that you utilize the drop-down menu to select your environment.
+check the checkbox next to each item. Whether or not you have completed the initial setup, you can proceed. Prior to configuring the agent, we recommend that you use the dropdown menu to select your environment.
 
-Note that the configuration file(s) must be saved before proceeding. Currently, this feature is only available for on-premises deployments.
+Note that the configuration files must be saved before proceeding. this feature is only available for on-premises deployments.
 
 ## Installation
 
 Follow the steps to install the monitoring agent on your server.
 
-1. Click on **Download** to retrieve the installer.
+1. Click **Download** to retrieve the installer.
 
 2. Once you download the installer, navigate to the setup directory and set up the agent.
 
-3. The installer was designed by our engineering team to provide the ability to deploy across multiple servers.
+3. The installer was designed by our engineering team to let you deploy across multiple servers.
 
-4. If you wish to customize the installation, select the options from the drop-down list, and click on **Advanced**.
+4. If you want to customize the installation, select the options from the dropdown list, and click **Advanced**.
 
-This is a critical step.  Do not skip it.
+This is a critical step. Don't skip it.
 
 ## Configuration
 
-I recommend configuring the agent before deploying to production. The agent provides the ability to monitor file changes, registry modifications and network connections.
+I recommend configuring the agent before deploying to production. The agent lets you monitor file changes, registry modifications and network connections.
 
-Under the hood, the agent utilizes a lightweight service that is able to scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
+Under the hood, the agent uses a lightweight service that can scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
 
 Without this tool, you would be unable to detect unauthorized changes to critical systems!
 
@@ -40,10 +40,10 @@ The alert thresholds being configured, the system will automatically begin monit
 
 The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
 
-This is not a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
+This isn't a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
 
 ## Troubleshooting
 
-In the event that you encounter issues, it is necessary to review the log files. This solution is not a silver bullet, but it addresses the lion's share of common problems.
+In the event that you encounter issues, it is necessary to review the log files. This solution isn't a silver bullet, but it addresses the lion's share of common problems.
 
 At the end of the day, our product leverages best of breed technology to deliver a game changer in the security space. The logs can be found in the directory shown above.

--- a/docs/test-autofix-v4.md
+++ b/docs/test-autofix-v4.md
@@ -1,0 +1,49 @@
+# Test Autofix V4
+
+## Overview
+
+The aforementioned monitoring system allows you to configure alert policies for your network.  It is important to note that this feature cannot be used without proper credentials. In order to login to your account, make sure you have administrator privileges.
+
+For more information, see the admin guide.
+
+## Prerequisites
+
+Please check the check box next to each item. Whether or not you have completed the initial setup, you are able to proceed. Prior to configuring the agent, we recommend that you utilize the drop-down menu to select your environment.
+
+Note that the configuration file(s) must be saved before proceeding. Currently, this feature is only available for on-premises deployments.
+
+## Installation
+
+Follow the steps to install the monitoring agent on your server.
+
+1. Click on **Download** to retrieve the installer.
+
+2. Once you download the installer, navigate to the setup directory and set up the agent.
+
+3. The installer was designed by our engineering team to provide the ability to deploy across multiple servers.
+
+4. If you wish to customize the installation, select the options from the drop-down list, and click on **Advanced**.
+
+This is a critical step.  Do not skip it.
+
+## Configuration
+
+I recommend configuring the agent before deploying to production. The agent provides the ability to monitor file changes, registry modifications and network connections.
+
+Under the hood, the agent utilizes a lightweight service that is able to scan endpoints without impacting performance. For the purpose of ensuring accurate results, it is necessary to configure exclusions.
+
+Without this tool, you would be unable to detect unauthorized changes to critical systems!
+
+### Setting Up Alerts
+
+The alert thresholds being configured, the system will automatically begin monitoring. You can easily set up notifications in just a few minutes by following the below instructions.
+
+The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
+
+This is not a simple notification system, it is a comprehensive alerting framework. For more details, [click here](alerts.md).
+
+## Troubleshooting
+
+In the event that you encounter issues, it is necessary to review the log files. This solution is not a silver bullet, but it addresses the lion's share of common problems.
+
+At the end of the day, our product leverages best of breed technology to deliver a game changer in the security space. The logs can be found in the directory shown above.

--- a/docs/test-autofix-v4.md
+++ b/docs/test-autofix-v4.md
@@ -15,7 +15,7 @@ See the admin guide for configuration details.
 check the checkbox next to each item. Whether you have completed the initial setup, you can proceed. Before configuring the agent, use the dropdown menu to select your environment.
 
 :::note
-The configuration files must be saved before proceeding. This feature is only available for on-premises deployments.
+Save the configuration files before proceeding. This feature is only available for on-premises deployments.
 :::
 
 ## Installation
@@ -38,18 +38,18 @@ Configure the agent before deploying to production. The agent lets you monitor f
 
 Internally, the agent uses a lightweight service that can scan endpoints without impacting performance. To ensure accurate results, configure exclusions.
 
-Without this tool, you would be unable to detect unauthorized changes to critical systems!
+This agent detects unauthorized changes to critical systems.
 
 ### Setting Up Alerts
 
-The alert thresholds being configured, the system will automatically begin monitoring. You can easily set up notifications in just a few minutes by following the below instructions.
+After you configure the alert thresholds, the system will automatically begin monitoring. Set up notifications using the following steps.
 
-The configuration was completed by the administrator before the deployment. See the instructions below for details on alert routing.
+The administrator completed the configuration before the deployment. See the following instructions for details on alert routing.
 
-This isn't a simple notification system, it is a comprehensive alerting framework. See [Alert Configuration](alerts.md) for details.
+This is a comprehensive alerting framework. See [Alert Configuration](alerts.md) for details.
 
 ## Troubleshooting
 
-If you encounter issues, review the log files. This solution isn't a guaranteed fix for all problems, but it addresses the lion's share of common problems.
+If you encounter issues, review the log files. This solution isn't a guaranteed fix for all problems, but it addresses most common problems.
 
-Ultimately, the product uses leading technology to deliver significant advancements in the security space. The logs can be found in the directory shown above.
+Ultimately, the product uses leading technology to deliver significant advancements in the security space. Find the logs in the directory configured during installation.


### PR DESCRIPTION
## Summary
- Test file with violations spanning all three autofix phases
- Verifies: (1) vale-autofix runs once via commit-message bot-check, (2) doc-review skips on autofix commits, (3) build-and-deploy triggers after `@claude` editorial fixes via VALE_TOKEN in claude-code-action

## What to watch
1. Vale Auto-Fix runs once, skips on re-trigger
2. Doc PR Review runs once, skips on autofix commits
3. After `@claude` editorial fixes, build-and-deploy triggers and completes (no empty commit needed)