### PR TITLE
fix(md-autofix): fetch PR files before running script

### DIFF
--- a/.github/workflows/md-extension-autofix.yml
+++ b/.github/workflows/md-extension-autofix.yml
@@ -67,7 +67,8 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.head.sha }}
           while IFS= read -r file; do
-            git checkout FETCH_HEAD -- "$file" 2>/dev/null || true
+            mkdir -p "$(dirname "$file")"
+            git show FETCH_HEAD:"$file" > "$file" 2>/dev/null || true
           done < /tmp/changed-files.txt
 
       - name: Run md-extension-autofix

--- a/.github/workflows/md-extension-autofix.yml
+++ b/.github/workflows/md-extension-autofix.yml
@@ -62,6 +62,14 @@ jobs:
             echo "count=$(echo "$CHANGED" | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Fetch changed files from PR head
+        if: steps.changed-files.outputs.count > 0
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          while IFS= read -r file; do
+            git checkout FETCH_HEAD -- "$file" 2>/dev/null || true
+          done < /tmp/changed-files.txt
+
       - name: Run md-extension-autofix
         id: autofix
         if: steps.changed-files.outputs.count > 0


### PR DESCRIPTION
## Summary                                                                                                                                              
                                                                                                                                                          
  Fixes a bug where the `md-extension-autofix` workflow ran successfully but                                                                              
  processed 0 files — producing no renames, no frontmatter injection, and no                                                                              
  PR comment output.                                                                                                                                      
                                                                                                                                                      
  ## Root cause                               
                                                                                                                                                          
  As a security measure, the workflow checks out the **base branch** (`dev`)                                                                              
  rather than the PR head. This means new files added in a PR don't exist on                                                                              
  disk when the script runs. The script's `[ -f "$file" ]` check correctly                                                                                
  skips files that don't exist (treating them as deleted), so all new files                                                                               
  were silently ignored.                                                                                                                                  
                                                                                                                                                          
  ## Fix                                                                                                                                                  
                                                                                                                                                          
  Adds a step between "Get changed files" and "Run md-extension-autofix" that                                                                             
  fetches only the specific changed files from the PR head commit:                                                                                        
                                                                                                                                                          
  ```yaml                                                                                                                                                 
  - name: Fetch changed files from PR head                                                                                                                
    if: steps.changed-files.outputs.count > 0                                                                                                             
    run: |                                                                                                                                                
      git fetch origin ${{ github.event.pull_request.head.sha }}                                                                                      
      while IFS= read -r file; do                               
        git checkout FETCH_HEAD -- "$file" 2>/dev/null || true                                                                                            
      done < /tmp/changed-files.txt
```                                                                                                                      
                                                                                                                                                          
  The script itself still runs from the trusted base checkout. Only file content is fetched from the PR head via git show, and is not executed.                          

>  CodeQL: Actions/untrusted-checkout/medium flagged this step and was dismissed. PRs are restricted to Netwrix org members with SSO; the untrusted-contributor attack vector does not apply.                                                                                                                                                                                                                 
                                                                                                                                                          
  ## Testing                                                                                                                                                 
                                                                                                                                                          
 - Verified via PR #731
   - Opened specifically to test the end-to-end workflow. 
   - Once this fix merges, re-trigger the workflow on that PR to confirm all scenarios behave as                                                                                   
  expected.                        