### PR TITLE
fix(workflow): check out PR head branch so fixes push to the PR

### DIFF
--- a/.github/workflows/md-extension-autofix.yml
+++ b/.github/workflows/md-extension-autofix.yml
@@ -36,9 +36,8 @@ jobs:
         if: steps.bot-check.outputs.skip != 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
-
 
       - name: Configure git identity
         if: steps.bot-check.outputs.skip != 'true'
@@ -61,15 +60,6 @@ jobs:
             echo "$CHANGED" > /tmp/changed-files.txt
             echo "count=$(echo "$CHANGED" | wc -l | tr -d ' ')" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Fetch changed files from PR head
-        if: steps.changed-files.outputs.count > 0
-        run: |
-          git fetch origin ${{ github.event.pull_request.head.sha }}
-          while IFS= read -r file; do
-            mkdir -p "$(dirname "$file")"
-            git show FETCH_HEAD:"$file" > "$file" 2>/dev/null || true
-          done < /tmp/changed-files.txt
 
       - name: Run md-extension-autofix
         id: autofix


### PR DESCRIPTION
## Root cause

  The workflow checked out the **base branch** (`dev`) rather than the PR head branch. As a result, when the autofix script committed and pushed its changes, they went to `dev` instead of the PR branch — so renamed files never appeared in the PR diff.
 
The bot comment was posted regardless of push success (the push step uses `continue-on-error: true`), which is why the workflow appeared to work while the files weren't actually being renamed in the PR.

  ## Fix

  - Changes the checkout `ref` from `pull_request.base.ref` to `pull_request.head.ref` so the bot commits land on the PR branch
  - Removes the "Fetch changed files from PR head" step added in #732 — no longer needed since the PR files are already on disk when checking out the head branch

  > **CodeQL:** `actions/untrusted-checkout/medium` will flag this checkout. Dismissed — PRs are restricted to Netwrix org members with SSO; the untrusted-contributor attack vector does not apply. See alert #80 for full justification.