### PR TITLE
fix(script): silence git rm --cached stdout to prevent JSON corruption

### DIFF
--- a/scripts/md-extension-autofix.sh
+++ b/scripts/md-extension-autofix.sh
@@ -155,7 +155,7 @@ while IFS= read -r file; do
   # Use mv + git add instead of git mv so it works for both tracked and untracked files
   mv "$file" "$new_file"
   git add "$new_file"
-  git rm --cached "$file" 2>/dev/null || true
+  git rm -q --cached "$file" 2>/dev/null || true
   rewrite_links_in_docs "$(basename "$file")" "$(basename "$new_file")"
 
   RENAMED_FROM+=("$file")


### PR DESCRIPTION
## Root cause            

  When the workflow checks out the PR head branch, the files without `.md` are tracked in the git index. `git rm --cached` succeeds and prints `rm 'filename'` to stdout, which gets captured in the `SUMMARY` variable and corrupts the JSON, causing `jq` to fail with exit code 5.
                                                                                                                                                         
  Previously undetected because the workflow checked out the base branch (`dev`), where the PR files aren't tracked — `git rm --cached` failed silently with no stdout output.                                                                                                                                 
                                                                                                                                                         
  ## Fix                                                                                                                                                 
                                                                                                                                                         
  Add `-q` to silence `git rm --cached` stdout.                                                                                                          
                                                                                                                                                     
  ## Testing

  Tested locally by simulating the workflow condition: checked out the PR head branch (files tracked in git index), ran the script, confirmed clean JSON output and correctly renames/injects frontmatter.             
