### PR TITLE
Add docs/kb/CLAUDE.md and update KB style guide linting guidance

### DIFF
--- a/docs/kb/CLAUDE.md
+++ b/docs/kb/CLAUDE.md
@@ -1,0 +1,10 @@
+# KB Articles
+
+KB articles live in `docs/kb/`. When writing or editing KB articles, follow `kb_style_guide.md` at the repo root for all style decisions.
+
+## Conflicts with docs/CLAUDE.md
+
+Two rules in `docs/CLAUDE.md` do NOT apply to KB articles:
+
+- **Contractions** — write out in full (do not, cannot, you will)
+- **Heading case** — title case (not sentence case)

--- a/kb_style_guide.md
+++ b/kb_style_guide.md
@@ -4,7 +4,7 @@ This guide establishes writing standards for Netwrix Knowledge Base (KB) article
 
 This guide is enforced by the `derek` linter skill (`/derek <kb-file>`).
 
-> **Important for documentation contributors:** This guide conflicts with the Netwrix docs style guide (`netwrix_style_guide.md`) on two points — contractions and heading case. Do not apply docs style guide rules to KB articles. Do not run `/dale` on KB files.
+> **Important for documentation contributors:** This guide conflicts with the Netwrix docs style guide (`netwrix_style_guide.md`) on two points — contractions and heading case. Do not apply docs style guide rules to KB articles. You can run `/dale` on KB files, but when applying fixes, follow `kb_style_guide.md` — not `docs/CLAUDE.md`.
 
 | Topic | KB rule | Docs rule |
 |---|---|---|


### PR DESCRIPTION
### Summary
- `docs/kb/CLAUDE.md` (new): Auto-loads when Claude Code works in docs/kb/, overriding the two rules in docs/CLAUDE.md that conflict with KB standards — contractions must be written out in full (do not, cannot, you will) and headings use title case, not sentence case.
- `kb_style_guide.md`: Replaces the blanket "Do not run /dale on KB files" restriction with a clarification that /dale can be run on KB files, but fixes must follow `kb_style_guide.md` — not `docs/CLAUDE.md`.                                                                                                                                  
- Addresses an issue noticed while testing /dale on KB files:
    -  Claude Code auto-loads `docs/CLAUDE.md` and applies docs-style rules (contractions encouraged, sentence case). 
    - This conflicts with KB standards. 
    - The new docs/kb/CLAUDE.md file resolves this by auto-loading the correct KB context whenever Claude Code is working inside docs/kb/.
                                                                                                                                                                           
### Testing         
- Build: npm run build passed clean with no errors from the new `docs/kb/CLAUDE.md` file.                                                                                    
- Context switching (Claude Code):                                                                                                                                         
    - Shared a few KB files (docs/kb/auditor/...) and asked for style recommendations → Claude correctly referenced `kb_style_guide.md`, called out title case, and no contractions.
    - Shared a few docs files (docs/auditor/10.8/...) and asked for style recommendations → Claude correctly applied `docs/CLAUDE.md` (sentence case, contractions encouraged).
    - Context switches correctly based on file path — KB rules are scoped to docs/kb/ and do not leak into regular docs work.
