### PR TITLE
Add admonition format check and relax knowledge_article_id rule

### DIFF
--- a/.claude/skills/derek/SKILL.md
+++ b/.claude/skills/derek/SKILL.md
@@ -58,7 +58,7 @@ Check that all required fields are present and valid:
 | `keywords` | Present, contains 8–12 items |
 | `products` | Present, contains at least one product ID |
 | `tags` | Present and includes `kb` |
-| `knowledge_article_id` | Present; starts with `kA` followed by alphanumeric characters |
+| `knowledge_article_id` | If present, must not be empty — a non-empty value must start with `kA` followed by alphanumeric characters. If absent, do not flag. |
 
 Flag each missing or invalid field as a separate row in the output table.
 
@@ -92,7 +92,14 @@ Check that Netwrix product names follow the correct pattern from `kb_style_guide
 - All subsequent mentions: short product name (e.g., "Auditor")
 - No unapproved abbreviations (e.g., "NA" for Netwrix Auditor)
 
-## 5. Keywords and Description Quality
+## 5. Admonition Format
+
+KB articles use blockquote callouts, not Docusaurus admonition syntax. Flag any `:::note`, `:::tip`, `:::warning`, or `:::danger` blocks and tell the writer to convert them:
+
+- `> **NOTE:**` — for supplementary information
+- `> **IMPORTANT:**` — for critical information that could cause issues if ignored
+
+## 6. Keywords and Description Quality
 
 **Keywords:** The 8–12 keywords should be specific and searchable — error codes, product names, technical terms, and phrases a customer would type into a search bar. Flag if keywords are too generic, simply repeat the title, or are missing obvious terms visible in the article body.
 


### PR DESCRIPTION
 ### Summary                                                                                                                                            
                                                                                                                                                         
  - Two updates to the `/derek` KB article quality reviewer skill based on issues identified during testing on PR #752.
     - The admonition format check was missed entirely during that review — `/derek` did not flag `:::note` and `:::tip` blocks that needed converting to KB-style blockquote callouts.                                                                                                             
     - The `knowledge_article_id` rule was too strict — it flagged articles written natively in the repo without a ZD/SF ID.                                                                                          
                                                                                                                                                         
  ### Changes                                                                                                                                            
                                                                                                                                                         
  - **Admonition format check (new)** — `/derek` now flags Docusaurus admonition blocks (`:::note`, `:::tip`, `:::warning`, `:::danger`) in KB articles and tells the writer to convert them to blockquote callouts (`> **NOTE:**` or `> **IMPORTANT:**`). Vale handles inline "Note that" text — `/derek` handles admonition syntax. No overlap.                                                                                      
  - **`knowledge_article_id` rule relaxed** — field absent is no longer flagged. Only flagged if the field is present but empty. Articles written natively in the repo (not migrated from ZD/SF) will not have a ZD/SF ID, so requiring the field on all articles produced false positives.                                                                                                                            
                                                                                                                                                         
  ### Testing                                                                                                                                            
                                                                                                                                                         
  - **Admonition format** — tested on `docs/kb/privilegesecure/remote-desktop-and-rds/configuring-the-netwrix-privilege-secure-rds-web-app-launcher.md`, the only KB article with Docusaurus admonition syntax. `/derek` correctly flagged `:::warning` at line 58 with the `admonition-format` rule and included the converted blockquote text in the message. Vale did not flag the same block — correct separation of concerns confirmed.                             
  - **`knowledge_article_id` absent** — tested on `docs/kb/passwordpolicyenforcer/ppe-supportability.md`, which has no `knowledge_article_id` field. `/derek` found 3 other issues but did not flag the missing field. Rule change confirmed working.                                                          
  - **`knowledge_article_id` present but empty** — not tested against a real article (no suitable candidate available). Low-risk untested path.