### PR TITLE
fix(aa2601): remove dev version examples from DSPM_TARGET_REVISION docs

### DIFF
--- a/docs/accessanalyzer/2601/install/install-commands.md
+++ b/docs/accessanalyzer/2601/install/install-commands.md
@@ -91,7 +91,7 @@ Export the variables before running the installer. When the same option is set a
 | `DRY_RUN` | `--dry-run` | `true` |
 
 :::note
-`LDAP_BIND_CREDENTIAL` is the only secret environment variable, and the installer does not actually honor it — the installer always reads the bind password via an interactive prompt or piped stdin, overwriting any exported value. See [Quick Install — Step 3](quickinstall.md#step-3-download-and-run-the-installer) for the two supported ways to provide the password.
+`LDAP_BIND_CREDENTIAL` is the only secret environment variable, and the installer doesn't actually honor it — the installer always reads the bind password via an interactive prompt or piped stdin, overwriting any exported value. See [Quick Install — Step 3](quickinstall.md#step-3-download-and-run-the-installer) for the two supported ways to provide the password.
 :::
 
 ## Running the Installer
@@ -170,7 +170,7 @@ If an installation fails and you need more detail to diagnose the problem, run w
 curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-install.sh?auth=license:$LICENSE_KEY" | bash -s -- --log-level debug
 ```
 
-The log is written to `/var/log/dspm-installer.log`. Accepted values are `debug`, `info`, `warn`, and `error`. The default is `info`. Terminal progress output is not affected — only the log file verbosity changes.
+The log is written to `/var/log/dspm-installer.log`. Accepted values are `debug`, `info`, `warn`, and `error`. The default is `info`. Terminal progress output isn't affected — only the log file verbosity changes.
 
 ## Identity Provider Flags
 

--- a/docs/accessanalyzer/2601/install/install-commands.md
+++ b/docs/accessanalyzer/2601/install/install-commands.md
@@ -49,9 +49,15 @@ export DSPM_TARGET_REVISION='[VERSION]'
 curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-install.sh?auth=license:$LICENSE_KEY" | bash -
 ```
 
-:::note
-The version number for each Access Analyzer release will be published here before general availability. Replace `[VERSION]` with the version string provided in the release notes.
-:::
+Version strings control which release is installed and what auto-upgrades apply:
+
+| Value | Behavior |
+| --- | --- |
+| (unset) | Installs the latest release; auto-upgrades to the latest version with no limit |
+| `1.0.8` | Pinned to exactly 1.0.8 — no auto-upgrade |
+| `1.*` | Auto-upgrades to any 1.x version |
+
+For most deployments, either omit this variable to stay on the latest release, or pin to a specific version (for example, `1.0.8`) to control when upgrades happen during your organization's patching cycle.
 
 ## Environment Variables
 
@@ -63,7 +69,7 @@ Export the variables before running the installer. When the same option is set a
 | --- | --- | --- |
 | `LICENSE_KEY` | `--license-key` | `NWRX-XXXX-XXXX-XXXX` |
 | `DSPM_HOSTNAME` | `--hostname` | `aa2601.corp.example.com` |
-| `DSPM_TARGET_REVISION` | `--target-revision` | `1.*` (latest stable) or `0.3.362-dev` |
+| `DSPM_TARGET_REVISION` | `--target-revision` | `1.0.8` (pinned) or omit for latest |
 | `SIZE` | `--size` | `1` (default), `2`, up to `10` |
 | `TLS_CERT_FILE` | `--tls-cert` | `/opt/dspm-tls/aa2601.crt` |
 | `TLS_KEY_FILE` | `--tls-key` | `/opt/dspm-tls/aa2601.key` |

--- a/docs/accessanalyzer/2601/install/install-commands.md
+++ b/docs/accessanalyzer/2601/install/install-commands.md
@@ -6,7 +6,7 @@ sidebar_position: 20
 
 # Installer Command Reference
 
-Access Analyzer is installed using a single curl command that downloads and runs the installer. You can pass options to this command to customize how the product is deployed on your server. Most installations need only a license key and accept all defaults.
+You install Access Analyzer using a single curl command that downloads and runs the installer. You can pass options to this command to customize how the product is deployed on your server. Most installations need only a license key and accept all defaults.
 
 ## Before You Run the Installer
 
@@ -26,7 +26,7 @@ Your license key authenticates access to the Netwrix package registry. Don't sha
 
 ### Choose an installer version
 
-**Without specifying a version**, the installer downloads the latest stable release automatically. This is appropriate for initial deployments and when you're ready to take the latest release:
+**Without specifying a version**, the installer downloads the latest stable release automatically. This is appropriate for initial deployments and when you want to install the latest release:
 
 ```bash
 # Set the Keygen license key variable
@@ -61,9 +61,9 @@ For most deployments, either omit this variable to stay on the latest release, o
 
 ## Environment Variables
 
-Most options can be set as environment variables instead of command-line flags. This is the recommended style for scripted or automated deployments — see the [Quick Install](quickinstall.md) for an end-to-end example.
+You can set most options as environment variables instead of command-line flags. This is the recommended style for scripted or automated deployments — see the [Quick Install](quickinstall.md) for an end-to-end example.
 
-Export the variables before running the installer. When the same option is set as both an environment variable and a command-line flag, the flag takes precedence.
+Export the variables before running the installer. When you set the same option as both an environment variable and a command-line flag, the flag takes precedence.
 
 | Environment variable | Equivalent flag | Example |
 | --- | --- | --- |
@@ -96,7 +96,7 @@ Export the variables before running the installer. When the same option is set a
 
 ## Running the Installer
 
-When you run the curl command above, the installer automatically:
+When you run the curl command, the installer automatically:
 
 1. Runs preflight checks to verify your system meets requirements
 2. Installs Kubernetes (k3s v1.33.4, the version validated by Netwrix for this release)
@@ -108,7 +108,7 @@ Installation typically takes 15–30 minutes depending on network speed and hard
 
 ### Passing additional options
 
-To customize the installation, add options after `bash -s --`. Everything after `--` is forwarded to the installer:
+To customize the installation, add options after `bash -s --`. The installer receives everything after `--`:
 
 ```bash
 curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-install.sh?auth=license:$LICENSE_KEY" | bash -s -- --dry-run
@@ -122,7 +122,7 @@ curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-insta
   --clickhouse-data-dir /mnt/nvme/clickhouse
 ```
 
-The available options are described in the sections below.
+The following sections describe the available options.
 
 ### Validate before installing (dry run)
 
@@ -170,11 +170,11 @@ If an installation fails and you need more detail to diagnose the problem, run w
 curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-install.sh?auth=license:$LICENSE_KEY" | bash -s -- --log-level debug
 ```
 
-The log is written to `/var/log/dspm-installer.log`. Accepted values are `debug`, `info`, `warn`, and `error`. The default is `info`. Terminal progress output isn't affected — only the log file verbosity changes.
+The installer writes the log to `/var/log/dspm-installer.log`. Accepted values are `debug`, `info`, `warn`, and `error`. The default is `info`. Terminal progress output isn't affected — only the log file verbosity changes.
 
 ## Identity Provider Flags
 
-The table below lists every IdP flag the installer accepts. For end-to-end examples, see one of these walkthroughs:
+The following table lists every IdP flag the installer accepts. For end-to-end examples, see one of these walkthroughs:
 
 - [Quick Install](quickinstall.md) — Active Directory deployment using environment variables (recommended for most customers)
 - [Configure Identity Provider](identity-provider.md) — example commands for Active Directory and LDAP, plus recovery with `--configure-idp-only`
@@ -207,7 +207,7 @@ Don't store your license key in this file. Use the `LICENSE_KEY` environment var
 
 ## Preflight Check Requirements
 
-The installer checks the following before installation begins. Results are written to `/var/log/dspm-preflight.json`.
+The installer checks the following before installation begins. The installer writes results to `/var/log/dspm-preflight.json`.
 
 | Check | Fail | Warn |
 |---|---|---|
@@ -221,7 +221,7 @@ The installer checks the following before installation begins. Results are writt
 | **Antivirus** | — | Known antivirus software detected |
 | **Network** | DNS resolution fails for a required domain | TCP connection timeout to a required domain |
 
-A **FAIL** result stops the installer and must be resolved. A **WARN** result also stops the installer by default — see [If the Installer Stops with Warnings](#if-the-installer-stops-with-warnings) below.
+A **FAIL** result stops the installer. Resolve it before retrying. A **WARN** result also stops the installer by default — see [If the Installer Stops with Warnings](#if-the-installer-stops-with-warnings).
 
 For the full list of required network domains, see [Network and Port Requirements](/docs/accessanalyzer/2601/install/system/network).
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -198,7 +198,7 @@ sudo update-ca-certificates
 Paste and customize the following at the top of your terminal session. Every subsequent command references these variables.
 
 ```bash
-export DSPM_TARGET_REVISION="<version, e.g. 0.3.*-dev or leave unset for latest>"
+# export DSPM_TARGET_REVISION="1.0.8"    # optional — omit to stay on latest; see version syntax below
 export LICENSE_KEY="<Your-License-Key>"
 export DSPM_HOSTNAME="<AA2601 FQDN, e.g. aa2601.corp.example.com>"
 export TLS_CERT_FILE="/opt/dspm-tls/<hostname>.crt"
@@ -227,7 +227,17 @@ export LDAP_EMAIL_ATTRIBUTE="mail"
 | `LDAP_BIND_DN` | Distinguished name of the read-only service account | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
 | `LDAP_USERS_DN` | Base DN for the OU containing user accounts | `CN=Users,DC=corp,DC=example,DC=com` |
 | `LDAP_EMAIL_ATTRIBUTE` | LDAP attribute storing the user's email address | `mail` |
-| `DSPM_TARGET_REVISION` | (Optional) Specific version to install. Omit for latest | `0.3.*-dev` |
+| `DSPM_TARGET_REVISION` | (Optional) Controls which version is installed and auto-upgraded to. Omit to stay on the latest release. | `1.0.8` |
+
+**Version syntax for `DSPM_TARGET_REVISION`:**
+
+| Value | Behavior |
+| --- | --- |
+| (unset) | Installs the latest release; auto-upgrades to the latest version with no limit |
+| `1.0.8` | Pinned to exactly 1.0.8 — no auto-upgrade |
+| `1.*` | Auto-upgrades to any 1.x version |
+
+For most deployments, either omit this variable to stay on the latest release, or pin to a specific version (for example, `1.0.8`) to control when upgrades happen during your organization's patching cycle.
 
 ### Step 3: Download and run the installer
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -16,7 +16,7 @@ Before running the installer, confirm the following.
 
 ### System requirements
 
-**Absolute installer minimums (enforced by preflight):** 6 vCPUs, 24 GB RAM, 20 GB free disk on `/`. Installation is blocked if the system falls below these thresholds.
+**Absolute installer minimums (enforced by preflight):** 6 vCPUs, 24 GB RAM, 20 GB free disk on `/`. The preflight check blocks installation if the system falls below these thresholds.
 
 Choose a deployment size based on your environment:
 
@@ -36,12 +36,12 @@ Choose a deployment size based on your environment:
 | `/var/log` | 5 GB | System and application logs |
 | `/etc` | 1 GB | Configuration files |
 
-**Network:** Outbound HTTPS (port 443) to required endpoints — see [Required Domains](#required-domains) below.
+**Network:** Outbound HTTPS (port 443) to required endpoints — see [Required Domains](#required-domains).
 
 **License:** Valid Netwrix license key.
 
 :::note
-**Supported OS:** Ubuntu 24.04 LTS is the primary tested platform. Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are also compatible. AIX and non-Linux operating systems aren't supported.
+**Supported OS:** Ubuntu 24.04 LTS is the primary tested platform. Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are also compatible. Access Analyzer doesn't support AIX or non-Linux operating systems.
 :::
 
 :::note
@@ -136,7 +136,7 @@ Ports the Access Analyzer server must be able to reach on your data sources and 
 
 ### Internal port requirements
 
-These ports are used within the Access Analyzer VM for service-to-service communication. No external firewall rules are required — only port 443 (Traefik) is exposed externally.
+These ports handle service-to-service communication within the Access Analyzer VM. No external firewall rules are required — the installer exposes only port 443 (Traefik) externally.
 
 | Port | Protocol | Service | Description |
 | --- | --- | --- | --- |
@@ -248,7 +248,7 @@ curl -sLfo /tmp/dspm-install.sh \
   "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-install.sh?auth=license:${LICENSE_KEY}"
 ```
 
-Run it with one of the two password options below. Installation takes 15–30 minutes.
+Run it with one of the following two password options. Installation takes 15–30 minutes.
 
 #### Option — Pipe the LDAP bind password (automated)
 
@@ -264,7 +264,7 @@ Runs non-interactively. Suitable for scripted or automated installs. After the i
 bash /tmp/dspm-install.sh
 ```
 
-The installer pauses part-way through and displays `Enter LDAP bind credential:`. Enter the password (input is silent — no characters are echoed) and press Enter. The password is never placed in shell history, environment, or disk. Requires a human at the keyboard at that moment.
+The installer pauses part-way through and displays `Enter LDAP bind credential:`. Enter the password (input is silent — no characters appear) and press Enter. The password never enters shell history, the environment, or disk. Requires a human at the keyboard at that moment.
 
 :::note
 Setting `LDAP_BIND_CREDENTIAL` as an environment variable isn't an alternative. The installer always reads the bind password interactively, which overwrites any exported value. Use one of the two options above.
@@ -422,15 +422,15 @@ END HIDDEN -->
 <!-- SYNC: configurations/identity-provider.md "Roles" -->
 <!-- If you change this block, update the matching block in configurations/identity-provider.md -->
 
-This table is also published at [Configuration > Identity Provider > Roles](../configurations/identity-provider.md#roles). It is duplicated here so this guide reads top-to-bottom.
+This table is also published at [Configuration > Identity Provider > Roles](../configurations/identity-provider.md#roles). This guide duplicates it here so it reads top-to-bottom.
 
 | Role | Description |
 | --- | --- |
 | **Administrator** | Full access: system configuration (sources, scans, connectors, application settings) and user management (create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users). |
-| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The bootstrap `admin@dspm.local` account is assigned this role. |
+| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The installer assigns this role to the bootstrap `admin@dspm.local` account. |
 | **Viewer** | Read-only access to data and reports. No configuration or user management rights. |
 
-The **User Admin** role exists to provide a dedicated account for user management with no system configuration access — useful for delegating user administration separately from system configuration. The bootstrap `admin@dspm.local` account is seeded as User Admin — you'll use it to pre-provision the rest of your users, including your first Administrator.
+The **User Admin** role exists to provide a dedicated account for user management with no system configuration access — useful for delegating user administration separately from system configuration. The installer seeds the bootstrap `admin@dspm.local` account as User Admin — you'll use it to pre-provision the rest of your users, including your first Administrator.
 
 <!-- END SYNC -->
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -41,7 +41,7 @@ Choose a deployment size based on your environment:
 **License:** Valid Netwrix license key.
 
 :::note
-**Supported OS:** Ubuntu 24.04 LTS is the primary tested platform. Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are also compatible. AIX and non-Linux operating systems are not supported.
+**Supported OS:** Ubuntu 24.04 LTS is the primary tested platform. Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are also compatible. AIX and non-Linux operating systems aren't supported.
 :::
 
 :::note
@@ -267,7 +267,7 @@ bash /tmp/dspm-install.sh
 The installer pauses part-way through and displays `Enter LDAP bind credential:`. Type the password (input is silent — no characters are echoed) and press Enter. The password is never placed in shell history, environment, or disk. Requires a human at the keyboard at that moment.
 
 :::note
-Setting `LDAP_BIND_CREDENTIAL` as an environment variable is not an alternative. The installer always reads the bind password interactively, which overwrites any exported value. Use one of the two options above.
+Setting `LDAP_BIND_CREDENTIAL` as an environment variable isn't an alternative. The installer always reads the bind password interactively, which overwrites any exported value. Use one of the two options above.
 :::
 
 ### Step 4: Verify the installation
@@ -286,7 +286,7 @@ All pods should show `Running` or `Completed` status. All ArgoCD applications sh
 <!-- SYNC: configurations/identity-provider.md "Sign in as the bootstrap User Admin" -->
 <!-- If you change this block, update the matching block in configurations/identity-provider.md -->
 
-The installer seeds a bootstrap account, `admin@dspm.local`, with the **User Admin** role. This account can create and manage other users but **cannot** access system configuration. Use it on first login to pre-provision your AD users, then sign out and sign back in as an Administrator for system-level work.
+The installer seeds a bootstrap account, `admin@dspm.local`, with the **User Admin** role. This account can create and manage other users but **can't** access system configuration. Use it on first log in to pre-provision your AD users, then sign out and sign back in as an Administrator for system-level work.
 
 1. Retrieve the bootstrap admin password:
 
@@ -303,14 +303,14 @@ The installer seeds a bootstrap account, `admin@dspm.local`, with the **User Adm
 
 4. Complete first-login setup:
    - Scan the QR code with an authenticator app, enter a device name, submit the one-time code. **Save this enrollment** — you will need the same authenticator for any future bootstrap admin login.
-   - Enter a first name and last name. **Do not change the email address.**
+   - Enter a first name and last name. **Don't change the email address.**
 
 5. Pre-provision each user who should be able to sign in. For each user:
    - Click **+ Add User**.
    - Enter the Name and Email. The email must match the user's AD `mail` attribute exactly, **including case**.
    - Assign a role (see [Roles](#roles) below).
 
-   Assign at least one user the **Administrator** role — the bootstrap account cannot access system configuration, so someone needs to. Assign at least one additional user the **User Admin** role if you want a non-bootstrap user to manage accounts going forward.
+   Assign at least one user the **Administrator** role — the bootstrap account can't access system configuration, so someone needs to. Assign at least one additional user the **User Admin** role if you want a non-bootstrap user to manage accounts going forward.
 
 6. Sign out.
 
@@ -443,11 +443,11 @@ For certificate-specific issues, see [TLS Certificate Requirements — Troublesh
 | Sign-in returns HTTP 401 with correct credentials | SAN hostname is mixed-case; browser normalized it to lowercase | Re-issue the certificate with lowercase hostname in the SAN list |
 | Installer exits with "Failed to read TLS private key" | Key file owned by `root`, installer runs as non-root user | `sudo chown <install-user> /opt/dspm-tls/<hostname>.key` |
 | Sign-in silently fails with `PKIX path building failed` in Keycloak logs | CA bundle is missing the LDAPS DC's CA (AD only) | Concatenate the DC's LDAPS CA into the bundle and re-run the installer with `--configure-idp-only` |
-| Browser rejects the application URL with a SAN mismatch error | `DSPM_HOSTNAME` is an IP, or SAN does not include the hostname in use | Use a DNS hostname for `DSPM_HOSTNAME` and verify the cert SAN list |
+| Browser rejects the application URL with a SAN mismatch error | `DSPM_HOSTNAME` is an IP, or SAN doesn't include the hostname in use | Use a DNS hostname for `DSPM_HOSTNAME` and verify the cert SAN list |
 | Installer rejects `--idp-alias` | Alias contains a space or special character | Use only letters, digits, hyphens, underscores, and dots |
-| Sign-in fails after pre-provisioning | Pre-provisioned email does not match the directory attribute | Confirm the email matches exactly, including case |
-| Entra ID login redirects fail | Redirect URI in App Registration does not match | Verify the redirect URI is `https://<DSPM_HOSTNAME>/auth/realms/dspm/broker/entra-id/endpoint` exactly |
-| Entra ID login prompt does not appear | Client secret entered incorrectly or has expired | Re-run with `--configure-idp-only` and re-enter the secret; rotate the secret in Azure if expired |
+| Sign-in fails after pre-provisioning | Pre-provisioned email doesn't match the directory attribute | Confirm the email matches exactly, including case |
+| Entra ID login redirects fail | Redirect URI in App Registration doesn't match | Verify the redirect URI is `https://<DSPM_HOSTNAME>/auth/realms/dspm/broker/entra-id/endpoint` exactly |
+| Entra ID login prompt doesn't appear | Client secret entered incorrectly or has expired | Re-run with `--configure-idp-only` and re-enter the secret; rotate the secret in Azure if expired |
 
 For other identity provider failures, see [Configure Identity Provider — Troubleshooting](identity-provider.md#troubleshooting-idp-configuration).
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -258,13 +258,13 @@ printf '<Service-Account-Password>\n' | bash /tmp/dspm-install.sh
 
 Runs non-interactively. Suitable for scripted or automated installs. After the install completes, clear your shell history if others can read the session (`history -c`, and clear `~/.bash_history` or equivalent) — the password was part of the `printf` command line.
 
-#### Option — Type the password when prompted
+#### Option — Enter the password when prompted
 
 ```bash
 bash /tmp/dspm-install.sh
 ```
 
-The installer pauses part-way through and displays `Enter LDAP bind credential:`. Type the password (input is silent — no characters are echoed) and press Enter. The password is never placed in shell history, environment, or disk. Requires a human at the keyboard at that moment.
+The installer pauses part-way through and displays `Enter LDAP bind credential:`. Enter the password (input is silent — no characters are echoed) and press Enter. The password is never placed in shell history, environment, or disk. Requires a human at the keyboard at that moment.
 
 :::note
 Setting `LDAP_BIND_CREDENTIAL` as an environment variable isn't an alternative. The installer always reads the bind password interactively, which overwrites any exported value. Use one of the two options above.


### PR DESCRIPTION
Replace -dev release tranche examples (0.3.*-dev, 0.3.362-dev) with GA version examples and add a version syntax table explaining install and auto-upgrade behavior for DSPM_TARGET_REVISION.

Generated with AI



Changes to quickinstall.md — Step 2: Set environment variables
Bash block — DSPM_TARGET_REVISION was an active export with a -dev example. Now it's commented out to make clear it's optional, with a real GA version as the example:


# Before
export DSPM_TARGET_REVISION="<version, e.g. 0.3.*-dev or leave unset for latest>"

# After
# export DSPM_TARGET_REVISION="1.0.8"    # optional — omit to stay on latest; see version syntax below
Environment variable table — Updated the row description and swapped the -dev example for a GA version:

Before	After
Description: "Specific version to install. Omit for latest"	Description: "Controls which version is installed and auto-upgraded to. Omit to stay on the latest release."
Example: 0.3.*-dev	Example: 1.0.8
New version syntax table added directly below the table:

Value	Behavior
(unset)	Installs the latest release; auto-upgrades to the latest version with no limit
1.0.8	Pinned to exactly 1.0.8 — no auto-upgrade
1.*	Auto-upgrades to any 1.x version
Changes to install-commands.md — "Choose an installer version" section
Note block replaced — The old note said versions would be published before GA (vague, unhelpful). Replaced with the same version syntax table above.

Environment variable table — Removed the -dev example from the DSPM_TARGET_REVISION row:


# Before
| `DSPM_TARGET_REVISION` | `--target-revision` | `1.*` (latest stable) or `0.3.362-dev` |

# After
| `DSPM_TARGET_REVISION` | `--target-revision` | `1.0.8` (pinned) or omit for latest |