### PR TITLE
fix(changetracker): improve API reference page load and navigation UX

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,7 +80,8 @@ const config = {
         ],
         theme: {
           options: {
-            scrollYOffset: '.navbar',
+            // navbar (3.75rem ≈ 60px) + back-link bar (2.5rem = 40px)
+            scrollYOffset: 100,
           },
         },
       },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -544,3 +544,120 @@ html {
 html.plugin-redoc {
     scroll-behavior: auto !important;
 }
+
+/* ============================================================
+   API reference page — back-to-docs link bar
+   Fixed strip immediately below the sticky Docusaurus navbar.
+   The Redoc content is pushed down by the same height so nothing
+   is obscured when the page first loads.
+   ============================================================ */
+.redoc-back-link {
+    position: fixed;
+    top: var(--ifm-navbar-height, 3.75rem);
+    left: 0;
+    right: 0;
+    height: 2.5rem;
+    display: flex;
+    align-items: center;
+    padding: 0 1rem;
+    background: var(--ifm-background-color);
+    border-bottom: 1px solid var(--ifm-toc-border-color);
+    z-index: 150;
+}
+
+.redoc-back-link__anchor {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--ifm-color-primary) !important;
+    text-decoration: none !important;
+    letter-spacing: 0.01em;
+}
+
+.redoc-back-link__anchor:hover {
+    text-decoration: underline !important;
+}
+
+/* Push the Redoc wrapper down so the fixed back-link bar does not
+   cover the top of the content on page load. */
+html.plugin-redoc .redocusaurus {
+    margin-top: 2.5rem;
+}
+
+/* ============================================================
+   API reference page — left panel (menu-content) sticky fix
+   Redoc sets position:sticky;top:0;height:100vh on .menu-content.
+   With the Docusaurus navbar (3.75rem) and the back-link bar (2.5rem)
+   both occupying the top of the viewport, we shift the panel down so
+   it never slides behind either bar.
+   ============================================================ */
+html.plugin-redoc .menu-content {
+    top: calc(var(--ifm-navbar-height, 3.75rem) + 2.5rem) !important;
+    height: calc(100vh - var(--ifm-navbar-height, 3.75rem) - 2.5rem) !important;
+    max-height: none !important;
+}
+
+/* Keep the operation filter search box pinned to the top of the
+   independently-scrollable left panel. Without this, Redoc's
+   automatic scroll-to-active-section drives the search box
+   off-screen; the only recovery is scrolling the whole page back
+   to the top. */
+html.plugin-redoc .search-input {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: inherit;
+    padding-bottom: 4px;
+}
+
+/* ============================================================
+   API reference page — progressive preloader / skeleton
+   Shown as a fixed overlay above the Redoc content while the
+   component tree hydrates. Fades out once the operation list
+   is detected in the DOM (see Root.js), with a 5 s hard cap.
+   ============================================================ */
+.redoc-preloader {
+    position: fixed;
+    inset: calc(var(--ifm-navbar-height, 3.75rem) + 2.5rem) 0 0 0;
+    background: var(--ifm-background-color);
+    display: flex;
+    z-index: 80;
+    opacity: 1;
+    transition: opacity 0.4s ease;
+    pointer-events: none;
+}
+
+.redoc-preloader--fading {
+    opacity: 0;
+}
+
+.redoc-preloader__sidebar {
+    width: 300px;
+    min-width: 300px;
+    flex-shrink: 0;
+    padding: 16px 12px;
+    border-right: 1px solid var(--ifm-toc-border-color);
+    overflow: hidden;
+}
+
+.redoc-preloader__main {
+    flex: 1;
+    padding: 32px 48px;
+    overflow: hidden;
+}
+
+.redoc-preloader__shimmer {
+    border-radius: 4px;
+    background: linear-gradient(
+        90deg,
+        var(--ifm-color-emphasis-200) 25%,
+        var(--ifm-color-emphasis-100) 50%,
+        var(--ifm-color-emphasis-200) 75%
+    );
+    background-size: 200% 100%;
+    animation: redoc-shimmer 1.6s infinite ease-in-out;
+}
+
+@keyframes redoc-shimmer {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}

--- a/src/theme/Redoc/index.js
+++ b/src/theme/Redoc/index.js
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react';
+import OriginalRedoc from '@theme-original/Redoc';
+
+// Docusaurus swizzle wrapper for @theme/Redoc (from docusaurus-theme-redoc).
+//
+// Problem: ServerRedoc's useSpec() call builds the entire Redoc operation store
+// synchronously during React's render phase. For client-side navigation this
+// blocks the main thread for several seconds before React can commit anything,
+// so the browser can't paint the preloader (Root.js) until AFTER the freeze —
+// which makes the preloader appear as a brief flash AFTER the blank period
+// rather than covering it.
+//
+// Fix: Detect whether we are on a client-side navigation (no .redoc-wrap in
+// the DOM yet) vs. a direct URL visit (SSR HTML already has .redoc-wrap).
+//
+//  - Client navigation  → mounted=false on first render → returns null instantly
+//    → browser paints preloader → useEffect fires → mounted=true → real render
+//    → expensive computation → content appears under the fading preloader.
+//
+//  - Direct URL / SSR   → .redoc-wrap is already in the HTML → mounted=true
+//    → renders OriginalRedoc immediately to match the server output (no
+//    hydration mismatch). The preloader from Root.js covers the hydration lag.
+export default function Redoc(props) {
+  const [mounted, setMounted] = useState(() => {
+    if (typeof document !== 'undefined') {
+      return document.querySelector('.redoc-wrap') !== null;
+    }
+    return true; // SSR: always render immediately
+  });
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return <OriginalRedoc {...props} />;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,37 +1,94 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { useLocation } from '@docusaurus/router';
+import Link from '@docusaurus/Link';
 import ProductMetaTags from '@site/src/components/ProductMetaTags';
 
-// Default implementation from Docusaurus
-// https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/Root/index.tsx
-export default function Root({ children }) {
-  useEffect(() => {
-    // Update favicon based on color mode using MutationObserver
-    const updateFavicon = () => {
-      const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-      const favicon = document.querySelector("link[rel='icon']");
-      if (favicon) {
-        favicon.href = isDark
-          ? '/branding/favicon-light.ico'
-          : '/branding/favicon-dark.ico';
-      }
-    };
+const API_REF_PATH = '/docs/changetracker/8_1/integration/api/reference';
 
-    // Initial update - temp. removed favicon changing on darkmode
-    //updateFavicon();
+const SHIMMER_SIDEBAR_WIDTHS = [80, 60, 90, 70, 85, 55, 75, 80, 60, 70];
+const SHIMMER_CONTENT_WIDTHS = [75, 90, 60, 85];
 
-    // Watch for theme changes
-    // const observer = new MutationObserver(updateFavicon);
-    // observer.observe(document.documentElement, {
-    //   attributes: true,
-    //   attributeFilter: ['data-theme']
-    // });
+function RedocPreloader() {
+  const [phase, setPhase] = useState('loading'); // 'loading' | 'fading' | 'done'
 
-    // return () => observer.disconnect();
+  const markReady = useCallback(() => {
+    setPhase((prev) => (prev === 'loading' ? 'fading' : prev));
   }, []);
+
+  // Transition 'fading' → 'done' after the CSS transition finishes
+  useEffect(() => {
+    if (phase !== 'fading') return;
+    const t = setTimeout(() => setPhase('done'), 450);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  // Watch for Redoc to finish rendering, then trigger the fade-out
+  useEffect(() => {
+    const isReady = () => document.querySelectorAll('.menu-content li').length > 2;
+
+    if (isReady()) {
+      markReady();
+      return;
+    }
+
+    const observer = new MutationObserver(() => {
+      if (isReady()) {
+        observer.disconnect();
+        markReady();
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    // Hard cap: never block the page for more than 5 s
+    const fallback = setTimeout(markReady, 5000);
+
+    return () => {
+      observer.disconnect();
+      clearTimeout(fallback);
+    };
+  }, [markReady]);
+
+  if (phase === 'done') return null;
+
+  const cls = `redoc-preloader${phase === 'fading' ? ' redoc-preloader--fading' : ''}`;
+
+  return (
+    <div className={cls} aria-hidden="true">
+      <div className="redoc-preloader__sidebar">
+        {/* search box placeholder */}
+        <div className="redoc-preloader__shimmer" style={{ height: '32px', marginBottom: '16px' }} />
+        {SHIMMER_SIDEBAR_WIDTHS.map((w, i) => (
+          <div key={i} className="redoc-preloader__shimmer" style={{ height: '14px', width: `${w}%`, marginBottom: '10px' }} />
+        ))}
+      </div>
+      <div className="redoc-preloader__main">
+        {/* heading placeholder */}
+        <div className="redoc-preloader__shimmer" style={{ height: '2.5rem', width: '45%', marginBottom: '1.5rem', borderRadius: '6px' }} />
+        {SHIMMER_CONTENT_WIDTHS.map((w, i) => (
+          <div key={i} className="redoc-preloader__shimmer" style={{ height: '14px', width: `${w}%`, marginBottom: '10px' }} />
+        ))}
+        {/* code block placeholder */}
+        <div className="redoc-preloader__shimmer" style={{ height: '160px', width: '100%', marginTop: '1.5rem', borderRadius: '6px' }} />
+      </div>
+    </div>
+  );
+}
+
+export default function Root({ children }) {
+  const { pathname } = useLocation();
+  const isApiRef = pathname === API_REF_PATH || pathname.startsWith(API_REF_PATH + '/');
 
   return (
     <>
       <ProductMetaTags />
+      {isApiRef && (
+        <nav className="redoc-back-link" aria-label="Return to Change Tracker documentation">
+          <Link to="/docs/changetracker/8_1/" className="redoc-back-link__anchor">
+            ← Change Tracker 8.1 docs
+          </Link>
+        </nav>
+      )}
+      {isApiRef && <RedocPreloader />}
       {children}
     </>
   );


### PR DESCRIPTION
Three things were off on the API reference page after #815.

The page would freeze for a few seconds on first visit before anything showed up, and then the loading skeleton would flash briefly as everything appeared at once. The skeleton was there to cover the load but it was arriving too late. The fix makes the skeleton show up first before Redoc starts its work, so you see something right away instead of a blank screen.

The filter search box in the left sidebar would disappear as you scrolled down the page. Redoc scrolls the sidebar to follow the active section and takes the search box with it. Getting it back meant scrolling all the way to the top. It is now pinned so it stays visible.

The sidebar was also sitting behind the navbar when you scrolled, and once you were in the API reference there was no way back to the main Change Tracker docs. Added a small back-link bar below the navbar and updated the sidebar to sit below it.