### PR TITLE
docs(aa2601): overhaul install section for interactive wizard installer

### DIFF
--- a/docs/accessanalyzer/2601/configurations/identity-provider.md
+++ b/docs/accessanalyzer/2601/configurations/identity-provider.md
@@ -6,7 +6,7 @@ sidebar_position: 75
 
 # Identity Provider
 
-Access Analyzer supports federation with your organization's identity system so that users can sign in with their existing corporate credentials. Authentication is handled by your identity provider; roles and permissions are managed within Access Analyzer.
+Access Analyzer supports federation with your organization's identity system so that users can sign in with their existing corporate credentials. Your identity provider handles authentication; you manage roles and permissions within Access Analyzer.
 
 Setting up an identity provider connection is a two-part process: first you configure the integration in your identity system, then you prepare user accounts inside Access Analyzer.
 
@@ -86,7 +86,7 @@ No application registration or callback URL is required for LDAP. Prepare the fo
 
 **Service account:**
 
-Create a dedicated, read-only service account in your directory with read access to the user base DN. For Active Directory, the account needs **Read** permission on the user OU. No write access or special group membership is required.
+Create a dedicated, read-only service account in your directory with read access to the user base DN. For Active Directory, the account needs **Read** permission on the user OU. The account doesn't need write access or special group membership.
 
 **Network access:**
 
@@ -111,7 +111,7 @@ Collect the following values:
 
 ### First sign-in
 
-The installer provisions the first administrator account automatically during setup — the person whose email was entered at the **First Admin Email** prompt can sign in immediately using their Active Directory password.
+The installer provisions the first administrator account automatically during setup — the person whose email you entered at the **First Admin Email** prompt can sign in immediately using their Active Directory password.
 
 Navigate to `https://<your-hostname>` and sign in with the first admin's AD credentials. From here, add additional users under **Configuration** > **Users**.
 
@@ -130,7 +130,7 @@ Don't change the bootstrap account email address — doing so causes authenticat
 
 ### Pre-provision user accounts
 
-Before a user can sign in through the identity provider, their account must exist in Access Analyzer. The application authenticates them against your IdP successfully but denies access if no matching account has been created.
+Before a user can sign in through the identity provider, their account must exist in Access Analyzer. The application authenticates them against your IdP successfully but denies access if no matching account exists.
 
 :::note
 The email address entered during pre-provisioning must exactly match the address sent by the IdP or stored in the LDAP `mail` attribute, including case. A mismatch causes sign-in to fail.
@@ -173,7 +173,7 @@ Sessions are valid for up to 8 hours from sign-in and expire after 4 hours of in
 | --- | --- |
 | **Pre-provisioning required** | Users must have an account in Access Analyzer before their first sign-in. |
 | **Email must match exactly** | The email entered during pre-provisioning must match what the IdP or LDAP directory sends, including case. |
-| **Roles managed in Access Analyzer** | Roles and permissions are set in Access Analyzer, not in your IdP or directory. |
+| **Roles managed in Access Analyzer** | You set roles and permissions in Access Analyzer, not in your IdP or directory. |
 | **Local accounts coexist** | The administrator account created at deployment remains a local account and continues to sign in with a password. |
 | **Password reset unavailable for federated accounts** | The **Reset Password** action in the Users page is available for local accounts only. Federated users manage their credentials through your IdP. |
-| **Name and email locked after first sign-in** | Once a user has signed in at least once, their name and email are set from the IdP token and can't be changed in the Access Analyzer UI. Update them in your IdP instead. |
+| **Name and email locked after first sign-in** | Once a user has signed in at least once, their name and email come from the IdP token; you can't change them in the Access Analyzer UI. Update them in your IdP instead. |

--- a/docs/accessanalyzer/2601/configurations/identity-provider.md
+++ b/docs/accessanalyzer/2601/configurations/identity-provider.md
@@ -11,7 +11,7 @@ Access Analyzer supports federation with your organization's identity system so 
 Setting up an identity provider connection is a two-part process: first you configure the integration in your identity system, then you prepare user accounts inside Access Analyzer.
 
 :::note
-Before completing the steps below, confirm that the infrastructure and network requirements for your IdP type are in place. See [Configure Identity Provider](../install/identity-provider.md) in the Installation section.
+Before completing the steps below, confirm that the infrastructure and network requirements for your IdP type are in place. See [Network and Port Requirements](../install/system/network.md) and [TLS Certificate Requirements](../install/system/certificates.md).
 :::
 
 ## Supported integration types

--- a/docs/accessanalyzer/2601/configurations/identity-provider.md
+++ b/docs/accessanalyzer/2601/configurations/identity-provider.md
@@ -11,7 +11,7 @@ Access Analyzer supports federation with your organization's identity system so 
 Setting up an identity provider connection is a two-part process: first you configure the integration in your identity system, then you prepare user accounts inside Access Analyzer.
 
 :::note
-Before completing the steps below, confirm that the infrastructure and network requirements for your IdP type are in place. See [Network and Port Requirements](../install/system/network.md) and [TLS Certificate Requirements](../install/system/certificates.md).
+Before continuing, confirm that the infrastructure and network requirements for your IdP type are in place. See [Network and Port Requirements](../install/system/network.md) and [TLS Certificate Requirements](../install/system/certificates.md).
 :::
 
 ## Supported integration types
@@ -125,7 +125,7 @@ sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
 ```
 
 :::warning
-Do not change the bootstrap account email address — doing so causes authentication failures.
+Don't change the bootstrap account email address — doing so causes authentication failures.
 :::
 
 ### Pre-provision user accounts
@@ -139,7 +139,7 @@ The email address entered during pre-provisioning must exactly match the address
 1. Navigate to **Configuration** > **Users**.
 2. Click **Add User**.
 3. Enter the user's **Name** and **Email** address.
-4. Select a **Role**: **Administrator**, **User Admin**, or **Viewer** (see [Roles](#roles) below).
+4. Select a **Role**: **Administrator**, **User Admin**, or **Viewer** (see [Roles](#roles)).
 5. Click **Create User**.
 
 No password is required for pre-provisioned accounts. For details on managing users, see [Users](users.md).
@@ -149,12 +149,12 @@ No password is required for pre-provisioned accounts. For details on managing us
 <!-- SYNC: install/quickinstall.md "Roles" -->
 <!-- If you change this block, update the matching block in install/quickinstall.md -->
 
-Access Analyzer has three roles. The bootstrap `admin@dspm.local` account is seeded as User Admin, so it can pre-provision the rest of your users, including your first Administrator.
+Access Analyzer has three roles. The installer seeds the bootstrap `admin@dspm.local` account as User Admin, so it can pre-provision the rest of your users, including your first Administrator.
 
 | Role | Description |
 | --- | --- |
 | **Administrator** | Full access: system configuration (sources, scans, connectors, application settings) and user management (create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users). |
-| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The bootstrap `admin@dspm.local` account is assigned this role. |
+| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. Access Analyzer assigns this role to the bootstrap `admin@dspm.local` account. |
 | **Viewer** | Read-only access to data and reports. No configuration or user management rights. |
 
 <!-- END SYNC -->
@@ -163,7 +163,7 @@ Access Analyzer has three roles. The bootstrap `admin@dspm.local` account is see
 
 When identity provider integration is active, the Access Analyzer login page presents a credential form that validates against your directory.
 
-On first sign-in, Access Analyzer matches the email address from the IdP token or LDAP directory to the pre-provisioned account and permanently links the IdP identity to that account. On all subsequent sign-ins, the user's unique IdP identifier is used directly.
+On first sign-in, Access Analyzer matches the email address from the IdP token or LDAP directory to the pre-provisioned account and permanently links the IdP identity to that account. On all subsequent sign-ins, Access Analyzer uses the user's unique IdP identifier directly.
 
 Sessions are valid for up to 8 hours from sign-in and expire after 4 hours of inactivity.
 

--- a/docs/accessanalyzer/2601/configurations/identity-provider.md
+++ b/docs/accessanalyzer/2601/configurations/identity-provider.md
@@ -109,33 +109,24 @@ Collect the following values:
 
 ## Part 2: Prepare Access Analyzer
 
-### Sign in as the bootstrap User Admin
+### First sign-in
 
-<!-- SYNC: install/quickinstall.md "Sign in as the bootstrap User Admin" -->
-<!-- If you change this block, update the matching block in install/quickinstall.md -->
+The installer provisions the first administrator account automatically during setup — the person whose email was entered at the **First Admin Email** prompt can sign in immediately using their Active Directory password.
 
-The installer seeds a bootstrap account, `admin@dspm.local`, with the **User Admin** role. This account can create and manage other users but **cannot** access system configuration. Use it on first login to pre-provision your users, then sign out and sign back in as an Administrator for system-level work.
+Navigate to `https://<your-hostname>` and sign in with the first admin's AD credentials. From here, add additional users under **Configuration** > **Users**.
 
-1. Retrieve the bootstrap admin password from the Kubernetes secret:
+#### Breakglass account
 
-   ```bash
-   sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
-     -o jsonpath='{.data.password}' | base64 -d; echo
-   ```
+The installer also creates a bootstrap account, `admin@dspm.local`, as a recovery mechanism. If the first admin account becomes inaccessible, retrieve the bootstrap password to regain access:
 
-2. Open a browser and navigate to `https://<your-hostname>`.
+```bash
+sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
+  -o jsonpath='{.data.password}' | base64 -d; echo
+```
 
-3. Sign in with:
-   - **Username**: `admin@dspm.local`
-   - **Password**: (from step 1)
-
-4. Complete first-login setup:
-   - Scan the QR code with an authenticator app, enter a device name, submit the one-time code. **Save this enrollment** — you will need the same authenticator for any future bootstrap admin login.
-   - Enter a first name and last name. **Do not change the email address.**
-
-Proceed to [Pre-provision user accounts](#pre-provision-user-accounts) below.
-
-<!-- END SYNC -->
+:::warning
+Do not change the bootstrap account email address — doing so causes authentication failures.
+:::
 
 ### Pre-provision user accounts
 
@@ -150,8 +141,6 @@ The email address entered during pre-provisioning must exactly match the address
 3. Enter the user's **Name** and **Email** address.
 4. Select a **Role**: **Administrator**, **User Admin**, or **Viewer** (see [Roles](#roles) below).
 5. Click **Create User**.
-
-Assign at least one user the **Administrator** role — the bootstrap `admin@dspm.local` account is a User Admin only and cannot access system configuration. Assign at least one additional user the **User Admin** role if you want a non-bootstrap user to manage accounts going forward.
 
 No password is required for pre-provisioned accounts. For details on managing users, see [Users](users.md).
 

--- a/docs/accessanalyzer/2601/configurations/users.md
+++ b/docs/accessanalyzer/2601/configurations/users.md
@@ -9,7 +9,7 @@ sidebar_position: 70
 The Users page lets you create and manage the accounts that have access to Netwrix Access Analyzer. Navigate to **Configuration** > **Users** to view and manage all users.
 
 :::note
-This page is available to users with the **User Admin** or **Administrator** role. Users with the Viewer role cannot access this page.
+This page is available to users with the **User Admin** or **Administrator** role. Users with the Viewer role can't access this page.
 :::
 
 ## Users list
@@ -40,7 +40,7 @@ A user can only hold one role at a time.
 
 ## Bootstrap admin account
 
-Access Analyzer seeds a built-in account, `admin@dspm.local`, during installation. This account is assigned the **User Admin** role and is intended for first-time user provisioning only.
+Access Analyzer seeds a built-in account, `admin@dspm.local`, during installation. Access Analyzer assigns this account the **User Admin** role for first-time user provisioning only.
 
 To retrieve the bootstrap admin password:
 
@@ -49,10 +49,10 @@ sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
   -o jsonpath='{.data.password}' | base64 -d; echo
 ```
 
-On first login, you will be prompted to enroll an authenticator app for MFA and set a display name. Do not change the email address.
+On first login, Access Analyzer prompts you to enroll an authenticator app for MFA and set a display name. Don't change the email address.
 
 :::note
-Keep the bootstrap account active as an emergency recovery account, but do not use it for routine user management. Create at least one named User Admin account during initial setup and use that account for ongoing administration.
+Keep the bootstrap account active as an emergency recovery account, but don't use it for routine user management. Create at least one named User Admin account during initial setup and use that account for ongoing administration.
 :::
 
 For the full first-login walkthrough, see [Quick Install — Step 5](/docs/accessanalyzer/2601/install/quickinstall#step-6-sign-in).
@@ -64,10 +64,10 @@ After installation, complete the following steps in order before handing the pro
 | Step | Action | Notes |
 | --- | --- | --- |
 | **1** | Sign in as `admin@dspm.local` | Uses the bootstrap User Admin account. Retrieve the password using the kubectl command above. |
-| **2** | Create at least one named **User Admin** | Provides a dedicated account for user management with no system configuration access. Use this account for ongoing user administration so that Administrator accounts are not required for routine user changes. |
+| **2** | Create at least one named **User Admin** | Provides a dedicated account for user management with no system configuration access. Use this account for ongoing user administration so that Administrator accounts aren't required for routine user changes. |
 | **3** | Create at least one **Administrator** | Grants full access — system configuration and user management. This is typically the person responsible for setting up and maintaining the product. |
 | **4** | Create **Viewer** accounts as needed | Optional. Add Viewer accounts for stakeholders who need read-only access to dashboards and reports. |
-| **5** | Sign out of the bootstrap account | Day-to-day work should be done from named accounts. |
+| **5** | Sign out of the bootstrap account | Do day-to-day work from named accounts. |
 
 ## Add a user
 
@@ -107,7 +107,7 @@ When your deployment is configured to use an external Identity Provider, you can
 No password is required. The account is ready for the user to sign in through your IdP.
 
 :::note
-If a user authenticates through your IdP without a pre-provisioned account in Access Analyzer, their sign-in is blocked and they see an access error. Pre-provision the account first, then the user can sign in successfully.
+If a user authenticates through your IdP without a pre-provisioned account in Access Analyzer, Access Analyzer blocks their sign-in and they see an access error. Pre-provision the account first, then the user can sign in successfully.
 :::
 
 ## Edit a user
@@ -136,7 +136,7 @@ The account becomes active immediately. The user can sign in and use the applica
 
 1. In the users list, click the actions menu for an active user and select **Deactivate**.
 
-Deactivating a user revokes all of their active sessions immediately. The account record is preserved and can be reactivated later.
+Deactivating a user revokes all of their active sessions immediately. Access Analyzer preserves the account record; you can reactivate it later.
 
 :::note
 You can't deactivate your own account or the last active User Admin account.
@@ -158,7 +158,7 @@ Access Analyzer generates a password reset token for the user. The user must set
 2. Confirm the deletion.
 
 :::warning
-Deleting a user is permanent and can't be undone.
+Deleting a user is permanent; you can't undo it.
 :::
 
 You can't delete your own account or the last active User Admin account.

--- a/docs/accessanalyzer/2601/configurations/users.md
+++ b/docs/accessanalyzer/2601/configurations/users.md
@@ -55,7 +55,7 @@ On first login, you will be prompted to enroll an authenticator app for MFA and 
 Keep the bootstrap account active as an emergency recovery account, but do not use it for routine user management. Create at least one named User Admin account during initial setup and use that account for ongoing administration.
 :::
 
-For the full first-login walkthrough, see [Quick Install — Step 5](/docs/accessanalyzer/2601/install/quickinstall#step-5-sign-in-with-entra-id-credentials).
+For the full first-login walkthrough, see [Quick Install — Step 5](/docs/accessanalyzer/2601/install/quickinstall#step-6-sign-in).
 
 ## Recommended initial setup
 

--- a/docs/accessanalyzer/2601/configurations/users.md
+++ b/docs/accessanalyzer/2601/configurations/users.md
@@ -55,7 +55,7 @@ On first login, you will be prompted to enroll an authenticator app for MFA and 
 Keep the bootstrap account active as an emergency recovery account, but do not use it for routine user management. Create at least one named User Admin account during initial setup and use that account for ongoing administration.
 :::
 
-For the full first-login walkthrough, see [Quick Install — Step 5](/docs/accessanalyzer/2601/install/quickinstall#step-5-sign-in-as-the-bootstrap-user-admin-and-pre-provision-users).
+For the full first-login walkthrough, see [Quick Install — Step 5](/docs/accessanalyzer/2601/install/quickinstall#step-5-sign-in-with-entra-id-credentials).
 
 ## Recommended initial setup
 

--- a/docs/accessanalyzer/2601/install/identity-provider.md
+++ b/docs/accessanalyzer/2601/install/identity-provider.md
@@ -17,9 +17,9 @@ This article is for the team performing the Access Analyzer deployment. It cover
 - [Installer Command Reference](install-commands.md) — full catalog of every installer flag and environment variable
 - [TLS Certificate Requirements](system/certificates.md) — certificate formats, SAN rules, CA bundle preparation
 
-Access Analyzer supports connecting an identity provider (IdP) so users authenticate through your organization's directory rather than with local credentials. IdP federation is **optional** — if you omit `--idp-type` at install time, Access Analyzer is deployed without Keycloak and uses local accounts only.
+Access Analyzer supports connecting an identity provider (IdP) so users authenticate through your organization's directory rather than with local credentials. IdP federation is **optional** — if you omit `--idp-type` at install time, Access Analyzer deploys without Keycloak and uses local accounts only.
 
-When `--idp-type` is configured, the installer automatically:
+When you configure `--idp-type`, the installer automatically:
 
 1. Deploys Keycloak (v26.5.3) as part of the cluster
 2. Waits for Keycloak to become healthy
@@ -40,7 +40,7 @@ Confirm the following before running the installer with IdP flags:
 `--hostname` is required and must:
 
 - Be a real DNS hostname (not an IP address — IPs will not work because the browser TLS handshake requires the hostname in the certificate's SAN).
-- Be lowercase, and match lowercase in the certificate SAN list. Keycloak's OIDC issuer URL is derived from this value; a case mismatch between SAN and browser-normalized hostname produces HTTP 401 at sign-in.
+- Be lowercase, and match lowercase in the certificate SAN list. Keycloak derives its OIDC issuer URL from this value; a case mismatch between SAN and browser-normalized hostname produces HTTP 401 at sign-in.
 - Resolve the same from client browsers and in-cluster pods. The installer configures the in-cluster rewrite automatically; the customer is responsible for the public DNS record or `/etc/hosts` entry that client browsers use.
 - Avoid the `.local` and `.localhost` TLDs — both break in-cluster DNS resolution and silently break OIDC login flows.
 
@@ -62,7 +62,7 @@ For full certificate format and preparation details, see [TLS Certificate Requir
 END HIDDEN -->
 
 :::note
-`--idp-alias` must match `[A-Za-z0-9._-]+` — letters, digits, hyphens, underscores, and dots only. Spaces aren't allowed. The alias is shown as the label on the login button.
+`--idp-alias` must match `[A-Za-z0-9._-]+` — letters, digits, hyphens, underscores, and dots only. Spaces aren't allowed. The alias appears as the label on the login button.
 :::
 
 <!-- HIDDEN: Entra ID OIDC, Entra ID SAML, Generic OIDC, and Generic SAML are post-GA. Uncomment when ready to publish.
@@ -253,7 +253,7 @@ kubectl exec -n access-analyzer statefulset/keycloak -- bash -c '
 ```
 
 :::note
-The bootstrap admin credentials are read from environment variables already present in the pod. Don't pass them as command-line arguments — they would appear in Kubernetes audit logs.
+Keycloak reads the bootstrap admin credentials from environment variables already present in the pod. Don't pass them as command-line arguments — they would appear in Kubernetes audit logs.
 :::
 
 <!-- HIDDEN: Manual OIDC/SAML configuration sections are post-GA. Uncomment when ready to publish.

--- a/docs/accessanalyzer/2601/install/identity-provider.md
+++ b/docs/accessanalyzer/2601/install/identity-provider.md
@@ -62,7 +62,7 @@ For full certificate format and preparation details, see [TLS Certificate Requir
 END HIDDEN -->
 
 :::note
-`--idp-alias` must match `[A-Za-z0-9._-]+` — letters, digits, hyphens, underscores, and dots only. Spaces are not allowed. The alias is shown as the label on the login button.
+`--idp-alias` must match `[A-Za-z0-9._-]+` — letters, digits, hyphens, underscores, and dots only. Spaces aren't allowed. The alias is shown as the label on the login button.
 :::
 
 <!-- HIDDEN: Entra ID OIDC, Entra ID SAML, Generic OIDC, and Generic SAML are post-GA. Uncomment when ready to publish.
@@ -209,7 +209,7 @@ curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-insta
   --ldap-users-dn "OU=Users,DC=corp,DC=example,DC=com"
 ```
 
-As with the Active Directory section above, pass `--ca-bundle` with the root CA cert that signed the directory's LDAPS certificate when it is not in the OS trust store.
+As with the Active Directory section, pass `--ca-bundle` with the root CA cert that signed the directory's LDAPS certificate when it isn't in the OS trust store.
 
 The `ldap` type uses generic LDAP defaults: `uid` for the username attribute and `entryUUID` for the UUID attribute.
 
@@ -228,7 +228,7 @@ curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-insta
 ```
 
 :::note
-`--configure-idp-only` does not require `--license-key`. It skips all infrastructure provisioning steps and runs only the IdP configuration phase.
+`--configure-idp-only` doesn't require `--license-key`. It skips all infrastructure provisioning steps and runs only the IdP configuration phase.
 :::
 
 ## Next steps
@@ -520,7 +520,7 @@ curl -sLfo - "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-insta
   # ...same --idp-* flags used during the original install
 ```
 
-`--configure-idp-only` does not require `--license-key`.
+`--configure-idp-only` doesn't require `--license-key`.
 
 ### If retry fails with 409 Conflict
 
@@ -550,4 +550,4 @@ kubectl exec -n access-analyzer statefulset/keycloak -- \
   /opt/keycloak/bin/kcadm.sh delete components/"${LDAP_ID}" -r dspm
 ```
 
-Replace `<alias>` with the value that was passed to `--idp-alias` during the failed install. Then re-run `--configure-idp-only`.
+Replace `<alias>` with the value you passed to `--idp-alias` during the failed install. Then re-run `--configure-idp-only`.

--- a/docs/accessanalyzer/2601/install/identity-provider.md
+++ b/docs/accessanalyzer/2601/install/identity-provider.md
@@ -2,6 +2,7 @@
 title: "Configure Identity Provider"
 description: "Deployment steps for connecting an Identity Provider to Access Analyzer using the installer"
 sidebar_position: 50
+draft: true
 ---
 
 # Configure Identity Provider

--- a/docs/accessanalyzer/2601/install/install-commands.md
+++ b/docs/accessanalyzer/2601/install/install-commands.md
@@ -2,6 +2,7 @@
 title: "Installer Command Reference"
 description: "Options you can pass to the Access Analyzer installer to customize your deployment"
 sidebar_position: 20
+draft: true
 ---
 
 # Installer Command Reference

--- a/docs/accessanalyzer/2601/install/install-commands.md
+++ b/docs/accessanalyzer/2601/install/install-commands.md
@@ -7,7 +7,7 @@ draft: true
 
 # Installer Command Reference
 
-You install Access Analyzer using a single curl command that downloads and runs the installer. You can pass options to this command to customize how the product is deployed on your server. Most installations need only a license key and accept all defaults.
+You install Access Analyzer using a single curl command that downloads and runs the installer. You can pass options to this command to customize how the installer deploys the product on your server. Most installations need only a license key and accept all defaults.
 
 ## Before You Run the Installer
 
@@ -111,7 +111,7 @@ Export the variables before running the installer. When you set the same option 
 | `DRY_RUN` | `--dry-run` | `true` |
 
 :::note
-`LDAP_BIND_PASSWORD` is the only secret environment variable, and the installer doesn't actually honor it — the installer always reads the bind password via an interactive prompt or piped stdin, overwriting any exported value. See [Quick Install — Step 3](quickinstall.md#required-actions) for the two supported ways to provide the password.
+`LDAP_BIND_PASSWORD` is the only secret environment variable, and the installer doesn't honor it — the installer always reads the bind password via an interactive prompt or piped stdin, overwriting any exported value. See [Quick Install — Step 3](quickinstall.md#required-actions) for the two supported ways to provide the password.
 :::
 
 ## Running the Installer

--- a/docs/accessanalyzer/2601/install/install-commands.md
+++ b/docs/accessanalyzer/2601/install/install-commands.md
@@ -111,7 +111,7 @@ Export the variables before running the installer. When you set the same option 
 | `DRY_RUN` | `--dry-run` | `true` |
 
 :::note
-`LDAP_BIND_PASSWORD` is the only secret environment variable, and the installer doesn't actually honor it — the installer always reads the bind password via an interactive prompt or piped stdin, overwriting any exported value. See [Quick Install — Step 3](quickinstall.md#step-3-download-and-run-the-installer) for the two supported ways to provide the password.
+`LDAP_BIND_PASSWORD` is the only secret environment variable, and the installer doesn't actually honor it — the installer always reads the bind password via an interactive prompt or piped stdin, overwriting any exported value. See [Quick Install — Step 3](quickinstall.md#required-actions) for the two supported ways to provide the password.
 :::
 
 ## Running the Installer

--- a/docs/accessanalyzer/2601/install/postinstall.md
+++ b/docs/accessanalyzer/2601/install/postinstall.md
@@ -94,4 +94,4 @@ kubectl top pods -A --sort-by=memory
 
 - [Create your first admin account](/docs/accessanalyzer/2601/configurations/users) and sign in
 - [Configure a data source](../gettingstarted/active-directory/active-directory.md) and run your first scan
-- Review [install commands](/docs/accessanalyzer/2601/install/install-commands) for ongoing application management
+- Run `dspmctl --help` for ongoing application management via the command line tool

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -8,11 +8,18 @@ sidebar_position: 5
 
 This guide covers installing Access Analyzer on a fresh Linux VM with **Active Directory** as the identity provider.
 
-For the CLI-flag reference, see [Configure Identity Provider](identity-provider.md).
-
 ## Prerequisites Checklist
 
-Before running the installer, confirm the following.
+Before running the installer, confirm the following:
+
+- [ ] Server meets hardware and OS requirements
+- [ ] Outbound HTTPS access confirmed to all required domains
+- [ ] Server hostname is a fully qualified domain name (FQDN) that resolves to the server IP
+- [ ] TLS certificate option chosen; certificate files prepared if using Bring Your Own
+- [ ] AD/DC Root CA bundle file prepared and placed on the server
+- [ ] Active Directory service account details collected
+- [ ] First admin email address confirmed (must match the AD `mail` attribute exactly)
+- [ ] Netwrix license key on hand
 
 ### System requirements
 
@@ -46,71 +53,123 @@ Choose a deployment size based on your environment:
 
 :::note
 If running on a hypervisor, configure **static memory allocation** (not dynamic/ballooned memory). See [Hardware and System Requirements](/docs/accessanalyzer/2601/install/system/requirements) for hypervisor-specific instructions.
-:::
 
-### TLS certificates
-
-See [TLS Certificate Requirements](system/certificates.md) for the full specification. At a minimum you need:
-
-- **Application TLS certificate** (PEM). The Subject Alternative Name (SAN) list must include `DSPM_HOSTNAME` **in lowercase** and the server's IP address.
-- **Private key** paired with the certificate (PEM). The OS user running the installer must be able to read it, not just `root`.
-- **CA bundle** (PEM). Must contain the CA that signed the application certificate. For AD authentication, the CA bundle must also contain the CA that signed the domain controller's LDAPS certificate. If these are different CAs, concatenate them:
-
-  ```bash
-  cat app-ca.crt ldaps-ca.crt > ca-bundle.crt
-  ```
-
-:::warning
-`DSPM_HOSTNAME` must be a DNS hostname, **not an IP address**. The browser TLS handshake requires a hostname in the certificate's SAN. Avoid the `.local` and `.localhost` TLDs — both break in-cluster DNS resolution and silently break sign-in flows.
+- **VMware vSphere:** disable memory ballooning (`mem.balloon.enable = "FALSE"`)
+- **Hyper-V:** use static memory (`Set-VMMemory -DynamicMemoryEnabled $false`)
 :::
 
 ### DNS
 
-The value you pick for `DSPM_HOSTNAME` must resolve to the VM's IP address from:
+The hostname you enter during installation must be a fully qualified domain name (FQDN) — it must contain at least one dot (for example, `analyzer.corp.example.com`). A plain hostname without a dot is rejected by the installer.
+
+The hostname must resolve to the VM's IP address from:
 
 - Client browsers — configure a DNS A record, or add an entry to each client's `hosts` file.
 - In-cluster pods — the installer's CoreDNS rewrite handles these automatically. No customer action needed.
 
+:::warning
+Use a DNS hostname, **not an IP address**. The browser TLS handshake requires a hostname. Avoid the `.local` and `.localhost` TLDs — both break in-cluster DNS resolution and silently break sign-in flows.
+:::
+
+### TLS certificates
+
+The installer offers three ways to provision the server's TLS certificate. Choose your option before gathering certificate materials — only **Bring your own certificate** requires preparation in advance.
+
+| Option | What It Does | Best For | What to Prepare |
+| --- | --- | --- | --- |
+| **Generate self-signed** | Installer generates a certificate automatically — no CA involvement | Quick evaluations and proof-of-concept installs. Not for production — browsers will show a security warning | Nothing — installer handles it |
+| **Sign with AD Certificate Services** | Installer generates a CSR and submits it to your organization's AD CS to be signed by your internal Enterprise CA | Enterprise environments where AD CS is already deployed and the server can reach the CA | AD CS must be reachable from the server; an account with certificate enrollment rights |
+| **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS is not available | Three PEM files — see below |
+
+:::note
+**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#active-directory-information).
+:::
+
+#### Bring your own certificate — file requirements
+
+If you selected **Bring your own certificate**, prepare the following three files and place them in `/opt/dspm-tls/` on the server before running the installer:
+
+```bash
+sudo mkdir -p /opt/dspm-tls
+```
+
+| File | What It Is |
+| --- | --- |
+| `<hostname>.crt` | Server identity certificate in PEM format. The Subject Alternative Name (SAN) list must include the hostname **in lowercase** and the server's IP address. |
+| `<hostname>.key` | Private key paired with the certificate (PEM). The OS user running the installer must be able to read it — not just `root`. |
+| `ca-bundle.crt` | CA certificate(s) that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#active-directory-information). |
+
+**SAN requirement:** The hostname in the SAN list must be lowercase. Browsers normalize hostnames to lowercase during TLS validation — a case mismatch causes HTTP 401 failures at sign-in. The SAN must also include the server IP address.
+
+```bash
+sudo chown $(whoami) /opt/dspm-tls/<hostname>.key
+sudo chmod 644 /opt/dspm-tls/<hostname>.key
+
+sudo cp /opt/dspm-tls/ca-bundle.crt /usr/local/share/ca-certificates/dspm-ca.crt
+sudo update-ca-certificates
+```
+
+**Verifying certificate files before install:**
+
+```bash
+# Check that the SAN includes your hostname (lowercase) and server IP
+openssl x509 -noout -text -in /opt/dspm-tls/<hostname>.crt | grep -A5 "Subject Alternative"
+
+# Verify the cert was signed by your CA bundle
+openssl verify -CAfile /opt/dspm-tls/ca-bundle.crt /opt/dspm-tls/<hostname>.crt
+
+# Verify the key matches the cert (both md5sums must match)
+openssl pkey -pubout -in /opt/dspm-tls/<hostname>.key 2>/dev/null | md5sum
+openssl x509 -noout -pubkey -in /opt/dspm-tls/<hostname>.crt | md5sum
+```
+
+For the full TLS specification including SAN rules and multi-CA environments, see [TLS Certificate Requirements](system/certificates.md).
+
 ### Active Directory information
 
-Gather these values from your directory team before starting:
+Gather these values from your directory team before starting. The installer wizard prompts for each one.
 
-- Domain controller hostname or IP, and port (636 LDAPS strongly recommended; 389 plain LDAP works but is unencrypted)
-- Service account distinguished name (DN) — read-only access to the user directory is sufficient
-- Service account password
-- Base DN where your user accounts are stored (for example, `CN=Users,DC=example,DC=com`)
-- Email attribute name (usually `mail`)
-
-<!-- HIDDEN: Entra ID OIDC (Option B) is post-GA. Uncomment when ready to publish.
-
-### Entra ID information (Option B only)
-
-Before running the installer, register Access Analyzer as an application in your Azure tenant.
-
-1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
-2. Navigate to **Identity** > **Applications** > **App registrations**.
-3. Click **New registration**.
-4. Enter the following:
-   - **Name:** A display name for the application (for example, `Access Analyzer`)
-   - **Supported account types:** Accounts in this organizational directory only
-   - **Redirect URI:** Platform — **Web**. Value: `https://<DSPM_HOSTNAME>/auth/realms/dspm/broker/entra-id/endpoint`
-5. Click **Register**.
-6. On the app overview page, note the **Application (client) ID** and **Directory (tenant) ID** — you will need both when running the installer.
-7. Navigate to **API permissions** > **Add a permission** > **Microsoft Graph** > **Delegated permissions**.
-8. Add: `openid`, `profile`, `email`.
-9. Click **Grant admin consent** to apply the permissions tenant-wide.
-10. Navigate to **Certificates & secrets** > **New client secret**.
-11. Set an expiry period, click **Add**, and copy the **secret value immediately** — it is only shown once.
-
-**Values to collect before running the installer:**
-
-| Value | Description | Where to Find |
+| Field | What It Is | Example |
 | --- | --- | --- |
-| **Tenant ID** | Directory (tenant) ID | Entra admin center > Overview > Directory (tenant) ID |
-| **Client ID** | Application (client) ID | App registration > Overview > Application (client) ID |
-| **Client Secret** | OIDC client secret — entered at the interactive prompt during install | Certificates & secrets — copy immediately after creation |
+| LDAP URL | Address of your domain controller. Use port 636 (LDAPS, encrypted) — strongly recommended; port 389 (plain LDAP) is available if LDAPS is not configured | `ldaps://dc.corp.example.com:636` |
+| Bind DN | Full Distinguished Name of a read-only service account | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
+| Bind Password | Password for the service account | — |
+| Users Base DN | LDAP container where user accounts are stored | `CN=Users,DC=corp,DC=example,DC=com` |
+| Email Attribute | LDAP attribute storing the user's email address (usually `mail`) | `mail` |
+| AD/DC Root CA Bundle | Root CA certificate that signed the domain controller's LDAPS certificate. Required for all TLS options | `/opt/dspm-tls/ca-bundle.crt` |
 
-END HIDDEN -->
+**Bind DN format:** The installer requires full Distinguished Name (DN) format — for example, `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com`. User Principal Name (UPN) format (`user@domain.com`) is not accepted. The DN must exactly match the account's record in Active Directory.
+
+**AD/DC Root CA Bundle:** To identify which CA signed the domain controller's LDAPS certificate, run this from the Access Analyzer server:
+
+```bash
+openssl s_client -connect <dc-hostname>:636 -showcerts </dev/null 2>/dev/null \
+  | openssl x509 -noout -issuer
+```
+
+Ask your AD or PKI team for that CA's root certificate in PEM format. Place it at `/opt/dspm-tls/ca-bundle.crt`.
+
+If the server certificate CA and the DC LDAPS CA are the **same**, one file covers both:
+
+```bash
+sudo cp app-ca.crt /opt/dspm-tls/ca-bundle.crt
+```
+
+If they are **different CAs**, concatenate both into a single file:
+
+```bash
+cat app-ca.crt ldaps-ca.crt > /opt/dspm-tls/ca-bundle.crt
+```
+
+### First admin account
+
+Identify the email address and display name of the person who will be the first administrator. The installer prompts for both values during setup and provisions the account automatically. That person signs in using their Active Directory password — no separate password is set.
+
+The email address must match the `mail` attribute of the person's Active Directory account exactly, including case.
+
+### License key
+
+Your Netwrix license key is required to download the installer and is the first prompt in the installation wizard. Obtain it from your Netwrix account representative before starting.
 
 ### Connector port requirements
 
@@ -158,7 +217,7 @@ All outbound endpoints use HTTPS (port 443). The Access Analyzer server must rea
 | --- | --- | --- | --- |
 | `api.keygen.sh` | Keygen / Licensing | License validation API | Installation and updates |
 | `oci.pkg.keygen.sh` | Keygen / Licensing | Netwrix OCI registry — Helm charts and application images | Installation and updates |
-| `raw.pkg.keygen.sh` | Keygen / Licensing | Installer script download | Installation and updates |
+| `raw.pkg.keygen.sh` | Keygen / Licensing | Installer binary download | Installation and updates |
 | `keygen-dist.c3c9112df8df715f42d1162cdce5dba1.r2.cloudflarestorage.com` | Keygen / Licensing CDN | Keygen artifact storage | Installation and updates |
 | `api.github.com` | GitHub | GitHub API | Installation only |
 | `github.com` | GitHub | Repository and release access | Installation only |
@@ -172,166 +231,133 @@ All outbound endpoints use HTTPS (port 443). The Access Analyzer server must rea
 
 ---
 
-## Active Directory Authentication
+## Installation
 
-### Step 1: Prepare the VM — upload certs and trust the CA
+### Step 1: SSH into the server
 
-For full details on each certificate file (SAN rules, ownership, CA bundle concatenation), see [TLS Certificate Requirements](system/certificates.md).
+Connect to the Access Analyzer server:
 
 ```bash
-sudo mkdir -p /opt/dspm-tls
-
-# Copy your three PEM files into /opt/dspm-tls/:
-#   - <hostname>.crt   (Access Analyzer server certificate — SAN must match DSPM_HOSTNAME, lowercase)
-#   - <hostname>.key   (private key — chown to install user, chmod 644)
-#   - ca-bundle.crt    (concatenated: application CA + LDAPS DC CA)
-
-sudo chown $(whoami) /opt/dspm-tls/<hostname>.key
-sudo chmod 644 /opt/dspm-tls/<hostname>.key
-
-sudo cp /opt/dspm-tls/ca-bundle.crt /usr/local/share/ca-certificates/dspm-ca.crt
-sudo update-ca-certificates
+ssh <your-user>@<server-ip-or-hostname>
 ```
 
-### Step 2: Set environment variables
+### Step 2: Download the installer
 
-Paste and customize the following at the top of your terminal session. Every subsequent command references these variables.
-
-```bash
-# export TARGET_REVISION="1.0.8"          # optional — omit to stay on latest; see version syntax below
-export LICENSE_KEY="<Your-License-Key>"
-export DSPM_HOSTNAME="<AA2601 FQDN, e.g. aa2601.corp.example.com>"
-export TLS_CERT_FILE="/opt/dspm-tls/<hostname>.crt"
-export TLS_KEY_FILE="/opt/dspm-tls/<hostname>.key"
-export TLS_CA_BUNDLE_FILE="/opt/dspm-tls/ca-bundle.crt"
-export IDP_TYPE="ad"
-export IDP_ALIAS="<login-button-label>"                   # letters, digits, hyphens, underscores, dots only — no spaces
-export LDAP_URL="ldaps://<dc-hostname-or-ip>:636"
-export LDAP_BIND_DN="<Service-Account-DN>"                # e.g. CN=svc-dspm,OU=ServiceAccounts,DC=example,DC=com
-export LDAP_USERS_DN="<Users-Base-DN>"                    # e.g. CN=Users,DC=example,DC=com
-export LDAP_EMAIL_ATTRIBUTE="mail"
-```
-
-**Environment variable reference:**
-
-| Variable | Description | Example |
-| --- | --- | --- |
-| `LICENSE_KEY` | Netwrix license key | `NWRX-XXXX-XXXX-XXXX` |
-| `DSPM_HOSTNAME` | Fully qualified domain name. Must be lowercase and match the cert SAN | `aa2601.corp.example.com` |
-| `TLS_CERT_FILE` | Full path to PEM server certificate | `/opt/dspm-tls/aa2601.crt` |
-| `TLS_KEY_FILE` | Full path to PEM private key. The install user must be able to read this file | `/opt/dspm-tls/aa2601.key` |
-| `TLS_CA_BUNDLE_FILE` | Full path to CA bundle (application CA + LDAPS DC CA) | `/opt/dspm-tls/ca-bundle.crt` |
-| `IDP_TYPE` | Identity provider type | `ad` |
-| `IDP_ALIAS` | Login button label. Letters, digits, hyphens, underscores, dots only | `active-directory` |
-| `LDAP_URL` | LDAPS URL for the domain controller | `ldaps://dc.corp.example.com:636` |
-| `LDAP_BIND_DN` | Distinguished name of the read-only service account | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
-| `LDAP_USERS_DN` | Base DN for the OU containing user accounts | `CN=Users,DC=corp,DC=example,DC=com` |
-| `LDAP_EMAIL_ATTRIBUTE` | LDAP attribute storing the user's email address | `mail` |
-| `TARGET_REVISION` | (Optional) Controls which version is installed and auto-upgraded to. Omit to stay on the latest release. | `1.0.8` |
-
-**Version syntax for `TARGET_REVISION`:**
-
-| Value | Behavior |
-| --- | --- |
-| (unset) | Defaults to `1.*` — installs the latest 1.x release and auto-upgrades within 1.x |
-| `1.0.8` | Pinned to exactly 1.0.8 — no auto-upgrade |
-| `1.*` | Auto-upgrades to any 1.x version |
-
-For most deployments, either omit this variable to stay on the latest release, or pin to a specific version (for example, `1.0.8`) to control when upgrades happen during your organization's patching cycle.
-
-### Step 3: Download and run the installer
-
-Download the installer:
+Replace `YOUR_NETWRIX_LICENSE_KEY` on the first line with your license key — that is the only value you need to change. Run the remaining lines as-is:
 
 ```bash
-
-# Download and install the DSPM installer binary for your Linux system architecture (x86_64 or ARM64) using your license key.
+export LICENSE_KEY='YOUR_NETWRIX_LICENSE_KEY'
 ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 TMP_FILE=$(mktemp)
-curl -sLf -o "$TMP_FILE" "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-installer-linux-$ARCH?auth=license:$LICENSE_KEY"
+curl -sLf -o "$TMP_FILE" \
+  "https://raw.pkg.keygen.sh/v1/accounts/netwrix/artifacts/dspm-installer-linux-$ARCH?auth=license:${LICENSE_KEY}"
 sudo install -m 0755 "$TMP_FILE" "/usr/local/bin/dspm-installer"
 rm -f "$TMP_FILE"
- 
-# Launches the installation wizard
+```
+
+### Step 3: Verify the download
+
+```bash
+dspm-installer --version
+```
+
+If this returns a version number, the binary is ready. If it returns an error, the download failed — verify your license key is correct and that the server has outbound access to all required domains listed above.
+
+### Step 4: Run the installer
+
+```bash
 sudo dspm-installer
 ```
 
-When prompted, enter the password for the service account you specified in `LDAP_BIND_DN`.
+The installer presents an interactive wizard. Have your prerequisites ready before proceeding. Installation takes 15–30 minutes.
 
-Run `dspm-installer [command] --help` to view usage and available options for any command.
-<!-- HIDDEN:
-Run it with one of the following two password options. Installation takes 15–30 minutes.
+**Complete prompt reference:**
 
-#### Option — Pipe the LDAP bind password (automated)
+The **Example** column shows representative values for illustration — enter your own values when prompted.
 
-```bash
-printf '<Service-Account-Password>\n' | bash /tmp/dspm-install.sh
-```
-
-Runs non-interactively. Suitable for scripted or automated installs. After the install completes, clear your shell history if others can read the session (`history -c`, and clear `~/.bash_history` or equivalent) — the password was part of the `printf` command line.
-
-#### Option — Enter the password when prompted
-
-```bash
-bash /tmp/dspm-install.sh
-```
-
-The installer pauses part-way through and displays `Enter LDAP bind credential:`. Enter the password (input is silent — no characters appear) and press Enter. The password never enters shell history, the environment, or disk. Requires a human at the keyboard at that moment.
+| Prompt | Example | Notes |
+| --- | --- | --- |
+| License Key | `NWRX-XXXX-XXXX-XXXX` | Your Netwrix license key |
+| Hostname | `aa2601.corp.example.com` | Must contain a dot; must be lowercase and match the cert SAN exactly |
+| Identity Provider | `Active Directory` | Select from the list |
+| LDAP URL | `ldaps://dc.corp.example.com:636` | Use port 636 (LDAPS) — port 389 is available but unencrypted |
+| Bind DN | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` | Full DN format required — not UPN format |
+| Bind Password | *(your service account password)* | Input is silent — no characters appear |
+| Users Base DN | `CN=Users,DC=corp,DC=example,DC=com` | The LDAP container where user accounts are stored |
+| Email Attribute | `mail` | The LDAP attribute that holds the user's email address |
+| First Admin Email | `admin@corp.example.com` | Must match their AD `mail` attribute exactly, including case |
+| First Admin Name | `Jane Smith` | Used in the UI only |
+| Advanced Settings | `No` *(standard installations)* | See note below |
+| TLS Certificate | *(select your provisioning method)* | See [TLS certificates](#tls-certificates) |
+| TLS Certificate File *(Bring your own only)* | `/opt/dspm-tls/aa2601.crt` | |
+| TLS Private Key File *(Bring your own only)* | `/opt/dspm-tls/aa2601.key` | |
+| AD/DC Root CA Bundle Path | `/opt/dspm-tls/ca-bundle.crt` | Required for all TLS options |
 
 :::note
-Setting `LDAP_BIND_CREDENTIAL` as an environment variable isn't an alternative. The installer always reads the bind password interactively, which overwrites any exported value. Use one of the two options above.
+**Advanced Settings** exposes the **Target Revision** prompt — pin to a specific chart version (for example, `1.5.0`), or leave empty to stay on the latest release. Use this to control when upgrades happen during your organization's patching cycle.
 :::
-END HIDDEN -->
-### Step 4: Verify the installation
 
-After the installer completes, confirm all pods are healthy:
+### Step 5: Review the installation summary
 
-```bash
-kubectl get pods -A
-kubectl get apps -n argocd
+When the installer finishes, it displays a summary screen. Review it before proceeding — it includes the application URL, required actions, and useful paths.
+
+:::note
+This step can be skipped if you are signing in for the first time and only need to add users and assign roles. Return to complete the required actions before using `kubectl` or configuring firewall rules.
+:::
+
+```
+DSPM Installation Complete
+
+## Access Analyzer Web Application
+
+• URL: https://<your-hostname>
+• Administrator account provisioned for <first-admin-email>
+• Check application status: kubectl get pods -n access-analyzer
+
+## DSPM Command Line Tool
+
+Path: /usr/local/bin/dspmctl
+
+For detailed usage: /usr/local/bin/dspmctl --help
+
+## Required Actions
+
+• Ensure firewall allows inbound port 443
+• Log out and back in (or run newgrp dspm) to activate kubectl access
+
+## Granting kubectl Access to Additional Users
+
+  sudo usermod -aG dspm <username>
+  export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+## Troubleshooting
+
+Installation log: /var/log/dspm-installer.log
 ```
 
-All pods should show `Running` or `Completed` status. All ArgoCD applications should be `Synced` and `Healthy`.
+**Complete the required actions before signing in:**
 
-### Step 5: Sign in as the bootstrap User Admin and pre-provision users
+1. Confirm that inbound port 443 is open on the server's firewall.
+2. Log out of your current SSH session and log back in, or run `newgrp dspm`, to activate `kubectl` access for your user. Commands like `kubectl get pods` will not work until you do this.
 
-<!-- SYNC: configurations/identity-provider.md "Sign in as the bootstrap User Admin" -->
-<!-- If you change this block, update the matching block in configurations/identity-provider.md -->
+### Step 6: Sign in
 
-The installer seeds a bootstrap account, `admin@dspm.local`, with the **User Admin** role. This account can create and manage other users but **can't** access system configuration. Use it on first log in to pre-provision your AD users, then sign out and sign back in as an Administrator for system-level work.
+Navigate to `https://<your-hostname>` in a browser. Sign in using the first admin email address and the corresponding Active Directory password.
 
-1. Retrieve the bootstrap admin password:
+From here, add additional users under **Configuration** > **Users**.
 
-   ```bash
-   sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
-     -o jsonpath='{.data.password}' | base64 -d; echo
-   ```
+#### Breakglass account
 
-2. Open a browser and navigate to `https://<DSPM_HOSTNAME>`.
+The installer also creates a bootstrap administrator account (`admin@dspm.local`) as a recovery mechanism. If the first admin account becomes inaccessible, use this account to regain access:
 
-3. Sign in with:
-   - **Username**: `admin@dspm.local`
-   - **Password**: (from step 1)
+```bash
+sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
+  -o jsonpath='{.data.password}' | base64 -d; echo
+```
 
-4. Complete first-login setup:
-   - Scan the QR code with an authenticator app, enter a device name, submit the one-time code. **Save this enrollment** — you will need the same authenticator for any future bootstrap admin login.
-   - Enter a first name and last name. **Don't change the email address.**
-
-5. Pre-provision each user who should be able to sign in. For each user:
-   - Click **+ Add User**.
-   - Enter the Name and Email. The email must match the user's AD `mail` attribute exactly, **including case**.
-   - Assign a role (see [Roles](#roles)).
-
-   Assign at least one user the **Administrator** role — the bootstrap account can't access system configuration, so someone needs to. Assign at least one additional user the **User Admin** role if you want a non-bootstrap user to manage accounts going forward.
-
-6. Sign out.
-
-<!-- END SYNC -->
-
-### Step 6: Sign in with AD credentials
-
-1. Navigate to `https://<DSPM_HOSTNAME>`.
-2. Enter the email and password for a pre-provisioned AD user and sign in.
+:::warning
+Do not change the bootstrap account email address — doing so causes authentication failures.
+:::
 
 ---
 
@@ -416,11 +442,7 @@ kubectl get apps -n argocd
 
 All pods should show `Running` or `Completed` status. All ArgoCD applications should be `Synced` and `Healthy`.
 
-### Step 5: Sign in as the bootstrap User Admin and pre-provision users
-
-The same bootstrap account flow applies for Entra ID as for AD. Follow [Option A — Step 5](#step-5-sign-in-as-the-bootstrap-user-admin-and-pre-provision-users) with one difference: when pre-provisioning users, the email must match the address sent by Entra ID exactly, **including case** (not the AD `mail` attribute).
-
-### Step 6: Sign in with Entra ID credentials
+### Step 5: Sign in with Entra ID credentials
 
 1. Navigate to `https://<DSPM_HOSTNAME>`.
 2. Enter the email and password for a pre-provisioned Entra ID user and sign in.
@@ -439,10 +461,10 @@ This table also appears at [Configuration > Identity Provider > Roles](../config
 | Role | Description |
 | --- | --- |
 | **Administrator** | Full access: system configuration (sources, scans, connectors, application settings) and user management (create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users). |
-| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The installer assigns this role to the bootstrap `admin@dspm.local` account. |
+| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The bootstrap `admin@dspm.local` account is assigned this role. |
 | **Viewer** | Read-only access to data and reports. No configuration or user management rights. |
 
-The **User Admin** role provides a dedicated account for user management with no system configuration access — useful for delegating user administration separately from system configuration. The installer seeds the bootstrap `admin@dspm.local` account as User Admin — you'll use it to pre-provision the rest of your users, including your first Administrator.
+The **User Admin** role provides a dedicated account for user management with no system configuration access — useful for delegating user administration separately from system configuration.
 
 <!-- END SYNC -->
 
@@ -454,16 +476,44 @@ For certificate-specific issues, see [TLS Certificate Requirements — Troublesh
 | --- | --- | --- |
 | Sign-in returns HTTP 401 with correct credentials | SAN hostname is mixed-case; browser normalized it to lowercase | Re-issue the certificate with lowercase hostname in the SAN list |
 | Installer exits with "Failed to read TLS private key" | Key file owned by `root`, installer runs as non-root user | `sudo chown <install-user> /opt/dspm-tls/<hostname>.key` |
-| Sign-in silently fails with `PKIX path building failed` in Keycloak logs | CA bundle is missing the LDAPS DC's CA (AD only) | Concatenate the DC's LDAPS CA into the bundle and re-run the installer with `--configure-idp-only` |
-| Browser rejects the application URL with a SAN mismatch error | `DSPM_HOSTNAME` is an IP, or SAN doesn't include the hostname in use | Use a DNS hostname for `DSPM_HOSTNAME` and verify the cert SAN list |
-| Installer rejects `--idp-alias` | Alias contains a space or special character | Use only letters, digits, hyphens, underscores, and dots |
-| Sign-in fails after pre-provisioning | Pre-provisioned email doesn't match the directory attribute | Confirm the email matches exactly, including case |
-| Entra ID login redirects fail | Redirect URI in App Registration doesn't match | Verify the redirect URI is `https://<DSPM_HOSTNAME>/auth/realms/dspm/broker/entra-id/endpoint` exactly |
-| Entra ID login prompt doesn't appear | Client secret entered incorrectly or has expired | Re-run with `--configure-idp-only` and re-enter the secret; rotate the secret in Azure if expired |
+| Sign-in silently fails with `PKIX path building failed` in Keycloak logs | CA bundle is missing the LDAPS DC's CA | Concatenate the DC's LDAPS CA into the bundle and re-run the installer |
+| Browser rejects the application URL with a SAN mismatch error | Hostname entered as an IP address, or SAN doesn't include the hostname in use | Use a DNS hostname and verify the cert SAN list |
+| Pods not starting after installation | Outbound HTTPS blocked to one or more required endpoints | Verify connectivity to all domains in [Required Domains](#required-domains) |
+| Installer rejects the hostname | Hostname does not contain a dot — not a valid FQDN | Use a fully qualified domain name such as `analyzer.corp.example.com` |
+| Installer rejects the Bind DN | UPN format (`user@domain.com`) entered instead of full DN | Use full Distinguished Name format: `CN=user,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
 
-For other identity provider failures, see [Configure Identity Provider — Troubleshooting](identity-provider.md#troubleshooting-idp-configuration).
+**Useful diagnostic commands:**
+
+```bash
+# View installer log
+cat /var/log/dspm-installer.log
+
+# Check pod status (access-analyzer namespace)
+sudo kubectl get pods -n access-analyzer
+
+# Check all namespaces
+sudo kubectl get pods -A
+
+# Check ArgoCD sync status
+sudo kubectl get apps -n argocd
+
+# View Keycloak logs
+sudo kubectl logs -n access-analyzer statefulset/keycloak --tail=50
+```
 
 ## Reinstalling
 
-- **Same VM**: your certificates are already in place at `/opt/dspm-tls/`. Skip Step 1 and restart at Step 2.
-- **New VM, same CA**: upload the same three certificate files to `/opt/dspm-tls/` on the new VM (Step 1), then continue with Step 2.
+Before reinstalling, completely remove the existing installation:
+
+```bash
+sudo /usr/local/bin/k3s-dspm-uninstall.sh
+sudo rm -rf /var/lib/rancher/k3s /opt/dspm ~/.kube/config
+sudo rm -f /usr/local/bin/dspm-installer
+```
+
+See [Uninstalling Access Analyzer](uninstall.md) for the complete uninstall procedure.
+
+After uninstalling:
+
+- **Same VM**: your certificates are already in place at `/opt/dspm-tls/`. Skip the certificate preparation steps and restart at [Step 1](#step-1-ssh-into-the-server).
+- **New VM, same CA**: upload the same certificate files to `/opt/dspm-tls/` on the new VM (see [TLS certificates](#tls-certificates)), then continue with [Step 1](#step-1-ssh-into-the-server).

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -82,7 +82,7 @@ The installer offers three ways to provision the server's TLS certificate. Choos
 | **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS isn't available | Three PEM files — see below |
 
 :::note
-**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
+**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#active-directory-information).
 :::
 
 #### Bring your own certificate — file requirements
@@ -97,7 +97,7 @@ sudo mkdir -p /opt/dspm-tls
 | --- | --- |
 | `<hostname>.crt` | Server identity certificate in PEM format. The Subject Alternative Name (SAN) list must include the hostname **in lowercase** and the server's IP address. |
 | `<hostname>.key` | Private key paired with the certificate (PEM). The OS user running the installer must be able to read it — not just `root`. |
-| `ca-bundle.crt` | CA certificates that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#bring-your-own-certificate-file-requirements). |
+| `ca-bundle.crt` | CA certificates that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#active-directory-information). |
 
 **SAN requirement:** The hostname in the SAN list must be lowercase. Browsers normalize hostnames to lowercase during TLS validation — a case mismatch causes HTTP 401 failures at sign-in. The SAN must also include the server IP address.
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -82,7 +82,7 @@ The installer offers three ways to provision the server's TLS certificate. Choos
 | **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS isn't available | Three PEM files — see below |
 
 :::note
-**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#active-directory-information).
+**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
 :::
 
 #### Bring your own certificate — file requirements
@@ -97,7 +97,7 @@ sudo mkdir -p /opt/dspm-tls
 | --- | --- |
 | `<hostname>.crt` | Server identity certificate in PEM format. The Subject Alternative Name (SAN) list must include the hostname **in lowercase** and the server's IP address. |
 | `<hostname>.key` | Private key paired with the certificate (PEM). The OS user running the installer must be able to read it — not just `root`. |
-| `ca-bundle.crt` | CA certificates that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#active-directory-information). |
+| `ca-bundle.crt` | CA certificates that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#bring-your-own-certificate-file-requirements). |
 
 **SAN requirement:** The hostname in the SAN list must be lowercase. Browsers normalize hostnames to lowercase during TLS validation — a case mismatch causes HTTP 401 failures at sign-in. The SAN must also include the server IP address.
 
@@ -287,7 +287,7 @@ The **Example** column shows representative values for illustration — enter yo
 | Email Attribute | `mail` | The LDAP attribute that holds the user's email address |
 | First Admin Email | `admin@corp.example.com` | Must match their AD `mail` attribute exactly, including case |
 | First Admin Name | `Jane Smith` | Used in the UI only |
-| Advanced Settings | `No` *(standard installations)* | See note below |
+| Advanced Settings | `No` *(standard installations)* | See the following note |
 | TLS Certificate | *(select your provisioning method)* | See [TLS certificates](#tls-certificates) |
 | TLS Certificate File *(Bring your own only)* | `/opt/dspm-tls/aa2601.crt` | |
 | TLS Private Key File *(Bring your own only)* | `/opt/dspm-tls/aa2601.key` | |

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -60,7 +60,7 @@ If running on a hypervisor, configure **static memory allocation** (not dynamic/
 
 ### DNS
 
-The hostname you enter during installation must be a fully qualified domain name (FQDN) — it must contain at least one dot (for example, `analyzer.corp.example.com`). A plain hostname without a dot is rejected by the installer.
+The hostname you enter during installation must be a fully qualified domain name (FQDN) — it must contain at least one dot (for example, `analyzer.corp.example.com`). The installer rejects a plain hostname without a dot.
 
 The hostname must resolve to the VM's IP address from:
 
@@ -79,10 +79,10 @@ The installer offers three ways to provision the server's TLS certificate. Choos
 | --- | --- | --- | --- |
 | **Generate self-signed** | Installer generates a certificate automatically — no CA involvement | Quick evaluations and proof-of-concept installs. Not for production — browsers will show a security warning | Nothing — installer handles it |
 | **Sign with AD Certificate Services** | Installer generates a CSR and submits it to your organization's AD CS to be signed by your internal Enterprise CA | Enterprise environments where AD CS is already deployed and the server can reach the CA | AD CS must be reachable from the server; an account with certificate enrollment rights |
-| **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS is not available | Three PEM files — see below |
+| **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS isn't available | Three PEM files — see below |
 
 :::note
-**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#active-directory-information).
+**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
 :::
 
 #### Bring your own certificate — file requirements
@@ -97,7 +97,7 @@ sudo mkdir -p /opt/dspm-tls
 | --- | --- |
 | `<hostname>.crt` | Server identity certificate in PEM format. The Subject Alternative Name (SAN) list must include the hostname **in lowercase** and the server's IP address. |
 | `<hostname>.key` | Private key paired with the certificate (PEM). The OS user running the installer must be able to read it — not just `root`. |
-| `ca-bundle.crt` | CA certificate(s) that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#active-directory-information). |
+| `ca-bundle.crt` | CA certificates that trust the server certificate. If the CA that signed the server certificate and the CA that signed the domain controller's LDAPS certificate are different, concatenate both — see [Active Directory information](#bring-your-own-certificate-file-requirements). |
 
 **SAN requirement:** The hostname in the SAN list must be lowercase. Browsers normalize hostnames to lowercase during TLS validation — a case mismatch causes HTTP 401 failures at sign-in. The SAN must also include the server IP address.
 
@@ -131,14 +131,14 @@ Gather these values from your directory team before starting. The installer wiza
 
 | Field | What It Is | Example |
 | --- | --- | --- |
-| LDAP URL | Address of your domain controller. Use port 636 (LDAPS, encrypted) — strongly recommended; port 389 (plain LDAP) is available if LDAPS is not configured | `ldaps://dc.corp.example.com:636` |
+| LDAP URL | Address of your domain controller. Use port 636 (LDAPS, encrypted) — strongly recommended; port 389 (plain LDAP) is available if LDAPS isn't configured | `ldaps://dc.corp.example.com:636` |
 | Bind DN | Full Distinguished Name of a read-only service account | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
 | Bind Password | Password for the service account | — |
 | Users Base DN | LDAP container where user accounts are stored | `CN=Users,DC=corp,DC=example,DC=com` |
 | Email Attribute | LDAP attribute storing the user's email address (usually `mail`) | `mail` |
 | AD/DC Root CA Bundle | Root CA certificate that signed the domain controller's LDAPS certificate. Required for all TLS options | `/opt/dspm-tls/ca-bundle.crt` |
 
-**Bind DN format:** The installer requires full Distinguished Name (DN) format — for example, `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com`. User Principal Name (UPN) format (`user@domain.com`) is not accepted. The DN must exactly match the account's record in Active Directory.
+**Bind DN format:** The installer requires full Distinguished Name (DN) format — for example, `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com`. The installer doesn't accept User Principal Name (UPN) format (`user@domain.com`). The DN must exactly match the account's record in Active Directory.
 
 **AD/DC Root CA Bundle:** To identify which CA signed the domain controller's LDAPS certificate, run this from the Access Analyzer server:
 
@@ -163,13 +163,13 @@ cat app-ca.crt ldaps-ca.crt > /opt/dspm-tls/ca-bundle.crt
 
 ### First admin account
 
-Identify the email address and display name of the person who will be the first administrator. The installer prompts for both values during setup and provisions the account automatically. That person signs in using their Active Directory password — no separate password is set.
+Identify the email address and display name of the person who will be the first administrator. The installer prompts for both values during setup and provisions the account automatically. That person signs in using their Active Directory password — no separate password is needed.
 
 The email address must match the `mail` attribute of the person's Active Directory account exactly, including case.
 
 ### License key
 
-Your Netwrix license key is required to download the installer and is the first prompt in the installation wizard. Obtain it from your Netwrix account representative before starting.
+You need your Netwrix license key to download the installer; it's the first prompt in the installation wizard. Obtain it from your Netwrix account representative before starting.
 
 ### Connector port requirements
 
@@ -261,7 +261,7 @@ rm -f "$TMP_FILE"
 dspm-installer --version
 ```
 
-If this returns a version number, the binary is ready. If it returns an error, the download failed — verify your license key is correct and that the server has outbound access to all required domains listed above.
+If this returns a version number, the binary is ready. If it returns an error, the download failed — verify your license key is correct and that the server has outbound access to all required domains listed earlier.
 
 ### Step 4: Run the installer
 
@@ -302,7 +302,7 @@ The **Example** column shows representative values for illustration — enter yo
 When the installer finishes, it displays a summary screen. Review it before proceeding — it includes the application URL, required actions, and useful paths.
 
 :::note
-This step can be skipped if you are signing in for the first time and only need to add users and assign roles. Return to complete the required actions before using `kubectl` or configuring firewall rules.
+You can skip this step if you're signing in for the first time and only need to add users and assign roles. Return to complete the required actions before using `kubectl` or configuring firewall rules.
 :::
 
 ```
@@ -356,7 +356,7 @@ sudo kubectl get secret -n access-analyzer dspm-bootstrap-admin \
 ```
 
 :::warning
-Do not change the bootstrap account email address — doing so causes authentication failures.
+Don't change the bootstrap account email address — doing so causes authentication failures.
 :::
 
 ---
@@ -479,7 +479,7 @@ For certificate-specific issues, see [TLS Certificate Requirements — Troublesh
 | Sign-in silently fails with `PKIX path building failed` in Keycloak logs | CA bundle is missing the LDAPS DC's CA | Concatenate the DC's LDAPS CA into the bundle and re-run the installer |
 | Browser rejects the application URL with a SAN mismatch error | Hostname entered as an IP address, or SAN doesn't include the hostname in use | Use a DNS hostname and verify the cert SAN list |
 | Pods not starting after installation | Outbound HTTPS blocked to one or more required endpoints | Verify connectivity to all domains in [Required Domains](#required-domains) |
-| Installer rejects the hostname | Hostname does not contain a dot — not a valid FQDN | Use a fully qualified domain name such as `analyzer.corp.example.com` |
+| Installer rejects the hostname | Hostname doesn't contain a dot — not a valid FQDN | Use a fully qualified domain name such as `analyzer.corp.example.com` |
 | Installer rejects the Bind DN | UPN format (`user@domain.com`) entered instead of full DN | Use full Distinguished Name format: `CN=user,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
 
 **Useful diagnostic commands:**

--- a/docs/accessanalyzer/2601/install/system/certificates.md
+++ b/docs/accessanalyzer/2601/install/system/certificates.md
@@ -42,7 +42,7 @@ All three files must be in PEM format. When you choose **Bring your own certific
 
 - **Format**: a single PEM file containing one or more `-----BEGIN CERTIFICATE-----` blocks concatenated together.
 - **Must include**:
-  - The CA certificate that signed your **application TLS certificate** (item 1 above).
+  - The CA certificate that signed your **application TLS certificate** (item 1).
   - The CA certificate that signed your **domain controller's LDAPS certificate** — often a different CA in multi-domain or multi-CA environments.
 - **Concatenating multiple CAs** is a simple `cat` on Linux:
 

--- a/docs/accessanalyzer/2601/install/system/certificates.md
+++ b/docs/accessanalyzer/2601/install/system/certificates.md
@@ -8,22 +8,22 @@ sidebar_position: 40
 
 Access Analyzer requires three certificate-related files at install time. This page describes the format of each file, the rules the installer enforces, and common gotchas when preparing them.
 
-All three files must be in PEM format. They are passed to the installer as environment variables or CLI flags.
+All three files must be in PEM format. When choosing **Bring your own certificate** in the installer wizard, you will be prompted to provide the path to each file.
 
 ## Summary
 
-| File | Environment variable | Flag | Purpose |
-| --- | --- | --- | --- |
-| `<hostname>.crt` | `TLS_CERT_FILE` | `--tls-cert` | Application TLS certificate (what browsers validate) |
-| `<hostname>.key` | `TLS_KEY_FILE` | `--tls-key` | Private key paired with the certificate |
-| `ca-bundle.crt` | `TLS_CA_BUNDLE_FILE` | `--ca-bundle` | Trusted root CAs (application and LDAPS) |
+| File | Installer Prompt | Purpose |
+| --- | --- | --- |
+| `<hostname>.crt` | TLS Certificate File | Application TLS certificate (what browsers validate) |
+| `<hostname>.key` | TLS Private Key File | Private key paired with the certificate |
+| `ca-bundle.crt` | AD/DC Root CA Bundle Path | Trusted root CAs (application and LDAPS) |
 
 ## 1. Application TLS Certificate (`<hostname>.crt`)
 
 - **Format**: PEM (Base64 certificate block, starting with `-----BEGIN CERTIFICATE-----`).
 - **Issued by**: your internal certificate authority.
 - **Subject Alternative Names (SANs)**: must include **both** the server's hostname (for example, `accessanalyzer.example.com`) **and** the server IP address. Without a matching SAN, browsers reject the connection.
-- **Hostname in SANs must be lowercase.** Browsers normalize hostnames to lowercase during TLS validation, and Keycloak's OIDC issuer URL is derived from `DSPM_HOSTNAME`. If the cert SAN is mixed-case but the issuer URL is lowercased by the browser, sign-in fails with HTTP 401. Always generate certificates using a lowercase hostname in the SAN list.
+- **Hostname in SANs must be lowercase.** Browsers normalize hostnames to lowercase during TLS validation. If the cert SAN is mixed-case, sign-in fails with HTTP 401. Always generate certificates using a lowercase hostname in the SAN list.
 - **Where it's used**: served by Traefik for every browser request to the application URL.
 
 ## 2. Application TLS Private Key (`<hostname>.key`)
@@ -91,6 +91,6 @@ sudo update-ca-certificates
 | --- | --- | --- |
 | Sign-in fails with HTTP 401 after correct credentials | SAN hostname has mixed case, but browser normalized to lowercase | Re-issue the certificate with lowercase hostname in the SAN list |
 | Installer exits with "Failed to read TLS private key" | Key file owned by `root`, installer runs as non-root user | `sudo chown <install-user> /opt/dspm-tls/<hostname>.key` |
-| Web UI loads, IdP login button appears, sign-in fails silently | CA bundle missing the LDAPS CA | Concatenate the DC's LDAPS CA into the bundle; re-run the installer with `--configure-idp-only` |
+| Web UI loads, IdP login button appears, sign-in fails silently | CA bundle missing the LDAPS CA | Concatenate the DC's LDAPS CA into the bundle and re-run the installer |
 | Browser shows "certificate not trusted" | Application CA not distributed to client machines | Distribute the CA to client machines via Group Policy or MDM |
 | "Certificate is valid for X but not for Y" in browser | Cert SAN doesn't include the hostname or IP being used | Re-issue with full SAN list including both DNS name and IP |

--- a/docs/accessanalyzer/2601/install/system/certificates.md
+++ b/docs/accessanalyzer/2601/install/system/certificates.md
@@ -6,9 +6,9 @@ sidebar_position: 40
 
 # TLS Certificate Requirements
 
-Access Analyzer requires three certificate-related files at install time. This page describes the format of each file, the rules the installer enforces, and common gotchas when preparing them.
+Access Analyzer requires three certificate-related files at install time. This page describes the format of each file, the rules the installer enforces, and common pitfalls when preparing them.
 
-All three files must be in PEM format. When choosing **Bring your own certificate** in the installer wizard, you will be prompted to provide the path to each file.
+All three files must be in PEM format. When you choose **Bring your own certificate** in the installer wizard, the wizard prompts you for the path to each file.
 
 ## Summary
 
@@ -24,7 +24,7 @@ All three files must be in PEM format. When choosing **Bring your own certificat
 - **Issued by**: your internal certificate authority.
 - **Subject Alternative Names (SANs)**: must include **both** the server's hostname (for example, `accessanalyzer.example.com`) **and** the server IP address. Without a matching SAN, browsers reject the connection.
 - **Hostname in SANs must be lowercase.** Browsers normalize hostnames to lowercase during TLS validation. If the cert SAN is mixed-case, sign-in fails with HTTP 401. Always generate certificates using a lowercase hostname in the SAN list.
-- **Where it's used**: served by Traefik for every browser request to the application URL.
+- **Where it's used**: Traefik serves it for every browser request to the application URL.
 
 ## 2. Application TLS Private Key (`<hostname>.key`)
 
@@ -50,7 +50,7 @@ All three files must be in PEM format. When choosing **Bring your own certificat
   cat app-ca.crt ldaps-ca.crt > /opt/dspm-tls/ca-bundle.crt
   ```
 
-- **Why two purposes, one file**: the bundle is used by Traefik to secure the application's HTTPS endpoint **and** by Keycloak internally to trust the LDAPS connection to your domain controller.
+- **Why two purposes, one file**: Traefik uses the bundle to secure the application's HTTPS endpoint, **and** Keycloak uses it internally to trust the LDAPS connection to your domain controller.
 
 ## Multi-domain and Multi-CA Environments
 

--- a/docs/accessanalyzer/2601/install/system/network.md
+++ b/docs/accessanalyzer/2601/install/system/network.md
@@ -16,7 +16,7 @@ All outbound traffic uses HTTPS (port 443). The following endpoints must be reac
 | --- | --- | --- | --- |
 | `api.keygen.sh` | Keygen / Licensing | License validation API | Installation and updates |
 | `oci.pkg.keygen.sh` | Keygen / Licensing | Netwrix OCI registry — Helm charts and application images | Installation and updates |
-| `raw.pkg.keygen.sh` | Keygen / Licensing | Installer script download | Installation and updates |
+| `raw.pkg.keygen.sh` | Keygen / Licensing | Installer binary download | Installation and updates |
 | `keygen-dist.c3c9112df8df715f42d1162cdce5dba1.r2.cloudflarestorage.com` | Keygen / Licensing CDN | Keygen artifact storage | Installation and updates |
 | `api.github.com` | GitHub | GitHub API | Installation only |
 | `github.com` | GitHub | Repository and release access | Installation only |
@@ -84,7 +84,7 @@ If an endpoint detection or antivirus product is running on the Access Analyzer 
 | `/usr/local/bin/k3s` | K3s binary |
 
 :::note
-Setting `SKIP_AV_CHECK=true` before running the installer bypasses the antivirus detection prompt, but does not configure exclusions automatically. Configure exclusions manually before running the installer.
+Configure exclusions manually before running the installer. The installer's preflight check detects common antivirus products and will prompt you to confirm exclusions are in place before proceeding.
 :::
 
 ## Firewall Configuration

--- a/docs/accessanalyzer/2601/install/system/network.md
+++ b/docs/accessanalyzer/2601/install/system/network.md
@@ -10,7 +10,7 @@ Access Analyzer requires outbound internet access during installation and operat
 
 ## Outbound Endpoints (Internet)
 
-All outbound traffic uses HTTPS (port 443). The following endpoints must be reachable from the Access Analyzer server:
+All outbound traffic uses HTTPS (port 443). The Access Analyzer server must be able to reach the following endpoints:
 
 | Endpoint | Category | Purpose | When Required |
 | --- | --- | --- | --- |
@@ -30,7 +30,7 @@ All outbound traffic uses HTTPS (port 443). The following endpoints must be reac
 
 ## Internal Ports
 
-These ports are used within the Access Analyzer VM for service-to-service communication:
+Access Analyzer uses these ports within the VM for service-to-service communication:
 
 | Port | Protocol | Service | Description |
 | --- | --- | --- | --- |
@@ -64,7 +64,7 @@ Depending on the connectors you configure, the Access Analyzer VM must also have
 
 ## Proxy Configuration
 
-If outbound traffic is routed through a proxy, set the following environment variables before running the installer:
+If a proxy routes outbound traffic, set the following environment variables before running the installer:
 
 ```bash
 export HTTP_PROXY="http://<PROXY_HOST>:<PROXY_PORT>"
@@ -89,7 +89,7 @@ Configure exclusions manually before running the installer. The installer's pref
 
 ## Firewall Configuration
 
-Allow outbound HTTPS (port 443) to all endpoints listed in the [Outbound Endpoints](#outbound-endpoints-internet) table above. The examples below show how to configure this on common platforms.
+Allow outbound HTTPS (port 443) to all endpoints in the [Outbound Endpoints](#outbound-endpoints-internet) table. The following examples show how to configure this on common platforms.
 
 ### Azure (NSG Rule)
 
@@ -124,7 +124,7 @@ sudo ufw reload
 
 ### Verify Connectivity
 
-After configuring firewall rules, verify that the required endpoints are reachable from the Access Analyzer server:
+After configuring firewall rules, verify that the Access Analyzer server can reach the required endpoints:
 
 ```bash
 curl -I https://oci.pkg.keygen.sh

--- a/docs/accessanalyzer/2601/install/system/requirements.md
+++ b/docs/accessanalyzer/2601/install/system/requirements.md
@@ -20,9 +20,6 @@ The installer enforces absolute minimums via preflight checks — installation i
 | **Medium** | 16 cores | 48 GB | 1 TB SSD | Up to ~5,000 assets |
 | **Large** | 32 cores | 64 GB | 1 TB SSD | 5,000+ assets / enterprise |
 
-:::note
-The `--size` flag scales memory thresholds by the specified multiplier. For example, `--size 2` doubles the minimum and recommended memory requirements enforced by the preflight checks.
-:::
 
 ## Disk Space Requirements
 

--- a/docs/accessanalyzer/2601/install/system/requirements.md
+++ b/docs/accessanalyzer/2601/install/system/requirements.md
@@ -6,11 +6,11 @@ sidebar_position: 10
 
 # Hardware and System Requirements
 
-Access Analyzer is deployed on a single Linux virtual machine. The installer runs preflight checks to validate that your system meets these requirements before installation begins.
+Access Analyzer runs on a single Linux virtual machine. The installer runs preflight checks to validate that your system meets these requirements before installation begins.
 
 ## Deployment Sizing
 
-The installer enforces absolute minimums via preflight checks — installation is blocked if the system falls below these thresholds. Use the **Production Recommended** specifications for customer-facing or enterprise deployments.
+The installer enforces absolute minimums via preflight checks — the installer blocks installation if the system falls below these thresholds. Use the **Production Recommended** specifications for customer-facing or enterprise deployments.
 
 **Absolute installer minimums (enforced by preflight):** 6 vCPUs, 24 GB RAM, 20 GB free disk.
 
@@ -33,7 +33,7 @@ The installer validates free space on the following paths:
 | `/var/log` | 5 GB | System and application logs |
 | `/etc` | 1 GB | Configuration files |
 
-Write access is also verified for `/var`, `/tmp`, and `/etc`.
+The installer also verifies write access for `/var`, `/tmp`, and `/etc`.
 
 ## Operating System
 
@@ -45,7 +45,7 @@ Write access is also verified for `/var`, `/tmp`, and `/etc`.
 
 **Compatible distributions (engineer-validated):** Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are compatible with the installer. Ubuntu is Debian-based, so Debian stable releases are also supported.
 
-**Not supported:** AIX and other non-Linux operating systems are not compatible. The installer requires a 64-bit Linux distribution with kernel capabilities including cgroups v1/v2, Linux namespaces, and overlay filesystem support.
+**Not supported:** AIX and other non-Linux operating systems aren't compatible. The installer requires a 64-bit Linux distribution with kernel capabilities including cgroups v1/v2, Linux namespaces, and overlay filesystem support.
 
 ## Kernel and Container Runtime Requirements
 

--- a/docs/accessanalyzer/2601/install/uninstall.md
+++ b/docs/accessanalyzer/2601/install/uninstall.md
@@ -49,4 +49,4 @@ The service should not be found or should show as inactive.
 
 ## Reinstallation
 
-After uninstalling, you can reinstall Access Analyzer by running the installer again. See [Quick Install](/docs/accessanalyzer/2601/install/quickinstall) or [Install Commands](/docs/accessanalyzer/2601/install/install-commands).
+After uninstalling, you can reinstall Access Analyzer by running the installer again. See [Quick Install](/docs/accessanalyzer/2601/install/quickinstall).

--- a/docs/accessanalyzer/2601/install/uninstall.md
+++ b/docs/accessanalyzer/2601/install/uninstall.md
@@ -6,7 +6,7 @@ sidebar_position: 80
 
 # Uninstalling Access Analyzer
 
-To completely remove Access Analyzer from the system, run the K3s uninstall script provided by the installer.
+To completely remove Access Analyzer from the system, run the K3s uninstall script that the installer provides.
 
 :::warning
 Uninstalling removes all Kubernetes resources, databases, and application data. This action is irreversible. Back up any data you need before proceeding.
@@ -45,7 +45,7 @@ Confirm that K3s is no longer running:
 systemctl status k3s-dspm
 ```
 
-The service should not be found or should show as inactive.
+The service should either not exist or show as inactive.
 
 ## Reinstallation
 


### PR DESCRIPTION
## Summary

- **Quick Install** fully restructured for the new interactive `dspm-installer` wizard — prerequisites checklist, three TLS cert options (self-signed / AD CS / BYOC), prompt reference table, installation complete summary step, direct AD first-admin sign-in, bootstrap account demoted to breakglass
- **`install/identity-provider.md`** and **`install/install-commands.md`** hidden with `draft: true` — both built around the old curl/bash env-var installer; preserved for future IdP work
- **System subsections** cleaned of old CLI flag references (`--size`, `--configure-idp-only`, `SKIP_AV_CHECK`, `DSPM_HOSTNAME`, env var/flag tables in certificates.md)
- **Broken links** to hidden pages fixed across `configurations/identity-provider.md`, `postinstall.md`, and `uninstall.md`

## Test plan

- [ ] Review Quick Install page on dev server at `/docs/accessanalyzer/2601/install/quickinstall`
- [ ] Confirm `identity-provider` and `install-commands` pages no longer appear in sidebar
- [ ] Verify all links resolve — no broken link build errors
- [ ] Review Configuration > Identity Provider page for updated first-admin sign-in flow

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>