### PR TITLE
fix(anchor-update): replace positional diff-pairing with content-based word overlap

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,7 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 # check-anchors.sh requires bash 4+ (associative arrays). On macOS the system
-# bash is 3.2; prefer the Homebrew one if present.
-BASH_EXEC=bash
-if [[ ${BASH_VERSINFO[0]:-0} -lt 4 ]] && [[ -x /opt/homebrew/bin/bash ]]; then
-  BASH_EXEC=/opt/homebrew/bin/bash
-fi
+# bash is 3.2; prefer Homebrew bash if present.
+BASH_EXEC="${HOMEBREW_PREFIX:-/opt/homebrew}/bin/bash"
+[ ! -x "$BASH_EXEC" ] && BASH_EXEC=bash
 "$BASH_EXEC" "$REPO_ROOT/scripts/check-anchors.sh" --staged

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -19,7 +19,7 @@ Before running the installer, confirm the following:
 - [ ] AD/DC Root CA bundle file prepared and placed on the server
 - [ ] Active Directory service account details collected
 - [ ] First admin email address confirmed (must match the AD `mail` attribute exactly)
-- [ ] Netwrix license key on hand
+- [ ] Netwrix license key ready
 
 ### System requirements
 
@@ -134,7 +134,7 @@ Gather these values from your directory team before starting. The installer wiza
 | LDAP URL | Address of your domain controller. Use port 636 (LDAPS, encrypted) — strongly recommended; port 389 (plain LDAP) is available if LDAPS isn't configured | `ldaps://dc.corp.example.com:636` |
 | Bind DN | Full Distinguished Name of a read-only service account | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` |
 | Bind Password | Password for the service account | — |
-| Users Base DN | LDAP container where user accounts are stored | `CN=Users,DC=corp,DC=example,DC=com` |
+| Users Base DN | LDAP container that holds user accounts | `CN=Users,DC=corp,DC=example,DC=com` |
 | Email Attribute | LDAP attribute storing the user's email address (usually `mail`) | `mail` |
 | AD/DC Root CA Bundle | Root CA certificate that signed the domain controller's LDAPS certificate. Required for all TLS options | `/opt/dspm-tls/ca-bundle.crt` |
 
@@ -283,7 +283,7 @@ The **Example** column shows representative values for illustration — enter yo
 | LDAP URL | `ldaps://dc.corp.example.com:636` | Use port 636 (LDAPS) — port 389 is available but unencrypted |
 | Bind DN | `CN=svc-dspm,OU=ServiceAccounts,DC=corp,DC=example,DC=com` | Full DN format required — not UPN format |
 | Bind Password | *(your service account password)* | Input is silent — no characters appear |
-| Users Base DN | `CN=Users,DC=corp,DC=example,DC=com` | The LDAP container where user accounts are stored |
+| Users Base DN | `CN=Users,DC=corp,DC=example,DC=com` | The LDAP container that holds user accounts |
 | Email Attribute | `mail` | The LDAP attribute that holds the user's email address |
 | First Admin Email | `admin@corp.example.com` | Must match their AD `mail` attribute exactly, including case |
 | First Admin Name | `Jane Smith` | Used in the UI only |
@@ -461,7 +461,7 @@ This table also appears at [Configuration > Identity Provider > Roles](../config
 | Role | Description |
 | --- | --- |
 | **Administrator** | Full access: system configuration (sources, scans, connectors, application settings) and user management (create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users). |
-| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The bootstrap `admin@dspm.local` account is assigned this role. |
+| **User Admin** | User and role management rights only: create, edit, activate, deactivate, and delete users; assign roles; pre-provision federated users. Does **not** have system configuration rights. The bootstrap `admin@dspm.local` account has this role. |
 | **Viewer** | Read-only access to data and reports. No configuration or user management rights. |
 
 The **User Admin** role provides a dedicated account for user management with no system configuration access — useful for delegating user administration separately from system configuration.

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -78,8 +78,8 @@ The installer offers three ways to provision the server's TLS certificate. Choos
 | Option | What It Does | Best For | What to Prepare |
 | --- | --- | --- | --- |
 | **Generate self-signed** | Installer generates a certificate automatically — no CA involvement | Quick evaluations and proof-of-concept installs. Not for production — browsers will show a security warning | Nothing — installer handles it |
-| **Sign with AD Certificate Services** | Installer generates a CSR and submits it to your organization's AD CS to be signed by your internal Enterprise CA | Enterprise environments where AD CS is already deployed and the server can reach the CA | AD CS must be reachable from the server; an account with certificate enrollment rights |
-| **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS isn't available | Three PEM files — see below |
+| **Sign with AD Certificate Services** | Installer generates a CSR and submits it to your organization's AD CS, where your internal Enterprise CA signs it | Enterprise environments where AD CS is already deployed and the server can reach the CA | AD CS must be reachable from the server; an account with certificate enrollment rights |
+| **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS isn't available | Three PEM files — see [file requirements](#bring-your-own-certificate-file-requirements) |
 
 :::note
 **AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
@@ -163,7 +163,7 @@ cat app-ca.crt ldaps-ca.crt > /opt/dspm-tls/ca-bundle.crt
 
 ### First admin account
 
-Identify the email address and display name of the person who will be the first administrator. The installer prompts for both values during setup and provisions the account automatically. That person signs in using their Active Directory password — no separate password is needed.
+Identify the email address and display name of the person who will be the first administrator. The installer prompts for both values during setup and provisions the account automatically. That person signs in using their Active Directory password and doesn't need a separate one.
 
 The email address must match the `mail` attribute of the person's Active Directory account exactly, including case.
 
@@ -261,7 +261,7 @@ rm -f "$TMP_FILE"
 dspm-installer --version
 ```
 
-If this returns a version number, the binary is ready. If it returns an error, the download failed — verify your license key is correct and that the server has outbound access to all required domains listed earlier.
+If this returns a version number, the binary is ready. If it returns an error, the download failed — verify your license key is correct and that the server has outbound access to all [required domains](#required-domains).
 
 ### Step 4: Run the installer
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -85,7 +85,7 @@ The installer offers three ways to provision the server's TLS certificate. Choos
 **AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
 :::
 
-#### Bring your own certificate — file requirements
+#### Bring your own certificate file requirements
 
 If you selected **Bring your own certificate**, prepare the following three files and place them in `/opt/dspm-tls/` on the server before running the installer:
 

--- a/scripts/test-anchor-update.sh
+++ b/scripts/test-anchor-update.sh
@@ -58,7 +58,7 @@ git commit -q -m "fix(vale): auto-fix substitutions and removals"
 
 # Run the anchor update function
 source "$SCRIPT_DIR/vale-autofix.sh" --test
-update_heading_anchors
+update_heading_anchors HEAD~1
 
 # Verify: guide.md should have updated anchor
 PASS=0

--- a/scripts/vale-autofix.sh
+++ b/scripts/vale-autofix.sh
@@ -38,131 +38,111 @@ _get_product_version_folder() {
   fi
 }
 
-_process_heading_pairs() {
-  local file="$1"
-  local -n _old="$2"
-  local -n _new="$3"
-  local updates=0
-
-  if [ -z "$file" ] || [ ${#_old[@]} -eq 0 ] || [ ${#_new[@]} -eq 0 ]; then
-    echo 0
-    return 0
-  fi
-
-  local count=${#_old[@]}
-  if [ ${#_new[@]} -lt "$count" ]; then
-    count=${#_new[@]}
-  fi
-
-  local folder
-  folder=$(_get_product_version_folder "$file")
-
-  if [ ! -d "$folder" ]; then
-    echo 0
-    return 0
-  fi
-
-  for ((i = 0; i < count; i++)); do
-    local old_slug new_slug
-    old_slug=$(slugify "${_old[$i]}")
-    new_slug=$(slugify "${_new[$i]}")
-
-    if [ "$old_slug" = "$new_slug" ] || [ -z "$old_slug" ] || [ -z "$new_slug" ]; then
-      continue
-    fi
-
-    # Replace #old-slug with #new-slug in all .md files in the folder
-    find "$folder" -name '*.md' -exec \
-      sed -i "s|#${old_slug}\([) ]\)|#${new_slug}\1|g" {} +
-
-    updates=$((updates + 1))
+_word_overlap_score() {
+  local old_heading="$1" new_heading="$2"
+  local old_slug new_slug
+  old_slug=$(slugify "$old_heading")
+  new_slug=$(slugify "$new_heading")
+  [ "$old_slug" = "$new_slug" ] && echo 100 && return
+  local -a ow nw
+  IFS='-' read -ra ow <<< "$old_slug"
+  IFS='-' read -ra nw <<< "$new_slug"
+  local intersect=0 word nword
+  for word in "${ow[@]}"; do
+    [ -z "$word" ] && continue
+    for nword in "${nw[@]}"; do
+      [ -z "$nword" ] && continue
+      if [ "$word" = "$nword" ]; then intersect=$((intersect + 1)); break; fi
+    done
   done
-
-  echo "$updates"
-  return 0
+  local maxlen=${#ow[@]}
+  [ ${#nw[@]} -gt "$maxlen" ] && maxlen=${#nw[@]}
+  [ "$maxlen" -eq 0 ] && echo 0 && return
+  echo $(( (intersect * 100) / maxlen ))
 }
 
 update_heading_anchors() {
-  local base_ref="${1:-}"
+  local base_ref="${1:-HEAD}"
   local files_list="${2:-}"
-  local diff_output
-
+  local -a files=()
   if [ -n "$files_list" ] && [ -f "$files_list" ]; then
-    local files=()
     mapfile -t files < "$files_list"
-    if [ ${#files[@]} -eq 0 ]; then
-      return 0
-    fi
-    diff_output=$(git diff "${base_ref}" -- "${files[@]}" 2>/dev/null || true)
-  elif [ -n "$base_ref" ]; then
-    diff_output=$(git diff "${base_ref}" -- '*.md' 2>/dev/null || true)
   else
-    diff_output=$(git diff HEAD -- '*.md' 2>/dev/null || true)
+    mapfile -t files < <(git diff --name-only "${base_ref}" -- '*.md' 2>/dev/null || true)
   fi
+  [ ${#files[@]} -eq 0 ] && return 0
 
-  if [ -z "$diff_output" ]; then
-    return 0
-  fi
-
-  local current_file=""
-  local old_headings=()
-  local new_headings=()
-  local in_hunk=0
   local anchor_updates=0
+  local file
+  for file in "${files[@]}"; do
+    [ -f "$file" ] || continue
+    local base_content
+    base_content=$(git show "${base_ref}:${file}" 2>/dev/null || true)
+    [ -z "$base_content" ] && continue
 
-  while IFS= read -r line; do
-    if [[ "$line" =~ ^diff\ --git\ a/(.*\.md)\ b/ ]]; then
-      # Process pending heading pairs from previous file
-      if [ -n "$current_file" ] && [ ${#old_headings[@]} -gt 0 ] && [ ${#new_headings[@]} -gt 0 ]; then
-        local _pair_result
-        _pair_result=$(_process_heading_pairs "$current_file" old_headings new_headings)
-        anchor_updates=$((anchor_updates + _pair_result))
+    local -a old_h=() new_h=()
+    local line in_fence=0
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^(\`{3,}|~{3,}) ]]; then
+        in_fence=$(( 1 - in_fence )); continue
       fi
-      current_file="${BASH_REMATCH[1]}"
-      old_headings=()
-      new_headings=()
-      in_hunk=0
-      continue
-    fi
-
-    if [[ "$line" =~ ^@@ ]]; then
-      if [ -n "$current_file" ] && [ ${#old_headings[@]} -gt 0 ] && [ ${#new_headings[@]} -gt 0 ]; then
-        local _pair_result
-        _pair_result=$(_process_heading_pairs "$current_file" old_headings new_headings)
-        anchor_updates=$((anchor_updates + _pair_result))
+      [ "$in_fence" -eq 0 ] && [[ "$line" =~ ^#{1,6}[[:space:]] ]] && old_h+=("$line")
+    done <<< "$base_content"
+    in_fence=0
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^(\`{3,}|~{3,}) ]]; then
+        in_fence=$(( 1 - in_fence )); continue
       fi
-      old_headings=()
-      new_headings=()
-      in_hunk=1
-      continue
-    fi
+      [ "$in_fence" -eq 0 ] && [[ "$line" =~ ^#{1,6}[[:space:]] ]] && new_h+=("$line")
+    done < "$file"
 
-    if [ "$in_hunk" -eq 0 ]; then
-      continue
-    fi
+    local -a removed=() added=()
+    local h match n o
+    for h in "${old_h[@]}"; do
+      match=0
+      for n in "${new_h[@]}"; do [ "$h" = "$n" ] && match=1 && break; done
+      [ "$match" -eq 0 ] && removed+=("$h")
+    done
+    for h in "${new_h[@]}"; do
+      match=0
+      for o in "${old_h[@]}"; do [ "$h" = "$o" ] && match=1 && break; done
+      [ "$match" -eq 0 ] && added+=("$h")
+    done
+    if [ ${#removed[@]} -eq 0 ] || [ ${#added[@]} -eq 0 ]; then continue; fi
 
-    # Collect removed headings (lines starting with - then #)
-    if [[ "$line" =~ ^-#{1,6}\ + ]]; then
-      old_headings+=("${line:1}")
-    fi
+    local folder
+    folder=$(_get_product_version_folder "$file")
+    [ -d "$folder" ] || continue
 
-    # Collect added headings (lines starting with + then #)
-    if [[ "$line" =~ ^\+#{1,6}\ + ]]; then
-      new_headings+=("${line:1}")
-    fi
-  done <<< "$diff_output"
+    local -a used_new_idx=()
+    for h in "${removed[@]}"; do
+      local best_score=0 best_idx=-1 best_new="" idx=0 cand
+      for cand in "${added[@]}"; do
+        local already=0 ui
+        for ui in "${used_new_idx[@]}"; do [ "$ui" -eq "$idx" ] && already=1 && break; done
+        if [ "$already" -eq 0 ]; then
+          local score
+          score=$(_word_overlap_score "$h" "$cand")
+          if [ "$score" -gt "$best_score" ]; then
+            best_score=$score; best_idx=$idx; best_new="$cand"
+          fi
+        fi
+        idx=$((idx + 1))
+      done
+      [ "$best_score" -lt 50 ] && continue
+      local old_slug new_slug
+      old_slug=$(slugify "$h")
+      new_slug=$(slugify "$best_new")
+      if [ "$old_slug" != "$new_slug" ] && [ -n "$old_slug" ] && [ -n "$new_slug" ]; then
+        find "$folder" -name '*.md' -exec \
+          sed -i "s|#${old_slug}\([) ]\)|#${new_slug}\1|g" {} +
+        anchor_updates=$((anchor_updates + 1))
+        used_new_idx+=("$best_idx")
+      fi
+    done
+  done
 
-  # Process final file
-  if [ -n "$current_file" ] && [ ${#old_headings[@]} -gt 0 ] && [ ${#new_headings[@]} -gt 0 ]; then
-    local _pair_result
-    _pair_result=$(_process_heading_pairs "$current_file" old_headings new_headings)
-    anchor_updates=$((anchor_updates + _pair_result))
-  fi
-
-  if [ "$anchor_updates" -gt 0 ]; then
-    echo "Updated $anchor_updates anchor link(s)"
-  fi
-
+  [ "$anchor_updates" -gt 0 ] && echo "Updated $anchor_updates anchor link(s)"
   return 0
 }
 


### PR DESCRIPTION
The old algorithm collected removed/added headings from diff hunks and paired them by array index, which broke on restructured files where the old[N] and new[N] heading at the same position are unrelated.  It also had no code-fence tracking, so bash comments inside fenced blocks were treated as markdown headings.

The new algorithm:
- Reads the base and current versions of each file directly (git show vs working tree) instead of parsing the diff stream
- Extracts headings with code-fence tracking so shell comments inside code blocks are ignored
- Computes set difference to identify removed/added headings
- Matches removed→added pairs using word-overlap scoring on slugified words (Jaccard-style: |intersection|/max(|old|,|new|))
- Only updates anchors when score ≥ 50; unmatched headings are left for check-anchors.sh to report

Generated with AI