### PR TITLE
docs(npsd): Container-Based Deployment guide + installation sidebar updates

### DIFF
--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/_category_.json
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Container-Based Deployment",
+  "position": 50,
+  "collapsed": true,
+  "collapsible": true
+}

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/_category_.json
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Container-Based Deployment",
-  "position": 50,
+  "position": 10,
   "collapsed": true,
   "collapsible": true
 }

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -51,7 +51,7 @@ A `Login Succeeded` message confirms the authentication was successful.
 
 :::note
 The ECR login token expires after 12 hours. If a deployment or upgrade fails with an authentication
-error, re-run the login command above before retrying.
+error, re-run the login command before retrying.
 :::
 
 :::tip

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -1,0 +1,47 @@
+---
+title: "AWS Configuration"
+description: "Configure AWS CLI credentials to authenticate with the Netwrix ECR container registry"
+sidebar_position: 30
+---
+
+# AWS Configuration
+
+NPS-D container images are hosted in a private Amazon Elastic Container Registry (ECR). Each Ubuntu
+machine in the deployment must be authenticated with ECR before `secureone.sh` can pull images.
+
+Complete these steps on every node — primary and secondary — before running the deployment script.
+
+## Configure AWS Credentials
+
+Run the following command and follow the prompts to enter the AWS Access Key ID, Secret Access Key,
+and region. Use the credentials provided to you by Netwrix support or your internal deployment team.
+
+```bash
+aws configure
+```
+
+When prompted:
+
+| Field | Value |
+|---|---|
+| AWS Access Key ID | `<access-key-id>` |
+| AWS Secret Access Key | `<secret-access-key>` |
+| Default region name | `us-west-2` |
+| Default output format | `json` |
+
+## Log In to ECR
+
+After configuring credentials, authenticate Docker with the Netwrix ECR registry:
+
+```bash
+aws ecr get-login-password --region us-west-2 | \
+  sudo docker login --username AWS --password-stdin \
+  176947481038.dkr.ecr.us-west-2.amazonaws.com
+```
+
+A `Login Succeeded` message confirms the authentication was successful.
+
+:::note
+The ECR login token expires after 12 hours. If a deployment or upgrade fails with an authentication
+error, re-run the login command above before retrying.
+:::

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -51,3 +51,9 @@ A `Login Succeeded` message confirms the authentication was successful.
 The ECR login token expires after 12 hours. If a deployment or upgrade fails with an authentication
 error, re-run the login command above before retrying.
 :::
+
+:::tip
+To avoid storing Docker credentials as base64-encoded text in `~/.docker/config.json`, set up an
+encrypted credential store. See [Docker Credentials Helper](../dockercredentials.md) for
+instructions.
+:::

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -11,10 +11,16 @@ machine in the deployment must be authenticated with ECR before `secureone.sh` c
 
 Complete these steps on every node — primary and secondary — before running the deployment script.
 
+:::note
+The AWS Access Key ID and Secret Access Key required for this step are provided by Netwrix Support
+as part of the deployment onboarding process. Contact Netwrix Support if you have not received your
+credentials.
+:::
+
 ## Configure AWS Credentials
 
 Run the following command and follow the prompts to enter the AWS Access Key ID, Secret Access Key,
-and region. Use the credentials provided to you by Netwrix support or your internal deployment team.
+and region. Use the credentials provided to you by Netwrix Support.
 
 ```bash
 aws configure

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -23,6 +23,7 @@ Run the following command and follow the prompts to enter the AWS Access Key ID,
 and region. Use the credentials provided to you by Netwrix Support.
 
 ```bash
+# Configure AWS:
 aws configure
 ```
 
@@ -40,6 +41,7 @@ When prompted:
 After configuring credentials, authenticate Docker with the Netwrix ECR registry:
 
 ```bash
+# Log in to ECR:
 aws ecr get-login-password --region us-west-2 | \
   sudo docker login --username AWS --password-stdin \
   176947481038.dkr.ecr.us-west-2.amazonaws.com

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -6,14 +6,14 @@ sidebar_position: 30
 
 # AWS Configuration
 
-NPS-D container images are hosted in a private Amazon Elastic Container Registry (ECR). Each Ubuntu
-machine in the deployment must be authenticated with ECR before `secureone.sh` can pull images.
+NPS-D container images are hosted in a private Amazon Elastic Container Registry (ECR). You must
+authenticate each Ubuntu machine in the deployment with ECR before `secureone.sh` can pull images.
 
 Complete these steps on every node — primary and secondary — before running the deployment script.
 
 :::note
-The AWS Access Key ID and Secret Access Key required for this step are provided by Netwrix Support
-as part of the deployment onboarding process. Contact Netwrix Support if you have not received your
+Netwrix Support provides the AWS Access Key ID and Secret Access Key required for this step as part
+of the deployment onboarding process. Contact Netwrix Support if you have not received your
 credentials.
 :::
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -6,7 +6,7 @@ sidebar_position: 30
 
 # AWS Configuration
 
-NPS-D container images are hosted in a private Amazon Elastic Container Registry (ECR). You must
+Netwrix hosts NPS-D container images in a private Amazon Elastic Container Registry (ECR). You must
 authenticate each Ubuntu machine in the deployment with ECR before `secureone.sh` can pull images.
 
 Complete these steps on every node — primary and secondary — before running the deployment script.

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -53,7 +53,7 @@ error, re-run the login command above before retrying.
 :::
 
 :::tip
-To avoid storing Docker credentials as base64-encoded text in `~/.docker/config.json`, set up an
-encrypted credential store. See [Docker Credentials Helper](../dockercredentials.md) for
+For enhanced security, store Docker credentials in an encrypted credential store instead of the
+default configuration file. See [Docker Credentials Helper](../dockercredentials.md) for
 instructions.
 :::

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -48,14 +48,25 @@ unzip privilegesecure-discovery-quickstart-<version>.zip
 Both files are extracted into the current directory (`~/`). The setup script looks for
 `secureone.tar.gz` in the directory it is run from, so keep both files together in `~/`.
 
-For a **cluster deployment**, copy both extracted files to each secondary node before proceeding:
+For a **cluster deployment**, distribute the files to each secondary node. Use whichever method
+is more convenient:
+
+**Option A — copy from the primary node using `scp`:**
 
 ```bash
 scp secureone.sh secureone.tar.gz <user>@<secondary-node-ip>:~/
 ```
 
-Repeat for each secondary node. Both files must be present in the home directory on every node
-before you run the setup script.
+**Option B — download directly on each secondary node:**
+
+```bash
+cd ~
+wget https://releases.netwrix.com/products/privilegesecure-discovery/<major.minor>/privilegesecure-discovery-quickstart-<version>.zip
+unzip privilegesecure-discovery-quickstart-<version>.zip
+```
+
+Repeat for each secondary node. Both files must be present in the home directory (`~/`) on every
+node before you run the setup script.
 
 :::note
 The setup script creates the `/secureone/` directory on the server to store the deployment

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -235,6 +235,18 @@ sudo -E bash secureone.sh deploy --version 2.23.0
 sudo -E bash secureone.sh teardown
 ```
 
+### Post-Deploy Checks
+
+```bash
+docker stack services s1          # replica counts and image versions
+docker stack ps s1                # per-task state across all nodes
+docker service logs s1_api -f     # live API logs
+curl -sk https://localhost/api/v1/health
+```
+
+See [Verify the Deployment](./verifydeployment.md) for a full health checklist and
+troubleshooting guide.
+
 ## Installation Directory
 
 After `setup` completes, all deployment files are under `/secureone/`:

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -133,6 +133,22 @@ sudo -E bash secureone.sh deploy --version <version>
 
 Docker Swarm performs a rolling update of any changed services.
 
+## Full Reset Before a Reinstall
+
+:::warning
+`teardown` is a destructive operation. It removes the running stack, stops all containers, leaves
+the swarm, and deletes `/secureone` and `~/secureone.tar.gz`. All data in the MongoDB volume is
+lost. Run this only when you intend to fully reinstall the deployment.
+:::
+
+Run on the primary node (and repeat on each secondary node if it is a cluster):
+
+```bash
+sudo -E bash secureone.sh teardown
+```
+
+After teardown, follow the full installation steps from [Step 1](#step-1-download-the-quickstart-bundle) to redeploy.
+
 ## Script Reference
 
 ### Commands

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -153,17 +153,38 @@ After teardown, follow the full installation steps from [Step 1](#step-1-downloa
 
 ### Commands
 
-| Command | Description |
-|---|---|
-| `setup` | Guided initial setup for this node. Installs Docker if missing, configures the network, initializes Swarm, pulls images, creates the encryption secret, deploys the stack, runs DB migrations, and sets the default user. |
-| `setup --cluster --primary` | Cluster primary setup. Same as above, then labels nodes and initializes the MongoDB replica set. |
-| `setup --cluster --join-token <token>` | Join an existing cluster swarm as a manager after network setup. |
-| `upgrade --version <tag>` | Upgrade all services to a new version. Pins the API to the manager node, pulls new images, performs a rolling update, runs migrations, then unpins the API. |
-| `deploy --version <tag>` | Re-deploy the stack from `/secureone/docker-stack.yml`. Safe to re-run — Swarm rolling-updates changed services. |
-| `generate-join-token` | Print the exact join command for secondary nodes. Run on the primary after `setup --cluster --primary`. |
-| `promote` | Promote all worker nodes to managers. Run on the primary after all secondary nodes have joined. Safe to re-run. |
-| `init` | Initialize Docker Swarm on this node (primary only). Called automatically by `setup` — only use standalone if you need to re-initialize the swarm without repeating full setup. |
-| `teardown` | Destructive reset. Removes the running stack, stops all containers, leaves the swarm, and deletes `/secureone` and `~/secureone.tar.gz`. |
+**`setup`** — Interactive guided setup for this node. Installs Docker if missing, extracts the
+tarball, sets the hostname, and reconfigures the Docker bridge network. Behavior depends on the
+options passed:
+
+- **Single-node** — initializes Swarm, pulls images, creates the encryption secret, deploys the
+  stack, runs DB migrations, and sets the default user.
+- **Cluster primary** (`--cluster --primary`) — same as single-node, then labels nodes and
+  initializes the MongoDB replica set.
+- **Cluster secondary** (`--cluster --join-token`) — reconfigures the network, then joins the
+  swarm using the provided join token.
+
+**`upgrade --version <tag>`** — Upgrade all services to a new version. Pins the API to the
+manager node, pulls the new images, performs a rolling update, runs DB migrations, then unpins
+the API.
+
+**`deploy --version <tag>`** — Deploy or re-deploy the Docker stack from
+`/secureone/docker-stack.yml`. Safe to re-run — Docker Swarm rolling-updates any changed
+services. Waits 30 seconds then prints service status.
+
+**`generate-join-token`** — Print the exact command to run on each secondary node to join the
+swarm. Run on the primary node after `setup --cluster --primary`.
+
+**`promote`** — Promote all worker nodes in the swarm to managers. Run on the primary node after
+all secondary nodes have joined. Safe to re-run — nodes already at manager role are skipped.
+
+**`init`** — Initialize Docker Swarm on this node (primary only). Called automatically by
+`setup` — only run standalone if you need to re-initialize the swarm without repeating full
+setup.
+
+**`teardown`** — Destructive reset of this node. Removes the running stack, stops all containers,
+leaves the swarm, and deletes `/secureone` and `~/secureone.tar.gz`. Prompts you to reset
+secondary nodes manually.
 
 ### Options
 
@@ -171,9 +192,15 @@ After teardown, follow the full installation steps from [Step 1](#step-1-downloa
 |---|---|
 | `--cluster` | Treat this node as part of a cluster deployment. |
 | `--primary` | Treat this node as the cluster primary. Requires `--cluster`. |
-| `--join-token <TOKEN@HOST:PORT>` | Manager join token from `generate-join-token`. Requires `--cluster`. |
-| `--version <tag>` | Image tag to pull and deploy (for example `2.22.14`). Required for `setup`, `upgrade`, and `deploy`. |
+| `--join-token <TOKEN@HOST:PORT>` | Manager join token from `generate-join-token`. Requires `--cluster`. The node joins the swarm as a manager after network setup. |
+| `--version <tag>` | Image tag to pull and deploy (for example `2.22.14`). Required for commands that pull images: `setup` and `upgrade`. |
 | `-h`, `--help` | Show help and exit. |
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `S1_TARBALL_URL` | URL to download `secureone.tar.gz` instead of looking for it in the current directory. Useful when the tarball is hosted on an internal server. |
 
 ## Installation Directory
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -147,7 +147,7 @@ Run on the primary node (and repeat on each secondary node if it is a cluster):
 sudo -E bash secureone.sh teardown
 ```
 
-After teardown, follow the full installation steps from the [beginning of this page](#download-and-deploy) to redeploy.
+After teardown, follow the full installation steps from Step 1 to redeploy.
 
 ## Script Reference
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -1,0 +1,117 @@
+---
+title: "Download and Deploy"
+description: "Download the NPS-D quickstart bundle and deploy using secureone.sh"
+sidebar_position: 40
+---
+
+# Download and Deploy
+
+This page covers downloading the NPS-D quickstart bundle from the Netwrix releases server,
+distributing it to all nodes, and running the deployment script.
+
+## Prerequisites
+
+- All nodes have [OS prerequisites](./prerequisites.md) installed
+- All nodes are [authenticated with ECR](./awsconfiguration.md)
+
+## Step 1 — Download the Quickstart Bundle
+
+Download the versioned quickstart archive on the **primary node**. Replace `<version>` and
+`<major.minor>` with the target release, for example `2.22.14` and `2.22`:
+
+```bash
+wget https://releases.netwrix.com/products/privilegesecure-discovery/<major.minor>/privilegesecure-discovery-quickstart-<version>.zip
+```
+
+**Example for 2.22.14:**
+
+```bash
+wget https://releases.netwrix.com/products/privilegesecure-discovery/2.22/privilegesecure-discovery-quickstart-2.22.14.zip
+```
+
+**Example for 26.03.2:**
+
+```bash
+wget https://releases.netwrix.com/products/privilegesecure-discovery/26.03/privilegesecure-discovery-quickstart-26.03.2.zip
+```
+
+## Step 2 — Extract the Bundle
+
+Extract the archive on each node. The zip contains two files: `secureone.sh` and `secureone.tar.gz`.
+
+```bash
+unzip privilegesecure-discovery-quickstart-<version>.zip
+```
+
+For a **cluster deployment**, copy both extracted files to each secondary node before proceeding:
+
+```bash
+scp secureone.sh secureone.tar.gz <user>@<secondary-node-ip>:~/
+```
+
+Repeat for each secondary node. Both files must be present in the home directory on every node
+before you run the setup script.
+
+## Step 3 — Run the Deployment Script
+
+All deployment operations use `secureone.sh`. Run the script as root (with `-E` to preserve
+environment variables including the AWS credentials configured earlier).
+
+### Single-Node Deployment
+
+Run on the single node:
+
+```bash
+sudo -E bash secureone.sh setup
+```
+
+The script installs Docker if missing, extracts the configuration package, initializes Docker Swarm,
+pulls images, creates the encryption secret, deploys the stack, runs database migrations, and sets
+the default user.
+
+### Three-Node Cluster Deployment
+
+**On the primary node:**
+
+```bash
+sudo -E bash secureone.sh setup --cluster --primary
+```
+
+Follow the prompts. The script initializes the swarm, deploys the stack, and then outputs the exact
+command to run on secondary nodes.
+
+**On each secondary node** (use the command output by the primary):
+
+```bash
+sudo -E bash secureone.sh setup --cluster --join-token <TOKEN@HOST:PORT>
+```
+
+After all secondary nodes have joined the swarm, promote them to managers from the primary node:
+
+```bash
+sudo -E bash secureone.sh promote
+```
+
+## Upgrade an Existing Deployment
+
+To upgrade to a new version, run on the primary node:
+
+```bash
+sudo -E bash secureone.sh upgrade --version <version>
+```
+
+The script pins the API to the manager node, pulls the new images, performs a rolling update,
+runs database migrations, then unpins the API.
+
+## Common Script Commands
+
+| Command | Description |
+|---|---|
+| `setup` | Guided initial setup for this node |
+| `setup --cluster --primary` | Initial setup for a cluster primary node |
+| `setup --cluster --join-token <token>` | Join an existing cluster swarm |
+| `upgrade --version <tag>` | Upgrade all services to a new version |
+| `deploy --version <tag>` | Re-deploy the stack after a configuration change |
+| `generate-join-token` | Print the join command for secondary nodes |
+| `promote` | Promote all worker nodes to managers |
+| `teardown` | Full destructive reset of this node |

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -147,7 +147,7 @@ Run on the primary node (and repeat on each secondary node if it is a cluster):
 sudo -E bash secureone.sh teardown
 ```
 
-After teardown, follow the full installation steps from [Step 1](#step-1-download-the-quickstart-bundle) to redeploy.
+After teardown, follow the full installation steps from the [beginning of this page](#download-and-deploy) to redeploy.
 
 ## Script Reference
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -45,8 +45,8 @@ Extract the archive. The zip contains two files: `secureone.sh` and `secureone.t
 unzip privilegesecure-discovery-quickstart-<version>.zip
 ```
 
-Both files are extracted into the current directory (`~/`). The setup script looks for
-`secureone.tar.gz` in the directory it is run from, so keep both files together in `~/`.
+The unzip command extracts both files into the current directory (`~/`). The setup script looks
+for `secureone.tar.gz` in the directory you run it from, so keep both files together in `~/`.
 
 For a **cluster deployment**, distribute the files to each secondary node. Use whichever method
 is more convenient:
@@ -70,14 +70,14 @@ node before you run the setup script.
 
 :::note
 The setup script creates the `/secureone/` directory on the server to store the deployment
-configuration, stack files, data volumes, and logs. This is separate from `~/` where the
-quickstart files are downloaded.
+configuration, stack files, data volumes, and logs. This is separate from `~/` where you
+downloaded the quickstart files.
 :::
 
 ## Step 3 — Run the Deployment Script
 
 All deployment operations use `secureone.sh`. Run the script as root (with `-E` to preserve
-environment variables including the AWS credentials configured earlier).
+environment variables including the AWS credentials you configured earlier).
 
 ### Single-Node Deployment
 
@@ -137,8 +137,8 @@ Docker Swarm performs a rolling update of any changed services.
 
 :::warning
 `teardown` is a destructive operation. It removes the running stack, stops all containers, leaves
-the swarm, and deletes `/secureone` and `~/secureone.tar.gz`. All data in the MongoDB volume is
-lost. Run this only when you intend to fully reinstall the deployment.
+the swarm, and deletes `/secureone` and `~/secureone.tar.gz`. Teardown destroys all data in the
+MongoDB volume. Run this only when you intend to fully reinstall the deployment.
 :::
 
 Run on the primary node (and repeat on each secondary node if it is a cluster):
@@ -169,7 +169,7 @@ sudo -E bash secureone.sh <command> [options]
 
 **`setup`** — Interactive guided setup for this node. Installs Docker if missing, extracts the
 tarball, sets the hostname, and reconfigures the Docker bridge network. Behavior depends on the
-options passed:
+options you pass:
 
 - **Single-node** — initializes Swarm, pulls images, creates the encryption secret, deploys the
   stack, runs DB migrations, and sets the default user.
@@ -190,10 +190,10 @@ services. Waits 30 seconds then prints service status.
 swarm. Run on the primary node after `setup --cluster --primary`.
 
 **`promote`** — Promote all worker nodes in the swarm to managers. Run on the primary node after
-all secondary nodes have joined. Safe to re-run — nodes already at manager role are skipped.
+all secondary nodes have joined. Safe to re-run — the script skips nodes already at manager role.
 
-**`init`** — Initialize Docker Swarm on this node (primary only). Called automatically by
-`setup` — only run standalone if you need to re-initialize the swarm without repeating full
+**`init`** — Initialize Docker Swarm on this node (primary only). The `setup` command calls this
+automatically — only run standalone if you need to re-initialize the swarm without repeating full
 setup.
 
 **`teardown`** — Destructive reset of this node. Removes the running stack, stops all containers,

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -103,15 +103,50 @@ sudo -E bash secureone.sh upgrade --version <version>
 The script pins the API to the manager node, pulls the new images, performs a rolling update,
 runs database migrations, then unpins the API.
 
-## Common Script Commands
+## Re-Deploy After a Configuration Change
+
+```bash
+sudo -E bash secureone.sh deploy --version <version>
+```
+
+Docker Swarm performs a rolling update of any changed services.
+
+## Script Reference
+
+### Commands
 
 | Command | Description |
 |---|---|
-| `setup` | Guided initial setup for this node |
-| `setup --cluster --primary` | Initial setup for a cluster primary node |
-| `setup --cluster --join-token <token>` | Join an existing cluster swarm |
-| `upgrade --version <tag>` | Upgrade all services to a new version |
-| `deploy --version <tag>` | Re-deploy the stack after a configuration change |
-| `generate-join-token` | Print the join command for secondary nodes |
-| `promote` | Promote all worker nodes to managers |
-| `teardown` | Full destructive reset of this node |
+| `setup` | Guided initial setup for this node. Installs Docker if missing, configures the network, initializes Swarm, pulls images, creates the encryption secret, deploys the stack, runs DB migrations, and sets the default user. |
+| `setup --cluster --primary` | Cluster primary setup. Same as above, then labels nodes and initializes the MongoDB replica set. |
+| `setup --cluster --join-token <token>` | Join an existing cluster swarm as a manager after network setup. |
+| `upgrade --version <tag>` | Upgrade all services to a new version. Pins the API to the manager node, pulls new images, performs a rolling update, runs migrations, then unpins the API. |
+| `deploy --version <tag>` | Re-deploy the stack from `/secureone/docker-stack.yml`. Safe to re-run — Swarm rolling-updates changed services. |
+| `generate-join-token` | Print the exact join command for secondary nodes. Run on the primary after `setup --cluster --primary`. |
+| `promote` | Promote all worker nodes to managers. Run on the primary after all secondary nodes have joined. Safe to re-run. |
+| `init` | Initialize Docker Swarm on this node (primary only). Called automatically by `setup` — only use standalone if you need to re-initialize the swarm without repeating full setup. |
+| `teardown` | Destructive reset. Removes the running stack, stops all containers, leaves the swarm, and deletes `/secureone` and `~/secureone.tar.gz`. |
+
+### Options
+
+| Option | Description |
+|---|---|
+| `--cluster` | Treat this node as part of a cluster deployment. |
+| `--primary` | Treat this node as the cluster primary. Requires `--cluster`. |
+| `--join-token <TOKEN@HOST:PORT>` | Manager join token from `generate-join-token`. Requires `--cluster`. |
+| `--version <tag>` | Image tag to pull and deploy (for example `2.22.14`). Required for `setup`, `upgrade`, and `deploy`. |
+| `-h`, `--help` | Show help and exit. |
+
+## Installation Directory
+
+After `setup` completes, all deployment files are under `/secureone/`:
+
+```
+/secureone/
+  docker-stack.yml          Active stack file (single-node or cluster)
+  setup/                    Stack templates and helper scripts
+  data/db/                  MongoDB data volume
+  data/logs/                Application and Fluentd log files
+  conf/fluentd/fluent.conf  Fluentd logging configuration
+  conf/ssl/                 TLS certificate and key
+```

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -16,10 +16,12 @@ distributing it to all nodes, and running the deployment script.
 
 ## Step 1 — Download the Quickstart Bundle
 
-Download the versioned quickstart archive on the **primary node**. Replace `<version>` and
-`<major.minor>` with the target release, for example `2.22.14` and `2.22`:
+Log in to the **primary node** via SSH and run the following command from your **home directory**
+(`~/`). Replace `<version>` and `<major.minor>` with the target release, for example `2.22.14`
+and `2.22`:
 
 ```bash
+cd ~
 wget https://releases.netwrix.com/products/privilegesecure-discovery/<major.minor>/privilegesecure-discovery-quickstart-<version>.zip
 ```
 
@@ -37,11 +39,14 @@ wget https://releases.netwrix.com/products/privilegesecure-discovery/26.03/privi
 
 ## Step 2 — Extract the Bundle
 
-Extract the archive on each node. The zip contains two files: `secureone.sh` and `secureone.tar.gz`.
+Extract the archive. The zip contains two files: `secureone.sh` and `secureone.tar.gz`.
 
 ```bash
 unzip privilegesecure-discovery-quickstart-<version>.zip
 ```
+
+Both files are extracted into the current directory (`~/`). The setup script looks for
+`secureone.tar.gz` in the directory it is run from, so keep both files together in `~/`.
 
 For a **cluster deployment**, copy both extracted files to each secondary node before proceeding:
 
@@ -51,6 +56,12 @@ scp secureone.sh secureone.tar.gz <user>@<secondary-node-ip>:~/
 
 Repeat for each secondary node. Both files must be present in the home directory on every node
 before you run the setup script.
+
+:::note
+The setup script creates the `/secureone/` directory on the server to store the deployment
+configuration, stack files, data volumes, and logs. This is separate from `~/` where the
+quickstart files are downloaded.
+:::
 
 ## Step 3 — Run the Deployment Script
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -214,7 +214,7 @@ secondary nodes manually.
 
 | Variable | Description |
 |---|---|
-| `S1_TARBALL_URL` | URL to download `secureone.tar.gz` instead of looking for it in the current directory. Useful when the tarball is hosted on an internal server. |
+| `S1_TARBALL_URL` | URL to download `secureone.tar.gz` instead of looking for it in the current directory. Useful when the tarball lives on an internal server. |
 
 ### Typical Workflows
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -151,6 +151,20 @@ After teardown, follow the full installation steps from [Step 1](#step-1-downloa
 
 ## Script Reference
 
+### Usage
+
+```
+sudo -E bash secureone.sh <command> [options]
+```
+
+### Prerequisites
+
+- Run as root with `sudo -E` to preserve environment variables (AWS credentials)
+- AWS CLI installed and authenticated with the Netwrix ECR registry (see [AWS Configuration](./awsconfiguration.md))
+- `python3` — installed automatically by `setup` if missing
+- Docker — installed automatically by `setup` if missing
+- Ubuntu 24.04 (other distributions not tested)
+
 ### Commands
 
 **`setup`** — Interactive guided setup for this node. Installs Docker if missing, extracts the
@@ -201,6 +215,25 @@ secondary nodes manually.
 | Variable | Description |
 |---|---|
 | `S1_TARBALL_URL` | URL to download `secureone.tar.gz` instead of looking for it in the current directory. Useful when the tarball is hosted on an internal server. |
+
+### Typical Workflows
+
+```bash
+# Single-node deployment (all-in-one):
+sudo -E bash secureone.sh setup
+
+# Three-node cluster (follow prompts to copy and run commands on secondary nodes):
+sudo -E bash secureone.sh setup --cluster --primary
+
+# Upgrade to a new version (run on the primary node):
+sudo -E bash secureone.sh upgrade --version 2.23.0
+
+# Re-deploy after a config change:
+sudo -E bash secureone.sh deploy --version 2.23.0
+
+# Full reset before a reinstall:
+sudo -E bash secureone.sh teardown
+```
 
 ## Installation Directory
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/overview.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/overview.md
@@ -1,0 +1,38 @@
+---
+title: "Container-Based Deployment Overview"
+description: "Deploy Privilege Secure Discovery on bare Ubuntu machines using the container-based deployment method"
+sidebar_position: 10
+---
+
+# Container-Based Deployment Overview
+
+:::note
+Container-based deployment is available in NPS-D 2.22.14, 26.03.2, or later.
+:::
+
+Container-based deployment lets you deploy Privilege Secure Discovery (NPS-D) on standard Ubuntu
+machines without using the ISO appliance image. The deployment uses a single shell script
+(`secureone.sh`) and a configuration package (`secureone.tar.gz`), both bundled in a versioned
+quickstart archive available on the Netwrix releases server.
+
+This method supports both single-node and three-node high-availability cluster deployments.
+
+## Deployment Steps
+
+1. Prepare Ubuntu machines and install [OS prerequisites](./prerequisites.md).
+2. Configure [AWS credentials](./awsconfiguration.md) on each machine to authenticate with the
+   Netwrix container registry (Amazon ECR).
+3. [Download the quickstart bundle and deploy](./deploysecureone.md) using `secureone.sh`.
+4. [Verify the deployment](./verifydeployment.md) using Docker Swarm monitoring commands.
+
+## Single-Node vs. Cluster
+
+| | Single-node | Cluster |
+|---|---|---|
+| Machines required | 1 | 3 |
+| High availability | No | Yes |
+| Downtime on OS update | Yes | No |
+| MongoDB replication | No | Yes (replica set) |
+
+Use a single-node deployment for proof-of-concept or low-risk environments. Use a three-node
+cluster for production environments that require high availability.

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/overview.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/overview.md
@@ -17,13 +17,20 @@ quickstart archive available on the Netwrix releases server.
 
 This method supports both single-node and three-node high-availability cluster deployments.
 
+The entire deployment process is transparent — the `secureone.sh` script contains all logic with
+no hidden components. The tarball (`secureone.tar.gz`) provides the installation directory
+structure and default configuration files.
+
 ## Deployment Steps
 
-1. Prepare Ubuntu machines and install [OS prerequisites](./prerequisites.md).
-2. Configure [AWS credentials](./awsconfiguration.md) on each machine to authenticate with the
+1. Create one Ubuntu machine (single-node) or three Ubuntu machines (cluster). These can be
+   virtual machines.
+2. Install [OS prerequisites](./prerequisites.md) on each machine.
+3. Configure [AWS credentials](./awsconfiguration.md) on each machine to authenticate with the
    Netwrix container registry (Amazon ECR).
-3. [Download the quickstart bundle and deploy](./deploysecureone.md) using `secureone.sh`.
-4. [Verify the deployment](./verifydeployment.md) using Docker Swarm monitoring commands.
+4. [Download the quickstart bundle](./deploysecureone.md) onto each machine and run `secureone.sh`
+   on the primary machine.
+5. [Verify the deployment](./verifydeployment.md) using Docker Swarm monitoring commands.
 
 ## Single-Node vs. Cluster
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
@@ -35,12 +35,14 @@ sudo install -m 0755 -d /etc/apt/keyrings
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 sudo chmod a+r /etc/apt/keyrings/docker.asc
 
+# Add the repository:
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
   https://download.docker.com/linux/ubuntu \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
+# Install:
 sudo apt-get update
 sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 ```

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
@@ -53,6 +53,7 @@ The AWS Command Line Interface (AWS CLI) is required to authenticate with the Ne
 Container Registry (ECR) and pull NPS-D container images.
 
 ```bash
+# Install unzip:
 sudo apt install unzip
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
@@ -1,0 +1,64 @@
+---
+title: "OS Prerequisites"
+description: "Install operating system prerequisites for container-based NPS-D deployment on Ubuntu"
+sidebar_position: 20
+---
+
+# OS Prerequisites
+
+Prepare each Ubuntu machine before deploying NPS-D. This procedure applies to all nodes — both
+primary and secondary — in a single-node or cluster deployment.
+
+## Requirements
+
+- Ubuntu Server 24.04.4 LTS
+- 1 machine for a single-node deployment, or 3 machines for a cluster
+- Internet access to download packages and container images
+
+## Install SSH
+
+If SSH is not already installed, run:
+
+```bash
+sudo apt install openssh-server
+sudo systemctl enable --now ssh
+```
+
+## Install Docker
+
+Run the following commands to add the Docker repository and install Docker Engine:
+
+```bash
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+  https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+## Install the AWS CLI
+
+The AWS Command Line Interface (AWS CLI) is required to authenticate with the Netwrix Amazon Elastic
+Container Registry (ECR) and pull NPS-D container images.
+
+```bash
+sudo apt install unzip
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update
+```
+
+Repeat these steps on every node in the deployment.
+
+**See also:** [AWS Configuration](./awsconfiguration.md) — configure credentials after installing the
+AWS CLI.

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/prerequisites.md
@@ -17,7 +17,7 @@ primary and secondary — in a single-node or cluster deployment.
 
 ## Install SSH
 
-If SSH is not already installed, run:
+If SSH isn't already installed, run:
 
 ```bash
 sudo apt install openssh-server
@@ -49,7 +49,7 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin 
 
 ## Install the AWS CLI
 
-The AWS Command Line Interface (AWS CLI) is required to authenticate with the Netwrix Amazon Elastic
+You need the AWS Command Line Interface (AWS CLI) to authenticate with the Netwrix Amazon Elastic
 Container Registry (ECR) and pull NPS-D container images.
 
 ```bash

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
@@ -1,6 +1,6 @@
 ---
 title: "Verify the Deployment"
-description: "Verify that NPS-D deployed successfully using Docker Swarm monitoring commands"
+description: "Verify that NPS-D deployed successfully and troubleshoot common issues using Docker Swarm commands"
 sidebar_position: 50
 ---
 
@@ -8,6 +8,17 @@ sidebar_position: 50
 
 After running `secureone.sh setup`, confirm that the deployment is healthy using the commands below.
 All commands run on a swarm manager node.
+
+## Service Overview
+
+The stack name is `s1`. Services differ slightly between single-node and cluster deployments.
+
+**Single-node services:** `api`, `analytics_engine`, `db`, `health_reporter`, `mq`, `worker`,
+`worker-secondary`, `expire`, `fluentd`, `scanner`, `ldapsync`, `internal_api`, `windows-bridge`,
+`windows-bridge-proxy`
+
+**Cluster adds:** `mongo1`, `mongo2`, `mongo3`, `health_reporter1`, `health_reporter2`,
+`health_reporter3` (replacing the single `db` and `health_reporter`)
 
 ## Quick Health Checklist
 
@@ -36,16 +47,37 @@ docker exec -it $(docker ps -q -f name=s1_mq) rabbitmqctl list_queues name messa
 du -sh /secureone/data/*
 ```
 
-## Service Overview
+## Stack and Service Status
 
-The stack name is `s1`. Services differ slightly between single-node and cluster deployments.
+```bash
+# List all services with replica counts and image versions
+docker stack services s1
 
-**Single-node services:** `api`, `analytics_engine`, `db`, `health_reporter`, `mq`, `worker`,
-`worker-secondary`, `expire`, `fluentd`, `scanner`, `ldapsync`, `internal_api`, `windows-bridge`,
-`windows-bridge-proxy`
+# Show all tasks with node placement
+docker stack ps s1
 
-**Cluster adds:** `mongo1`, `mongo2`, `mongo3`, `health_reporter1`, `health_reporter2`,
-`health_reporter3` (replacing the single `db` and `health_reporter`)
+# Filter to only failing or stopped tasks
+docker stack ps s1 | grep -v "Running"
+
+# Inspect a specific service (config, env vars, constraints)
+docker service inspect s1_api --pretty
+
+# Show history and failure messages for a service
+docker service ps s1_api --no-trunc
+```
+
+**Cluster — swarm node status:**
+
+```bash
+# List all nodes
+docker node ls
+
+# Inspect a specific node
+docker node inspect <node-hostname> --pretty
+
+# See which tasks are running on a node
+docker node ps <node-hostname>
+```
 
 ## View Logs
 
@@ -62,12 +94,158 @@ docker service logs s1_fluentd --follow | grep "s1_api"
 docker service logs s1_fluentd --follow | grep "s1_scanner"
 ```
 
-For services that write directly to the json-file driver (`db`, `mq`, `fluentd`):
+For services that write directly to the json-file driver (`db`, `mq`, `fluentd`, and cluster
+`mongo*`):
 
 ```bash
-docker service logs s1_api --follow
 docker service logs s1_db --follow
 docker service logs s1_mq --follow
+docker service logs s1_fluentd --follow
+
+# Cluster MongoDB nodes
+docker service logs s1_mongo1 --follow
+docker service logs s1_mongo2 --follow
+docker service logs s1_mongo3 --follow
+```
+
+Useful log flags:
+
+| Flag | Description |
+|---|---|
+| `--follow` | Stream logs in real time |
+| `--tail 100` | Show only the last N lines |
+| `--timestamps` | Include timestamps |
+| `--no-task-ids` | Cleaner output when multiple replicas |
+
+Log files written to disk by Fluentd are in `/secureone/data/logs/`.
+
+## Exec Into a Container
+
+To run a command or open a shell inside a running container:
+
+```bash
+# Find the container ID for a running service task
+docker ps -q -f name=s1_api
+
+# Open a shell
+docker exec -it $(docker ps -q -f name=s1_api) sh
+docker exec -it $(docker ps -q -f name=s1_db) bash
+
+# Run a one-off command
+docker exec -it $(docker ps -q -f name=s1_api) yarn run migrator up onprem
+```
+
+:::note
+On cluster deployments, each service task may run on a different node. If `docker ps` returns
+nothing for a service, that task isn't running on this node — SSH to the node that hosts it first.
+:::
+
+## MongoDB Health
+
+**Single-node:**
+
+```bash
+# Check DB stats
+docker exec -it $(docker ps -q -f name=s1_db) mongo --eval 'db.stats()'
+
+# Open a full mongo shell
+docker exec -it $(docker ps -q -f name=s1_db) mongo SecureONE
+
+# Count documents in a collection
+docker exec -it $(docker ps -q -f name=s1_db) mongo SecureONE --eval 'db.systems.count()'
+```
+
+**Cluster — replica set health:**
+
+```bash
+# Check replica set status
+docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.status()'
+
+# Confirm who is PRIMARY
+docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.isMaster()'
+
+# Check replication lag
+docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.printSlaveReplicationInfo()'
+```
+
+The replica set is named `secureone` with members `mongo1:27017`, `mongo2:27017`, `mongo3:27017`.
+All three must be running before the API will connect.
+
+## RabbitMQ (Message Queue)
+
+```bash
+# Open a shell in the mq container
+docker exec -it $(docker ps -q -f name=s1_mq) bash
+
+# List queues and message counts
+rabbitmqctl list_queues name messages consumers
+
+# Check node health
+rabbitmqctl status
+```
+
+A large message count in the `hello` queue with no consumers usually means `worker` or `scanner`
+is down.
+
+## Connectivity Checks
+
+```bash
+# Is the API responding over HTTPS?
+curl -sk https://localhost:443/api/v1/health
+curl -sk https://localhost:443/api/v1/_internal/health-report
+
+# Confirm ports 443 and 80 are bound
+ss -tlnp | grep -E '443|80|5672|24224'
+```
+
+From inside a container:
+
+```bash
+# Check API can reach MongoDB
+docker exec -it $(docker ps -q -f name=s1_api) sh -c \
+  'curl -s http://db:27017 || echo "no route to db"'
+
+# Check RabbitMQ is reachable
+docker exec -it $(docker ps -q -f name=s1_api) sh -c \
+  'nc -zv mq 5672 && echo "mq reachable"'
+```
+
+## Resource Usage
+
+```bash
+# Real-time CPU and memory for all s1 containers
+docker stats $(docker ps -q -f name=s1)
+
+# One-shot snapshot (no streaming)
+docker stats --no-stream $(docker ps -q -f name=s1)
+
+# Disk usage
+du -sh /secureone/data/db/
+du -sh /secureone/data/logs/
+```
+
+Log file size limits configured by Fluentd:
+
+| Component | Limit |
+|---|---|
+| `fluentd` container | 1 GB × 3 files |
+| `db` / `mongo*` | 500 MB × 3 files |
+| `mq` | 100 MB × 1 file |
+
+## Restart a Service
+
+```bash
+# Force a rolling restart
+docker service update --force s1_api
+
+# Scale down then back up (hard restart)
+docker service scale s1_api=0
+docker service scale s1_api=1
+
+# Remove and redeploy the entire stack (use with caution)
+docker stack rm s1
+# Wait for all containers to stop, then redeploy:
+docker stack deploy -c /secureone/docker-stack.yml s1
 ```
 
 ## Common Failure Patterns
@@ -77,6 +255,11 @@ docker service logs s1_mq --follow
 ```bash
 docker service ps s1_<service> --no-trunc
 ```
+
+**`health_reporter` keeps restarting:**
+
+It waits for `api:3000` to be ready before starting. If it loops, the API itself is unhealthy —
+check `s1_api` logs first.
 
 **`fluentd` is down — multiple services fail to start:**
 
@@ -94,22 +277,16 @@ docker service ps s1_fluentd --no-trunc
 docker exec -it $(docker ps -q -f name=s1_api) yarn run migrator up onprem
 ```
 
+If migrations fail, check `s1_api` logs for the specific migration that failed before taking
+further action.
+
 **Cluster: API can't connect to MongoDB:**
 
-Confirm all three mongo tasks are running and the replica set has a PRIMARY:
+The API connects to all three replicas:
+`mongodb://mongo1:27017,mongo2:27017,mongo3:27017/SecureONE?replicaSet=secureone`
 
-```bash
-docker stack ps s1 | grep mongo
-docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.status()'
-```
+Confirm that:
 
-## Restart a Service
-
-```bash
-# Force a rolling restart
-docker service update --force s1_api
-
-# Scale down then back up
-docker service scale s1_api=0
-docker service scale s1_api=1
-```
+1. All three mongo tasks are running: `docker stack ps s1 | grep mongo`
+2. The replica set has a PRIMARY: `docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.status()'`
+3. Node labels are set: `docker node ls` and `docker node inspect <node>`

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
@@ -58,6 +58,16 @@ docker stack ps s1
 
 # Filter to only failing or stopped tasks
 docker stack ps s1 | grep -v "Running"
+docker stack ps s1 --filter "desired-state=shutdown"
+
+# Check replica counts across all services at a glance
+docker service ls --filter "name=s1"
+
+# Show all tasks (current and historical) for a specific service
+docker service ps s1_api
+
+# Show only running tasks for a specific service
+docker service ps s1_api --filter "desired-state=running"
 
 # Inspect a specific service (config, env vars, constraints)
 docker service inspect s1_api --pretty
@@ -117,7 +127,12 @@ Useful log flags:
 | `--timestamps` | Include timestamps |
 | `--no-task-ids` | Cleaner output when multiple replicas |
 
-Log files written to disk by Fluentd are in `/secureone/data/logs/`.
+To read log files written to disk by Fluentd:
+
+```bash
+ls /secureone/data/logs/
+tail -f /secureone/data/logs/<logfile>
+```
 
 ## Exec Into a Container
 
@@ -253,7 +268,11 @@ docker stack deploy -c /secureone/docker-stack.yml s1
 **Service stuck in "Starting" or restart loop:**
 
 ```bash
+# See the failure history and error messages
 docker service ps s1_<service> --no-trunc
+
+# Check exit codes for stopped containers
+docker inspect $(docker ps -aq -f name=s1_<service>) | grep -A5 '"ExitCode"'
 ```
 
 **`health_reporter` keeps restarting:**

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
@@ -22,7 +22,7 @@ The stack name is `s1`. Services differ slightly between single-node and cluster
 
 ## Quick Health Checklist
 
-Run these commands in sequence to get an at-a-glance picture of system health:
+Run these commands in sequence for a quick view of system health:
 
 ```bash
 # 1. Are all services running with the correct replica counts?

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
@@ -6,8 +6,8 @@ sidebar_position: 50
 
 # Verify the Deployment
 
-After running `secureone.sh setup`, confirm that the deployment is healthy using the commands below.
-All commands run on a swarm manager node.
+After running `secureone.sh setup`, confirm that the deployment is healthy using the following
+commands. All commands run on a swarm manager node.
 
 ## Service Overview
 
@@ -125,7 +125,7 @@ Useful log flags:
 | `--timestamps` | Include timestamps |
 | `--no-task-ids` | Cleaner output when multiple replicas |
 
-To read log files written to disk by Fluentd:
+To read log files that Fluentd writes to disk:
 
 ```bash
 ls /secureone/data/logs/
@@ -247,7 +247,7 @@ du -sh /secureone/data/db/
 du -sh /secureone/data/logs/
 ```
 
-Log file size limits configured by Fluentd:
+Fluentd configures these log file size limits:
 
 | Component | Limit |
 |---|---|

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
@@ -1,0 +1,115 @@
+---
+title: "Verify the Deployment"
+description: "Verify that NPS-D deployed successfully using Docker Swarm monitoring commands"
+sidebar_position: 50
+---
+
+# Verify the Deployment
+
+After running `secureone.sh setup`, confirm that the deployment is healthy using the commands below.
+All commands run on a swarm manager node.
+
+## Quick Health Checklist
+
+Run these commands in sequence to get an at-a-glance picture of system health:
+
+```bash
+# 1. Are all services running with the correct replica counts?
+docker stack services s1
+
+# 2. Are any tasks in a failed or shutdown state?
+docker stack ps s1 | grep -v "Running"
+
+# 3. Is the API responding?
+curl -sk https://localhost/api/v1/health
+
+# 4. Is MongoDB up? (single-node)
+docker exec -it $(docker ps -q -f name=s1_db) mongo --eval 'db.stats()'
+
+# 4. Is MongoDB up? (cluster — check replica set)
+docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.isMaster()'
+
+# 5. Is the message queue healthy?
+docker exec -it $(docker ps -q -f name=s1_mq) rabbitmqctl list_queues name messages
+
+# 6. Disk usage
+du -sh /secureone/data/*
+```
+
+## Service Overview
+
+The stack name is `s1`. Services differ slightly between single-node and cluster deployments.
+
+**Single-node services:** `api`, `analytics_engine`, `db`, `health_reporter`, `mq`, `worker`,
+`worker-secondary`, `expire`, `fluentd`, `scanner`, `ldapsync`, `internal_api`, `windows-bridge`,
+`windows-bridge-proxy`
+
+**Cluster adds:** `mongo1`, `mongo2`, `mongo3`, `health_reporter1`, `health_reporter2`,
+`health_reporter3` (replacing the single `db` and `health_reporter`)
+
+## View Logs
+
+Most services use the Fluentd logging driver. Stream aggregated logs from the Fluentd container:
+
+```bash
+docker service logs s1_fluentd --follow
+```
+
+Filter to a specific service:
+
+```bash
+docker service logs s1_fluentd --follow | grep "s1_api"
+docker service logs s1_fluentd --follow | grep "s1_scanner"
+```
+
+For services that write directly to the json-file driver (`db`, `mq`, `fluentd`):
+
+```bash
+docker service logs s1_api --follow
+docker service logs s1_db --follow
+docker service logs s1_mq --follow
+```
+
+## Common Failure Patterns
+
+**Service stuck in "Starting" or restart loop:**
+
+```bash
+docker service ps s1_<service> --no-trunc
+```
+
+**`fluentd` is down — multiple services fail to start:**
+
+Most services use the Fluentd log driver. If Fluentd isn't running, other services can't start.
+Always check Fluentd first when multiple services fail simultaneously:
+
+```bash
+docker service logs s1_fluentd
+docker service ps s1_fluentd --no-trunc
+```
+
+**Migration failures after deploy:**
+
+```bash
+docker exec -it $(docker ps -q -f name=s1_api) yarn run migrator up onprem
+```
+
+**Cluster: API can't connect to MongoDB:**
+
+Confirm all three mongo tasks are running and the replica set has a PRIMARY:
+
+```bash
+docker stack ps s1 | grep mongo
+docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.status()'
+```
+
+## Restart a Service
+
+```bash
+# Force a rolling restart
+docker service update --force s1_api
+
+# Scale down then back up
+docker service scale s1_api=0
+docker service scale s1_api=1
+```

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/verifydeployment.md
@@ -34,11 +34,9 @@ docker stack ps s1 | grep -v "Running"
 # 3. Is the API responding?
 curl -sk https://localhost/api/v1/health
 
-# 4. Is MongoDB up? (single-node)
-docker exec -it $(docker ps -q -f name=s1_db) mongo --eval 'db.stats()'
-
-# 4. Is MongoDB up? (cluster — check replica set)
-docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.isMaster()'
+# 4. Is MongoDB up? (tries single-node first, falls back to cluster)
+docker exec -it $(docker ps -q -f name=s1_db) mongo --eval 'db.stats()' 2>/dev/null \
+  || docker exec -it $(docker ps -q -f name=s1_mongo1) mongo --eval 'rs.isMaster()'
 
 # 5. Is the message queue healthy?
 docker exec -it $(docker ps -q -f name=s1_mq) rabbitmqctl list_queues name messages
@@ -197,6 +195,9 @@ rabbitmqctl list_queues name messages consumers
 
 # Check node health
 rabbitmqctl status
+
+# Check if the 'hello' queue (used by worker, scanner, expire) is backed up
+rabbitmqctl list_queues name messages | grep hello
 ```
 
 A large message count in the `hello` queue with no consumers usually means `worker` or `scanner`
@@ -205,9 +206,12 @@ is down.
 ## Connectivity Checks
 
 ```bash
-# Is the API responding over HTTPS?
+# Check the HTTPS API is responding (ignore self-signed cert)
 curl -sk https://localhost:443/api/v1/health
 curl -sk https://localhost:443/api/v1/_internal/health-report
+
+# HTTP endpoint
+curl -s http://localhost:80/
 
 # Confirm ports 443 and 80 are bound
 ss -tlnp | grep -E '443|80|5672|24224'
@@ -216,13 +220,17 @@ ss -tlnp | grep -E '443|80|5672|24224'
 From inside a container:
 
 ```bash
-# Check API can reach MongoDB
+# From the api container — check it can reach MongoDB
 docker exec -it $(docker ps -q -f name=s1_api) sh -c \
   'curl -s http://db:27017 || echo "no route to db"'
 
-# Check RabbitMQ is reachable
+# Check RabbitMQ is reachable on port 5672
 docker exec -it $(docker ps -q -f name=s1_api) sh -c \
   'nc -zv mq 5672 && echo "mq reachable"'
+
+# Check windows-bridge-proxy
+docker exec -it $(docker ps -q -f name=s1_api) sh -c \
+  'nc -zv windows-bridge-proxy 80 && echo "proxy reachable"'
 ```
 
 ## Resource Usage
@@ -247,11 +255,14 @@ Log file size limits configured by Fluentd:
 | `db` / `mongo*` | 500 MB × 3 files |
 | `mq` | 100 MB × 1 file |
 
+If disk is filling up, check `/secureone/data/logs/` first.
+
 ## Restart a Service
 
 ```bash
 # Force a rolling restart
 docker service update --force s1_api
+docker service update --force s1_worker
 
 # Scale down then back up (hard restart)
 docker service scale s1_api=0

--- a/docs/privilegesecurediscovery/2.22/installation/dellpoweredge.md
+++ b/docs/privilegesecurediscovery/2.22/installation/dellpoweredge.md
@@ -10,6 +10,12 @@ Dell PowerEdge Default iDRAC Password
 
 # Dell PowerEdge Default iDRAC Password
 
+:::warning
+This page applies to legacy NPS-D deployments on Dell PowerEdge hardware appliances. For new
+deployments, use the [Container-Based Deployment](./containerbaseddeployment/overview.md) method,
+which does not require dedicated hardware.
+:::
+
 ## Dell PowerEdge - What is the default username and password for iDRAC?
 
 Source:

--- a/docs/privilegesecurediscovery/2.22/installation/dellpoweredge.md
+++ b/docs/privilegesecurediscovery/2.22/installation/dellpoweredge.md
@@ -13,10 +13,10 @@ Dell PowerEdge Default iDRAC Password
 :::warning
 This page applies to legacy NPS-D deployments on Dell PowerEdge hardware appliances. For new
 deployments, use the [Container-Based Deployment](./containerbaseddeployment/overview.md) method,
-which does not require dedicated hardware.
+which doesn't require dedicated hardware.
 :::
 
-## Dell PowerEdge - What is the default username and password for iDRAC?
+## Dell PowerEdge default iDRAC username and password
 
 Source:
 [https://www.dell.com/support/article/en-us/sln306783/dell-poweredge-what-is-the-default-username-and-password-for-idrac?lang=en](https://www.dell.com/support/article/en-us/sln306783/dell-poweredge-what-is-the-default-username-and-password-for-idrac?lang=en)

--- a/docs/privilegesecurediscovery/2.22/installation/dellpoweredge.md
+++ b/docs/privilegesecurediscovery/2.22/installation/dellpoweredge.md
@@ -1,7 +1,7 @@
 ---
-title: "Dell PowerEdge Default iDRAC Password"
+title: "(RETIRED) Dell PowerEdge Default iDRAC Password"
 description: "Dell PowerEdge Default iDRAC Password"
-sidebar_position: 10
+sidebar_position: 90
 ---
 
 # Dell PowerEdge Default iDRAC Password

--- a/docs/privilegesecurediscovery/2.22/installation/dockercredentials.md
+++ b/docs/privilegesecurediscovery/2.22/installation/dockercredentials.md
@@ -351,7 +351,7 @@ The installer performs these actions:
 - Initializes a local `gopass` store
 - Creates a symlink from the gopass store to `~/.password-store/`
 - Configures Docker with `credsStore: pass`
-- Removes any existing inline Docker `auths` entries unless `--keep-inline-auths` is specified
+- Removes any existing inline Docker `auths` entries unless you specify `--keep-inline-auths`
 
 ### Manual step-by-step path
 
@@ -520,7 +520,7 @@ This validator uses an Ubuntu 24.04 container plus a Docker-in-Docker sidecar an
 
 ## WSL Ubuntu
 
-Use the Ubuntu instructions above inside the WSL distro, with these differences:
+Use the Ubuntu instructions inside the WSL distro, with these differences:
 
 - Use the same installer script:
 
@@ -674,7 +674,7 @@ bash ./scripts/docker-credential-gopass/validate-macos-login.sh
 
 This validator downloads the official `docker-credential-pass` binary, uses a temporary Docker
 config and temporary GPG/gopass home, and confirms that the pre-existing default macOS Docker
-config is left untouched afterward.
+config remains untouched afterward.
 
 **Step 10 –** Validate a passphrase-protected GPG key path:
 

--- a/docs/privilegesecurediscovery/2.22/installation/dockercredentials.md
+++ b/docs/privilegesecurediscovery/2.22/installation/dockercredentials.md
@@ -11,7 +11,7 @@ sidebar_position: 20
 This guide sets up the official `docker-credential-pass` helper from
 [docker/docker-credential-helpers](https://github.com/docker/docker-credential-helpers) with
 `gopass` as the encrypted backend store. Instead of Docker writing base64-encoded credentials into
-`~/.docker/config.json`, credentials are encrypted with GPG and stored through `gopass`.
+`~/.docker/config.json`, GPG encrypts the credentials and `gopass` stores them.
 
 The main operational use case is deploying or upgrading NPS-D on a customer machine that needs to
 pull private images from a protected registry. The standard deployment model is local only: one
@@ -21,8 +21,7 @@ encrypted `gopass` store per engineer or per machine, with no Git remote require
 
 Docker calls the `docker-credential-pass` binary for credential storage and retrieval. That binary
 expects to talk to the `pass` CLI and read from `~/.password-store/`. Since `gopass` is
-CLI-compatible with `pass` and uses the same GPG-encrypted file format, two symlinks bridge the
-gap:
+CLI-compatible with `pass` and uses the same GPG-encrypted file format, two symlinks connect them:
 
 1. **`gopass` symlinked as `pass`** — so `docker-credential-pass` can find the binary it expects
 2. **gopass store symlinked to `~/.password-store/`** — so filesystem reads land in the right place
@@ -61,9 +60,9 @@ Repo assets:
 - `gopass`
 
 :::note
-A Git remote isn't required for the standard NPS-D customer-machine deployment flow. `git` is still
-installed in the validated path because `gopass` defaults to a local Git-backed store, even when no
-remote is configured.
+You don't need a Git remote for the standard NPS-D customer-machine deployment flow. The validated
+path still installs `git` because `gopass` defaults to a local Git-backed store, even when no
+remote exists.
 :::
 
 ### Production prerequisite
@@ -85,7 +84,7 @@ configuration so `gopass` can decrypt during `docker login`.
 - macOS (Apple Silicon and Intel)
 
 :::note
-Windows isn't supported by the official `docker-credential-pass` helper. For Windows environments,
+The official `docker-credential-pass` helper doesn't support Windows. For Windows environments,
 use WSL Ubuntu with the Linux binary.
 :::
 
@@ -139,9 +138,9 @@ Pulling NPS-D images requires authentication to the AWS ECR registry. Configure 
 before running `docker login`.
 
 :::note
-The AWS Access Key ID and Secret Access Key for customer deployments are provided by the CS team.
-This configuration is performed manually and is independent of the installer and validator scripts
-in the repository — those scripts don't interact with AWS or ECR.
+The CS team provides the AWS Access Key ID and Secret Access Key for customer deployments. You
+perform this configuration manually, independent of the installer and validator scripts in the
+repository — those scripts don't interact with AWS or ECR.
 :::
 
 **Step 1 –** Install the AWS CLI if not already present:
@@ -185,7 +184,7 @@ This command uses your AWS credentials to get a temporary ECR token (valid 12 ho
 directly to `docker login`. `docker-credential-pass` then stores the encrypted token —
 `~/.docker/config.json` receives no plain-text credentials.
 
-**Step 4 –** Verify the credential was stored correctly:
+**Step 4 –** Verify that `docker-credential-pass` stored the credential correctly:
 
 ```bash
 grep -q '"auth"' "$HOME/.docker/config.json" && echo "unexpected inline auth found"
@@ -209,7 +208,7 @@ Expected result:
 
 ## Recommended NPS-D Customer-Machine Workflow
 
-After the helper is installed and `gopass` is initialized for the operator account, the practical
+After you install the helper and initialize `gopass` for the operator account, the practical
 deployment flow is the same on Ubuntu, WSL Ubuntu, and macOS. This workflow is intentionally local
 only — it doesn't require a shared store or any Git remote.
 
@@ -231,7 +230,7 @@ For Ubuntu and WSL Ubuntu, the recommended path is the installer script:
 assumes the required packages are already present and only wires up the helper, the local `gopass`
 store, and the Docker config.
 
-### Step 1: Confirm Docker is configured to use the helper
+### Step 1: Confirm Docker uses the helper
 
 The active Docker client config for the current user should contain:
 
@@ -243,7 +242,7 @@ The active Docker client config for the current user should contain:
 
 Path on Linux, WSL, and macOS: `$HOME/.docker/config.json`
 
-### Step 2: Log in to the private registry used by the customer deployment
+### Step 2: Log in to the private registry the customer deployment uses
 
 Linux, WSL, or macOS:
 
@@ -303,8 +302,8 @@ During logout, Docker asks the helper to delete the stored credential entry.
 
 - Docker uses the helper automatically after you configure `credsStore: pass`. Operators
   don't need to invoke it directly during routine deployments.
-- Credentials are scoped to the registry hostname. Log in separately for each registry the customer
-  environment needs.
+- Docker scopes credentials to the registry hostname. Log in separately for each registry the
+  customer environment needs.
 - The standard deployment model is local only. One engineer account or one machine gets one local
   encrypted store. You don't need a remote repository.
 - `printf '%s' "$REGISTRY" | docker-credential-pass get` is a direct verification command when
@@ -314,7 +313,7 @@ During logout, Docker asks the helper to delete the stored credential entry.
   `pass` changes the active credential backend for that Docker client.
 - For customer-machine operators, prefer interactive `docker login` so you enter the token at
   Docker's password prompt instead of placing it in shell history or environment variables.
-- If unattended automation is required, only use `--password-stdin` from a secure secret source.
+- If you need unattended automation, only use `--password-stdin` from a secure secret source.
   Don't hardcode the token into the command line or export it in the shell profile.
 
 ---
@@ -442,8 +441,8 @@ gpg --batch --generate-key "$HOME/gpg-batch"
 ```
 
 :::note
-To use a passphrase-protected key instead, remove `%no-protection` and ensure a working
-`pinentry` program is configured before using `docker login`.
+To use a passphrase-protected key instead, remove `%no-protection` and configure a working
+`pinentry` program before using `docker login`.
 :::
 
 **Step 7 –** Get the key ID:
@@ -463,7 +462,7 @@ gopass --yes init "$KEYID"
 ln -sfn "${XDG_DATA_HOME:-$HOME/.local/share}/gopass/stores/root" "$HOME/.password-store"
 ```
 
-This creates the local encrypted store used by the helper and symlinks it to `~/.password-store/`
+This creates the local encrypted store the helper uses and symlinks it to `~/.password-store/`
 where `docker-credential-pass` expects to find it. For the standard NPS-D deployment flow, stop here
 and don't add any remote.
 
@@ -605,8 +604,8 @@ ln -sf "$(which gopass)" "$HOME/.local/bin/pass"
 
 Create the store symlink after gopass initialization in step 6.
 
-**Step 4 –** Configure Git identity for the local `gopass` store. A remote repository isn't
-required:
+**Step 4 –** Configure Git identity for the local `gopass` store. You don't need a remote
+repository:
 
 ```bash
 git config --global user.name "Your Name"

--- a/docs/privilegesecurediscovery/2.22/installation/dockercredentials.md
+++ b/docs/privilegesecurediscovery/2.22/installation/dockercredentials.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker Credentials Helper"
 description: "Docker Credentials Helper"
-sidebar_position: 50
+sidebar_position: 20
 ---
 
 # Docker Credentials Helper

--- a/docs/privilegesecurediscovery/2.22/installation/machineprovisionidrac.md
+++ b/docs/privilegesecurediscovery/2.22/installation/machineprovisionidrac.md
@@ -1,7 +1,7 @@
 ---
 title: "(RETIRED) Machine Provisioning - iDRAC"
 description: "Machine Provisioning - iDRAC"
-sidebar_position: 20
+sidebar_position: 100
 ---
 
 # Machine Provisioning — iDRAC

--- a/docs/privilegesecurediscovery/2.22/installation/machineprovisionidrac.md
+++ b/docs/privilegesecurediscovery/2.22/installation/machineprovisionidrac.md
@@ -1,14 +1,19 @@
 ---
-title: "(RETIRED INFO) Machine Provisioning - iDRAC"
+title: "(RETIRED) Machine Provisioning - iDRAC"
 description: "Machine Provisioning - iDRAC"
 sidebar_position: 20
 ---
 
-# Machine Provisioning - iDRAC
+# Machine Provisioning — iDRAC
 
 Machine Provisioning - iDRAC
 
-# Machine Provisioning - iDRAC
+# Machine Provisioning — iDRAC
+
+:::warning
+This page describes a retired hardware provisioning process for Dell PowerEdge appliances. For new
+deployments, use the [Container-Based Deployment](./containerbaseddeployment/overview.md) method.
+:::
 
 See the following article for information on machine provisioning:
 

--- a/docs/privilegesecurediscovery/2.22/installation/machineprovisionidrac.md
+++ b/docs/privilegesecurediscovery/2.22/installation/machineprovisionidrac.md
@@ -17,10 +17,10 @@ deployments, use the [Container-Based Deployment](./containerbaseddeployment/ove
 
 See the following article for information on machine provisioning:
 
-- [How to Setup and Manage Your iDRAC or CMC for Dell PowerEdge Servers and Blades](https://www.dell.com/support/kbdoc/en-us/000134243/how-to-setup-and-manage-your-idrac-or-cmc-for-dell-poweredge-servers-and-blades)
+- [How to set up and Manage Your iDRAC or CMC for Dell PowerEdge Servers and Blades](https://www.dell.com/support/kbdoc/en-us/000134243/how-to-setup-and-manage-your-idrac-or-cmc-for-dell-poweredge-servers-and-blades)
 
-    - One item to be aware of is that iDRAC has a password length max of **20 characters**, but
-      there is no indication that this has been exceeded.
+    - iDRAC has a password length max of **20 characters**, but gives no indication when you
+      exceed it.
 
 Dell recommended characters in user names and passwords:
 


### PR DESCRIPTION
## Summary

- Add new **Container-Based Deployment** documentation section (`installation/containerbaseddeployment/`) with 5 pages:
  - `overview.md` — intro, philosophy, 5-step deployment guide, single-node vs cluster table
  - `prerequisites.md` — Ubuntu 24.04, SSH, Docker, AWS CLI install steps
  - `awsconfiguration.md` — AWS credentials setup, ECR login, tip linking to Docker Credentials Helper
  - `deploysecureone.md` — download/extract/deploy, full script reference (usage, commands, options, env vars, typical workflows, post-deploy checks, install directory)
  - `verifydeployment.md` — full monitoring & debugging guide: service status, logs, exec, MongoDB, RabbitMQ, connectivity, resource usage, restart, common failures
- Mark `dellpoweredge.md` and `machineprovisionidrac.md` as **(RETIRED)** with warning admonitions pointing to the new container-based method
- Reorder Installation sidebar: Container-Based Deployment first, RETIRED pages at the bottom (positions 90/100)
- Add `redocusaurus` npm package (required for local dev server)

## Content sources

All technical content verified against internal Xchange documentation:
- OS Pre-Reqs, AWS Configuration, secureone.sh & secureone.tar.gz, Docker Swarm Monitoring & Debugging Guide

## Test plan

- [x] Branch builds without broken links (pre-commit hook passes on all commits)
- [x] Local dev server verified on `localhost:4500`
- [x] Sidebar order confirmed correct in browser
- [x] All internal cross-links validated

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>