### PR TITLE
NPS-D: add --version flag to setup commands

### DIFF
--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -6,8 +6,9 @@ sidebar_position: 40
 
 # Download and Deploy
 
-This page covers downloading the NPS-D quickstart bundle from the Netwrix releases server,
-distributing it to all nodes, and running the deployment script.
+This page covers downloading the Netwrix Privilege Secure for Discovery (NPS-D) quickstart
+bundle from the Netwrix releases server, distributing it to all nodes, and running the
+deployment script.
 
 ## Prerequisites
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -84,7 +84,7 @@ environment variables including the AWS credentials you configured earlier).
 Run on the single node:
 
 ```bash
-sudo -E bash secureone.sh setup
+sudo -E bash secureone.sh setup --version <version>
 ```
 
 The script installs Docker if missing, extracts the configuration package, initializes Docker Swarm,
@@ -96,7 +96,7 @@ the default user.
 **On the primary node:**
 
 ```bash
-sudo -E bash secureone.sh setup --cluster --primary
+sudo -E bash secureone.sh setup --cluster --primary --version <version>
 ```
 
 Follow the prompts. The script initializes the swarm, deploys the stack, and then outputs the exact
@@ -105,7 +105,7 @@ command to run on secondary nodes.
 **On each secondary node** (use the command output by the primary):
 
 ```bash
-sudo -E bash secureone.sh setup --cluster --join-token <TOKEN@HOST:PORT>
+sudo -E bash secureone.sh setup --cluster --join-token <TOKEN@HOST:PORT> --version <version>
 ```
 
 After all secondary nodes have joined the swarm, promote them to managers from the primary node:
@@ -167,9 +167,9 @@ sudo -E bash secureone.sh <command> [options]
 
 ### Commands
 
-**`setup`** — Interactive guided setup for this node. Installs Docker if missing, extracts the
-tarball, sets the hostname, and reconfigures the Docker bridge network. Behavior depends on the
-options you pass:
+**`setup --version <tag>`** — Interactive guided setup for this node. Installs Docker if missing,
+extracts the tarball, sets the hostname, and reconfigures the Docker bridge network. Behavior
+depends on the options you pass:
 
 - **Single-node** — initializes Swarm, pulls images, creates the encryption secret, deploys the
   stack, runs DB migrations, and sets the default user.
@@ -220,10 +220,10 @@ secondary nodes manually.
 
 ```bash
 # Single-node deployment (all-in-one):
-sudo -E bash secureone.sh setup
+sudo -E bash secureone.sh setup --version 2.23.0
 
 # Three-node cluster (follow prompts to copy and run commands on secondary nodes):
-sudo -E bash secureone.sh setup --cluster --primary
+sudo -E bash secureone.sh setup --cluster --primary --version 2.23.0
 
 # Upgrade to a new version (run on the primary node):
 sudo -E bash secureone.sh upgrade --version 2.23.0


### PR DESCRIPTION
## Summary

- Added `--version <version>` to all `setup` command examples in the container-based deployment guide (deploysecureone.md)
- Updated single-node, cluster primary, and cluster secondary setup examples
- Updated Typical Workflows code block to use `--version 2.23.0`
- Renamed `setup` entry in Commands reference to `setup --version <tag>` to clarify the flag is required

## Test plan

- [ ] Verify all `setup` command examples include `--version`
- [ ] Confirm build passes with no broken anchors

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>