### PR TITLE
NPS-D: update landing page and fix version numbers in container deployment docs

### DIFF
--- a/docs/privilegesecurediscovery/2.22/index.md
+++ b/docs/privilegesecurediscovery/2.22/index.md
@@ -16,8 +16,8 @@ lateral movement attacks, and significantly reducing an organization’s attack 
 :::note
 The 2.22 release line is approaching end of support. The current release line (26.03 and later)
 introduces new features and improvements, including native Microsoft Entra ID integration,
-container-based deployment on standard Ubuntu machines, enhanced high-availability cluster
-support, and ongoing security updates. Netwrix recommends upgrading to the latest release to
+container-based deployment on standard Ubuntu machines, and continued active development with
+new capabilities delivered in each release. Netwrix recommends upgrading to the latest release to
 take advantage of these capabilities and continued support. Contact your Netwrix account
 representative for upgrade guidance.
 :::

--- a/docs/privilegesecurediscovery/2.22/index.md
+++ b/docs/privilegesecurediscovery/2.22/index.md
@@ -13,12 +13,22 @@ getting access to only the right resource, at the right moment and for the lengt
 need to complete their job. This approach eliminates standing privileges, effectively preventing
 lateral movement attacks, and significantly reducing an organization’s attack surface.
 
+## Release Lines
+
+NPS-D is available in two release lines:
+
+- **2.22** — Legacy release line, approaching end of support.
+- **26.03 and later** — Current release line, actively developed with new features delivered on
+  a quarterly basis (26.03, 26.06, 26.09, and so on). This is the recommended line for all
+  new and existing deployments.
+
+This documentation covers both release lines. Where a feature or procedure applies only to a
+specific release, it is noted inline.
+
 :::note
-The 2.22 release line is approaching end of support. The current release line (26.03 and later)
-introduces new features and improvements, including native Microsoft Entra ID integration,
-container-based deployment on standard Ubuntu machines, and continued active development with
-new capabilities delivered in each release. Netwrix recommends upgrading to the latest release to
-take advantage of these capabilities and continued support. Contact your Netwrix account
+Netwrix recommends upgrading from 2.22 to the latest release to take advantage of new
+capabilities, including native Microsoft Entra ID integration, container-based deployment on
+standard Ubuntu machines, and continued active development. Contact your Netwrix account
 representative for upgrade guidance.
 :::
 

--- a/docs/privilegesecurediscovery/2.22/index.md
+++ b/docs/privilegesecurediscovery/2.22/index.md
@@ -1,19 +1,24 @@
 ---
-title: "Netwrix Privilege Secure for Discovery v2.22 Documentation"
-description: "Netwrix Privilege Secure for Discovery v2.22 Documentation"
+title: "Netwrix Privilege Secure for Discovery Documentation"
+description: "Documentation for Netwrix Privilege Secure for Discovery"
 sidebar_position: 1
 ---
 
-# Netwrix Privilege Secure for Discovery v2.22 Documentation
+# Netwrix Privilege Secure for Discovery Documentation
 
-Netwrix Privilege Secure for Discovery v2.22 Documentation
+Netwrix Privilege Secure for Discovery (formerly Remediant SecureONE) enables IT administrators
+and security analysts to have dynamic and continuous visibility into their organization’s privileged
+accounts and manage them from a single interface. Users then self-administer privilege access,
+getting access to only the right resource, at the right moment and for the length of time they
+need to complete their job. This approach eliminates standing privileges, effectively preventing
+lateral movement attacks, and significantly reducing an organization’s attack surface.
 
-# Netwrix Privilege Secure for Discovery v2.22 Documentation
-
-Netwrix Privilege Secure for Discovery (formerly Remediant SecureONE) enables IT administrators and
-security analysts to have dynamic and continuous visibility into their organization's privileged
-accounts and manage them from a single interface. Users then self-administer privilege access, getting
-access to only the right resource, at the right moment and for the length of time they need to
-complete their job. This approach eliminates standing privileges, effectively preventing lateral
-movement attacks, and significantly reducing an organization’s attack surface.
+:::note
+The 2.22 release line is approaching end of support. The current release line (26.03 and later)
+introduces new features and improvements, including native Microsoft Entra ID integration,
+container-based deployment on standard Ubuntu machines, enhanced high-availability cluster
+support, and ongoing security updates. Netwrix recommends upgrading to the latest release to
+take advantage of these capabilities and continued support. Contact your Netwrix account
+representative for upgrade guidance.
+:::
 

--- a/docs/privilegesecurediscovery/2.22/index.md
+++ b/docs/privilegesecurediscovery/2.22/index.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 Netwrix Privilege Secure for Discovery (formerly Remediant SecureONE) enables IT administrators
 and security analysts to have dynamic and continuous visibility into their organization’s privileged
 accounts and manage them from a single interface. Users then self-administer privilege access,
-getting access to only the right resource, at the right moment and for the length of time they
+getting access to only the right resource, at the right moment and for as long as they
 need to complete their job. This approach eliminates standing privileges, effectively preventing
 lateral movement attacks, and significantly reducing an organization’s attack surface.
 
@@ -18,12 +18,12 @@ lateral movement attacks, and significantly reducing an organization’s attack 
 NPS-D is available in two release lines:
 
 - **2.22** — Legacy release line, approaching end of support.
-- **26.03 and later** — Current release line, actively developed with new features delivered on
-  a quarterly basis (26.03, 26.06, 26.09, and so on). This is the recommended line for all
-  new and existing deployments.
+- **26.03 and later** — Current release line, actively developed with new features delivered
+  quarterly (26.03, 26.06, 26.09, and so on). This is the recommended line for all new and
+  existing deployments.
 
 This documentation covers both release lines. Where a feature or procedure applies only to a
-specific release, it is noted inline.
+specific release, an inline note calls this out.
 
 :::note
 Netwrix recommends upgrading from 2.22 to the latest release to take advantage of new

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/deploysecureone.md
@@ -18,7 +18,7 @@ deployment script.
 ## Step 1 — Download the Quickstart Bundle
 
 Log in to the **primary node** via SSH and run the following command from your **home directory**
-(`~/`). Replace `<version>` and `<major.minor>` with the target release, for example `2.22.14`
+(`~/`). Replace `<version>` and `<major.minor>` with the target release, for example `2.22.13`
 and `2.22`:
 
 ```bash
@@ -26,16 +26,16 @@ cd ~
 wget https://releases.netwrix.com/products/privilegesecure-discovery/<major.minor>/privilegesecure-discovery-quickstart-<version>.zip
 ```
 
-**Example for 2.22.14:**
+**Example for 2.22.13:**
 
 ```bash
-wget https://releases.netwrix.com/products/privilegesecure-discovery/2.22/privilegesecure-discovery-quickstart-2.22.14.zip
+wget https://releases.netwrix.com/products/privilegesecure-discovery/2.22/privilegesecure-discovery-quickstart-2.22.13.zip
 ```
 
-**Example for 26.03.2:**
+**Example for 26.03.1:**
 
 ```bash
-wget https://releases.netwrix.com/products/privilegesecure-discovery/26.03/privilegesecure-discovery-quickstart-26.03.2.zip
+wget https://releases.netwrix.com/products/privilegesecure-discovery/26.03/privilegesecure-discovery-quickstart-26.03.1.zip
 ```
 
 ## Step 2 — Extract the Bundle
@@ -208,7 +208,7 @@ secondary nodes manually.
 | `--cluster` | Treat this node as part of a cluster deployment. |
 | `--primary` | Treat this node as the cluster primary. Requires `--cluster`. |
 | `--join-token <TOKEN@HOST:PORT>` | Manager join token from `generate-join-token`. Requires `--cluster`. The node joins the swarm as a manager after network setup. |
-| `--version <tag>` | Image tag to pull and deploy (for example `2.22.14`). Required for commands that pull images: `setup` and `upgrade`. |
+| `--version <tag>` | Image tag to pull and deploy (for example `2.22.13`). Required for commands that pull images: `setup` and `upgrade`. |
 | `-h`, `--help` | Show help and exit. |
 
 ### Environment Variables

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/overview.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/overview.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 # Container-Based Deployment Overview
 
 :::note
-Container-based deployment is available in NPS-D 2.22.14, 26.03.2, or later.
+Container-based deployment is available in NPS-D 2.22.13, 26.03.1, or later.
 :::
 
 Container-based deployment lets you deploy Privilege Secure Discovery (NPS-D) on standard Ubuntu


### PR DESCRIPTION
## Summary

- Updated NPS-D landing page (index.md): removed duplicate title/headings, removed version number from title, added upgrade note highlighting new features in 26.03+ (Entra ID integration, container-based deployment, active development)
- Updated container-based deployment version examples from 2.22.14/26.03.2 to 2.22.13/26.03.1 across overview.md and deploysecureone.md

## Test plan

- [ ] Verify landing page renders correctly with note at the bottom
- [ ] Verify version numbers are consistent across container-based deployment pages
- [ ] Confirm build passes with no broken anchors

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>