### PR TITLE
add Password Reset link missing with Duo and PPE Client

### DIFF
--- a/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
+++ b/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
@@ -1,0 +1,57 @@
+---
+description: >-
+  If the Password Reset link is missing in the Netwrix Password Reset client and Duo MFA and Password Policy Enforcer Client are both in the environment. This article explains the steps and registry settings needed to get Password Reset Client, Password Policy Enforcer Client, and Duo MFA working together.
+keywords:
+  - password reset
+  - Password Reset client
+  - Duo
+  - ProvidersWhitelist
+  - registry
+  - Password Policy Enforcer Client
+  - GUID
+  - third-party credential provider
+products:
+  - password-reset
+sidebar_label: Password Reset Link Is Missing Duo and PPE Client
+tags: []
+title: "Password Reset Link Is Missing with Duo and PPE Client installed"
+knowledge_article_id: ""
+---
+
+# Password Reset Link Is Missing with Duo and PPE Client Installed
+
+## Symptoms
+
+The reset link is missing for Netwrix Password Reset when Duo MFA and Netwrix Password Policy Enforcer Client are installed.
+
+## Cause
+
+Multiple Credential Providers in the environment can conflict when you do not configure them correctly.
+
+## Resolution
+
+1. Uninstall all three: Duo MFA, Netwrix Password Reset (NPR) Client, and Netwrix Password Policy Enforcer (PPE) Client, and reboot the system.
+
+2. Install Duo and restore any Duo settings that the uninstallation process may have removed.
+
+3. Install PPE Client
+
+4. Install NPR Client
+
+5. Add a ProvidersWhitelist multi-string value of `{407DAD37-1BA1-49BB-8401-45B22F5EF77C}` following the Duo instructions here: https://help.duo.com/s/article/4041?language=en_US
+
+6. Press CTRL+ALT+DEL and select **Change Password**.
+
+7. Verify that PPE policies appear and that the Password Reset link appears on the Lock Screen.
+
+> **IMPORTANT:** If the Password Reset link is still missing or PPE Client is not showing policies, make sure the following registry values are not present on the machine.
+
+```
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\ANIXIS\Password Reset Client]
+"PreferredProvider"="{44E2ED41-48C7-4712-A3C3-250C5E6D5D84}"
+"PreferredProviderUsernameField"=dword:00000001
+"PreferredProviderFriendlyNameField"=dword:00000000
+"PreferredProviderConfirmPasswordField"=dword:00000004
+"PreferredProviderResetPasswordLinkField"=dword:00000006
+"PreferredProviderLogOnToField"=dword:00000008
+```

--- a/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
+++ b/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
@@ -11,10 +11,11 @@ keywords:
   - GUID
   - third-party credential provider
 products:
-  - password-reset
-sidebar_label: Password Reset Link Is Missing Duo and PPE Client
-tags: []
-title: "Password Reset Link Is Missing with Duo and PPE Client installed"
+  - passwordreset
+sidebar_label: Password Reset Link Missing with Duo and PPE Client
+tags:
+  - kb
+title: "Password Reset Link Is Missing with Duo and PPE Client Installed"
 knowledge_article_id: ""
 ---
 
@@ -38,7 +39,7 @@ Multiple Credential Providers in the environment can conflict when you do not co
 
 4. Install NPR Client
 
-5. Add a ProvidersWhitelist multi-string value of `{407DAD37-1BA1-49BB-8401-45B22F5EF77C}` following the Duo instructions here: https://help.duo.com/s/article/4041?language=en_US
+5. Add a ProvidersWhitelist multi-string value of `{407DAD37-1BA1-49BB-8401-45B22F5EF77C}` following the [Duo instructions ⸱ Duo 🡥](https://help.duo.com/s/article/4041?language=en_US).
 
 6. Press CTRL+ALT+DEL and select **Change Password**.
 

--- a/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
+++ b/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
@@ -27,8 +27,8 @@ The reset link is missing for Netwrix Password Reset when Duo MFA and Netwrix Pa
 
 ## Cause
 
-Multiple Credential Providers in the environment can conflict when you do not configure them correctly. 
-Ensure that the credential stacks are in the correct order. 
+Multiple Credential Providers in the environment can conflict when you do not configure them correctly. Ensure that the credential stacks are in the correct order. 
+
 The ProvidersWhitelist registry value must be added to the system to allow the Netwrix Password Reset Client and Netwrix Password Policy Enforcer Client to work together with Duo MFA.
 
 ## Resolution
@@ -41,11 +41,12 @@ The ProvidersWhitelist registry value must be added to the system to allow the N
 2. Reboot the system.
 
 3. Reinstall the following in this exact order:
+
+   > **IMPORTANT:** Restore any Duo settings that the uninstallation process may have removed before proceeding with the reinstall order below.
+
    - Duo MFA
    - PPE Client
    - NPR Client
-
-   > **NOTE:** Restore any Duo settings that the uninstallation process may have removed before re-installing the PPE and NPR Clients.
 
 4. Add a ProvidersWhitelist multi-string value of `{407DAD37-1BA1-49BB-8401-45B22F5EF77C}` following the [Duo instructions ⸱ Duo 🡥](https://help.duo.com/s/article/4041?language=en_US).
 
@@ -53,14 +54,14 @@ The ProvidersWhitelist registry value must be added to the system to allow the N
 
 6. Verify that PPE policies appear and that the Password Reset link appears on the Lock Screen.
 
-> **IMPORTANT:** If the Password Reset link is still missing or the PPE Client is not showing policies, confirm that the following registry values are not present on the machine.
-
-```
-[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\ANIXIS\Password Reset Client]
-"PreferredProvider"="{44E2ED41-48C7-4712-A3C3-250C5E6D5D84}"
-"PreferredProviderUsernameField"=dword:00000001
-"PreferredProviderFriendlyNameField"=dword:00000000
-"PreferredProviderConfirmPasswordField"=dword:00000004
-"PreferredProviderResetPasswordLinkField"=dword:00000006
-"PreferredProviderLogOnToField"=dword:00000008
-```
+> **IMPORTANT:** If the Password Reset link is still missing or the PPE Client is not showing policies, confirm that the following registry values are not present on the machine:
+  >
+  > ```
+  > [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\ANIXIS\Password Reset Client]
+  > "PreferredProvider"="{44E2ED41-48C7-4712-A3C3-250C5E6D5D84}"
+  > "PreferredProviderUsernameField"=dword:00000001
+  > "PreferredProviderFriendlyNameField"=dword:00000000
+  > "PreferredProviderConfirmPasswordField"=dword:00000004
+  > "PreferredProviderResetPasswordLinkField"=dword:00000006
+  > "PreferredProviderLogOnToField"=dword:00000008
+  > ```

--- a/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
+++ b/docs/kb/passwordreset/portal-access-and-authentication/password-reset-link-missing-duo-and-ppe-client.md
@@ -21,31 +21,39 @@ knowledge_article_id: ""
 
 # Password Reset Link Is Missing with Duo and PPE Client Installed
 
-## Symptoms
+## Symptom
 
 The reset link is missing for Netwrix Password Reset when Duo MFA and Netwrix Password Policy Enforcer Client are installed.
 
 ## Cause
 
-Multiple Credential Providers in the environment can conflict when you do not configure them correctly.
+Multiple Credential Providers in the environment can conflict when you do not configure them correctly. 
+Ensure that the credential stacks are in the correct order. 
+The ProvidersWhitelist registry value must be added to the system to allow the Netwrix Password Reset Client and Netwrix Password Policy Enforcer Client to work together with Duo MFA.
 
 ## Resolution
 
-1. Uninstall all three: Duo MFA, Netwrix Password Reset (NPR) Client, and Netwrix Password Policy Enforcer (PPE) Client, and reboot the system.
+1. Uninstall the following in this exact order:
+   - Duo MFA
+   - Netwrix Password Reset (NPR) Client
+   - Netwrix Password Policy Enforcer (PPE) Client
 
-2. Install Duo and restore any Duo settings that the uninstallation process may have removed.
+2. Reboot the system.
 
-3. Install PPE Client
+3. Reinstall the following in this exact order:
+   - Duo MFA
+   - PPE Client
+   - NPR Client
 
-4. Install NPR Client
+   > **NOTE:** Restore any Duo settings that the uninstallation process may have removed before re-installing the PPE and NPR Clients.
 
-5. Add a ProvidersWhitelist multi-string value of `{407DAD37-1BA1-49BB-8401-45B22F5EF77C}` following the [Duo instructions ⸱ Duo 🡥](https://help.duo.com/s/article/4041?language=en_US).
+4. Add a ProvidersWhitelist multi-string value of `{407DAD37-1BA1-49BB-8401-45B22F5EF77C}` following the [Duo instructions ⸱ Duo 🡥](https://help.duo.com/s/article/4041?language=en_US).
 
-6. Press CTRL+ALT+DEL and select **Change Password**.
+5. Press CTRL+ALT+DEL and select **Change Password**.
 
-7. Verify that PPE policies appear and that the Password Reset link appears on the Lock Screen.
+6. Verify that PPE policies appear and that the Password Reset link appears on the Lock Screen.
 
-> **IMPORTANT:** If the Password Reset link is still missing or PPE Client is not showing policies, make sure the following registry values are not present on the machine.
+> **IMPORTANT:** If the Password Reset link is still missing or the PPE Client is not showing policies, confirm that the following registry values are not present on the machine.
 
 ```
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\ANIXIS\Password Reset Client]


### PR DESCRIPTION
Adding new KB article to Password Reset that covers a scenario when Duo MFA, Password Policy Enforcer Client and Password Reset Client are all installed in the environment. 