### PR TITLE
feat(sidebar): enable auto-collapse categories site-wide

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -208,7 +208,7 @@ const config = {
       docs: {
         sidebar: {
           hideable: true,
-          autoCollapseCategories: false,
+          autoCollapseCategories: true,
         },
       },
       algolia: {


### PR DESCRIPTION
## Summary

- Sets `autoCollapseCategories: true` in `themeConfig.docs.sidebar`
- Opening a sidebar category now auto-collapses any previously open sibling at the same level — accordion-style navigation matching the pattern used by other large API reference sites
- Addresses the sluggish collapse behavior in the Change Tracker API Reference when multiple sub-categories are expanded simultaneously

## Test plan

- [ ] Open multiple sidebar categories across any product, confirm only one stays open at a time
- [ ] Verify Change Tracker API Reference accordion behavior specifically

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>