### PR TITLE
docs(endpointprotector): fix API endpoint names and document backgrou…

### DIFF
--- a/docs/endpointprotector/admin/API Logs/apispecification.md
+++ b/docs/endpointprotector/admin/API Logs/apispecification.md
@@ -561,18 +561,6 @@ curl -s -k \
   "https://<epp-server>/api/logs/content-aware-protection?start_date=2025-01-01&end_date=2025-01-31"
 ```
 
-## Database tables reference
-
-| Endpoint Group | Primary Table | Joined Tables |
-|---|---|---|
-| Device Control | `olog` | `event`, `devicetype`, `clientmachine`, `clientdevice` |
-| System Alerts | `sys_alert_log` | `sys_event` |
-| Content Filtering | `cf_log`, `cf_alert` | `event` |
-| EasyLock | `olog` | `event`, `devicetype`, `clientmachine`, `clientdevice` |
-| eDiscovery | `dr_object` | — |
-| SCIM Logs | `scim_log` | — |
-| Admin Actions | `admin_action` | `sf_guard_user` |
-
 ## Rate limiting
 
 The API enforces two independent rate limits using a fixed-window counter:

--- a/docs/endpointprotector/admin/API Logs/apispecification.md
+++ b/docs/endpointprotector/admin/API Logs/apispecification.md
@@ -123,7 +123,7 @@ Used by the `POST /login` endpoint.
 
 **Success (standard list with pagination)**
 
-Used by System Alerts and Content Filtering Alerts.
+Used by System Alerts, Content Filtering Alerts, and SCIM Logs.
 
 ```json
 {
@@ -216,7 +216,7 @@ Used by Admin Actions. Flat pagination with fewer metadata fields:
 | 400 | Bad request (invalid parameters) |
 | 401 | Unauthorized (missing or invalid token) |
 | 404 | Resource not found |
-| 405 | Method not allowed (only GET is supported) |
+| 405 | Method not allowed |
 | 429 | Rate limit exceeded |
 | 500 | Internal server error |
 
@@ -598,7 +598,7 @@ With defaults: 200 requests/minute globally, 60 requests/minute per user.
 
 ### Response headers
 
-Every API response includes per-user rate limit headers:
+Every authenticated request response includes per-user rate limit headers:
 
 | Header | Description |
 |---|---|

--- a/docs/endpointprotector/admin/API Logs/apispecification.md
+++ b/docs/endpointprotector/admin/API Logs/apispecification.md
@@ -48,7 +48,19 @@ Unauthenticated requests receive:
   "success": false,
   "error": {
     "code": 401,
-    "message": "Unauthorized"
+    "message": "Missing authentication token. Provide via Authorization: Bearer <token> header."
+  }
+}
+```
+
+Requests with an invalid or expired token receive:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 401,
+    "message": "Invalid or expired token."
   }
 }
 ```
@@ -90,7 +102,7 @@ The date field used for filtering varies by endpoint (documented per endpoint be
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `use_last_partition` | boolean | `false` | When `true`, restricts the query to the most recent partition only, which improves performance on large tables |
+| `use_last_partition` | boolean | `false` | When `true`, restricts the query to the most recent partition only, which improves performance on large tables. Accepts `true`, `1`, `yes`, or `on` (case-insensitive). |
 
 Available on: Device Control, Content-Aware Protection, eDiscovery, EasyLock.
 
@@ -98,18 +110,20 @@ Available on: Device Control, Content-Aware Protection, eDiscovery, EasyLock.
 
 **Success (single resource)**
 
+Used by the `POST /login` endpoint.
+
 ```json
 {
   "success": true,
   "data": {
-    "id": "1",
-    "name": "Example",
-    "created_at": "2025-01-15 10:30:00"
+    "token": "eyJ..."
   }
 }
 ```
 
-**Success (list with pagination)**
+**Success (standard list with pagination)**
+
+Used by System Alerts and Content Filtering Alerts.
 
 ```json
 {
@@ -126,6 +140,61 @@ Available on: Device Control, Content-Aware Protection, eDiscovery, EasyLock.
   }
 }
 ```
+
+**Success (legacy list format)**
+
+Used by Device Control, Content-Aware Protection, eDiscovery, and EasyLock. Pagination fields are at the top level alongside `items`:
+
+```json
+{
+  "current_page": 1,
+  "items": [
+    { "id": "1", "machine_name": "DESKTOP-01" },
+    { "id": "2", "machine_name": "DESKTOP-02" }
+  ],
+  "num_items_per_page": 50,
+  "max_rows_limit": 10000,
+  "max_rows_limit_reached": false,
+  "page_count": 3,
+  "page_items_count": 2,
+  "total_count": 128
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `current_page` | integer | Current page number (1-based) |
+| `items` | array | Array of log entries |
+| `num_items_per_page` | integer | Requested items per page |
+| `max_rows_limit` | integer | Maximum rows scanned for COUNT (default: 10 000). When reached, the count stops and `max_rows_limit_reached` is set to `true`. |
+| `max_rows_limit_reached` | boolean | `true` if `total_count` >= `max_rows_limit` — apply more filters to narrow results |
+| `page_count` | integer | Total number of pages |
+| `page_items_count` | integer | Number of items on the current page |
+| `total_count` | integer | Total matching records (capped at `max_rows_limit`) |
+
+**Success (legacy list format — simple)**
+
+Used by Admin Actions. Flat pagination with fewer metadata fields:
+
+```json
+{
+  "current_page": 1,
+  "items": [
+    { "id": 1, "section": "Custom Content Denylists" }
+  ],
+  "page_count": 10,
+  "items_per_page": 10,
+  "total_item_count": 95
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `current_page` | integer | Current page number (1-based) |
+| `items` | array | Array of log entries |
+| `page_count` | integer | Total number of pages |
+| `items_per_page` | integer | Requested items per page |
+| `total_item_count` | integer | Total matching records |
 
 **Error**
 
@@ -157,27 +226,40 @@ Available on: Device Control, Content-Aware Protection, eDiscovery, EasyLock.
 
 **POST /login**
 
-Authenticates with a username and password and returns a JWT token valid for 1 hour.
+Authenticates with a username and password and returns a JWT token valid for 1 hour. This is the only public endpoint — no token is required.
+
+:::note
+The login endpoint is at `https://<epp-server>/api/login`, not under the `/api/logs/` base URL.
+:::
 
 Request body:
 
 ```json
 {
-  "username": "admin",
-  "password": "secret"
+  "username": "api_admin",
+  "password": "your_password"
 }
 ```
 
-Response:
+Success response:
 
 ```json
 {
   "success": true,
   "data": {
-    "token": "eyJ..."
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
   }
 }
 ```
+
+Error responses:
+
+| Scenario | HTTP Code | Message |
+|---|---|---|
+| Missing/invalid JSON body | 400 | `Missing required fields: username and password` |
+| Wrong credentials | 401 | `Invalid credentials.` |
+| Account disabled | 401 | `Account is disabled.` |
+| Account locked | 429 | `Account temporarily locked. Try again later.` |
 
 Use the returned token in the `Authorization: Bearer` header for all subsequent requests.
 
@@ -185,9 +267,11 @@ Use the returned token in the `Authorization: Bearer` header for all subsequent 
 
 Online device tracking logs from the `olog` table, joined with `event`, `devicetype`, `clientmachine`, and `clientdevice` tables.
 
+**Response format:** Legacy list (see [Success (legacy list format)](#response-format))
+
 **GET /device-control**
 
-Date field: `eventtime`
+Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters:
 
@@ -201,33 +285,25 @@ Filters:
 
 Response fields:
 
-| Field | Source | Description |
-|---|---|---|
-| `id` | `olog.id` | Log entry ID |
-| `loclogid` | `olog.loclogid` | Local log ID |
-| `machine_id` | `olog.machine_id` | Machine ID |
-| `machine_name` | `olog.machine_name` | Computer name (denormalized) |
-| `ip` | `olog.ip` | Computer IP address (denormalized) |
-| `domain` | `olog.domain` | Computer domain |
-| `client_id` | `olog.client_id` | Client user ID |
-| `client_name` | `olog.client_name` | Username (denormalized) |
-| `device_type_id` | `olog.device_type_id` | Device type ID |
-| `device_type_name` | `devicetype.name` | Device type name (resolved via JOIN) |
-| `device_id` | `olog.device_id` | Device ID |
-| `device_name` | `olog.device_name` | Device name (denormalized) |
-| `event_id` | `olog.event_id` | Event ID |
-| `event_name` | `event.name` | Event name (resolved via JOIN) |
-| `machine_serial_number` | `clientmachine.serial_number` | Machine serial number (resolved via JOIN) |
-| `device_serial_number` | `clientdevice.serialno` | Device serial number (resolved via JOIN) |
-| `eventtime` | `olog.eventtime` | Event timestamp — server time (UTC) |
-| `eventtimelocal` | `olog.eventtimelocal` | Event timestamp — client local time |
-| `nrfiles` | `olog.nrfiles` | Number of files |
-| `alert_flag` | `olog.alert_flag` | Alert flag |
-| `filename` | `olog.filename` | File name |
-| `filetype` | `olog.filetype` | File type |
-| `os_type` | `olog.os_type` | OS type |
-| `timestamp` | `olog.timestamp` | Unix timestamp |
-| `department_id` | `olog.department_id` | Department ID |
+| Field | Description |
+|---|---|
+| `id` | Log entry ID |
+| `timestamp` | Unix timestamp |
+| `machine_name` | Computer name |
+| `event_time_local` | Event timestamp — client local time |
+| `file_name` | File name involved |
+| `event_name` | Event name, e.g. "Blocked" |
+| `file_type` | File type |
+| `ip` | Computer IP address |
+| `domain` | Computer domain |
+| `os_type` | OS type identifier |
+| `device_name` | Device name |
+| `vid` | Device vendor ID |
+| `pid` | Device product ID |
+| `serial_no` | Device serial number |
+| `device_type_name` | Device type name, e.g. "Webcam" |
+| `epp_client_version` | EPP client version |
+| `os_version` | Full OS version string |
 
 ### System Alerts
 
@@ -252,7 +328,9 @@ Content-Aware Protection logs and alerts, joined with `event` table for event na
 
 **GET /content-aware-protection**
 
-Date field: `eventtime`
+**Response format:** Legacy list (see [Success (legacy list format)](#response-format))
+
+Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters:
 
@@ -264,7 +342,28 @@ Filters:
 | `client_name` | string | Filter by client name (partial match) |
 | `use_last_partition` | boolean | Restrict query to the most recent partition (default: `false`) |
 
-Response fields: `id`, `loclogid`, `event_id`, `machine_id`, `machine_name`, `ip`, `domain`, `client_id`, `client_name`, `destination_type`, `destination`, `filename`, `content_policy`, `content_policy_type`, `item_type`, `matched_item`, `item_details`, `eventtime`, `eventtimelocal`, `alert_flag`, `nr_reports`, `filesize`, `filehash`, `os_type`, `department_id`, `justification`, `event_name`
+Response fields:
+
+| Field | Description |
+|---|---|
+| `id` | Log entry ID |
+| `timestamp` | Unix timestamp |
+| `machine_name` | Computer name |
+| `client_name` | Client/user name |
+| `event_time_local` | Event timestamp — client local time |
+| `file_name` | File name involved |
+| `file_size` | File size |
+| `event_name` | Event name |
+| `ip` | Computer IP address |
+| `os_type` | OS type identifier |
+| `destination_type` | Destination type |
+| `content_policy` | Content policy name |
+| `item_type` | Matched item type |
+| `matched_item` | Matched content item |
+| `item_details` | Item details |
+| `file_hash` | File hash |
+| `destination_details` | Destination details |
+| `justification` | User justification |
 
 **GET /content-filtering-alerts**
 
@@ -276,25 +375,15 @@ Filters: `event_id`, `content_policy`, `department_id`
 
 Response fields: `id`, `name`, `department_id`, `group_id`, `machine_id`, `client_id`, `content_policy`, `event_id`, `old_alert`, `created_at`, `created_by_user_id`, `event_name`
 
-**GET /content-filtering-alerts/(id)**
-
-Returns a single content filtering alert by ID with event name.
-
-### Mobile Management Logs
-
-**GET /mobile-management-logs**
-
-Date field: `eventtime`
-
-Filters: `mm_device_id`, `action_ck`, `result_code`
-
-Response fields: `id`, `mm_device_id`, `action_ck`, `action`, `result_code`, `error_code`, `error_message`, `latitude`, `longitude`, `altitude`, `loctime`, `locqual`, `other`, `short_address`, `long_address`, `eventtime`
-
 ### EasyLock Logs
+
+EasyLock encryption and deployment logs, filtered to EasyLock-related events only. Uses the same response structure as Device Control Logs.
 
 **GET /easy-lock**
 
-Date field: `timestamp`
+**Response format:** Legacy list (see [Success (legacy list format)](#response-format))
+
+Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters:
 
@@ -330,11 +419,13 @@ Response fields:
 
 ### eDiscovery (Data at Rest)
 
+eDiscovery scan results. Uses the legacy list response format.
+
 **GET /ediscovery**
 
-Lists Data-at-Rest scan results.
+**Response format:** Legacy list (see [Success (legacy list format)](#response-format))
 
-Date field: `timestamp`
+Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters:
 
@@ -352,16 +443,16 @@ Response fields:
 
 | Field | Description |
 |---|---|
-| `id` | Entry ID |
-| `timestamp` | Unix timestamp of the scan event |
+| `id` | Log entry ID |
+| `timestamp` | Unix timestamp |
 | `machine_name` | Computer name |
-| `event_time_local` | Event timestamp in client local time |
-| `file_name` | File name scanned |
-| `matched_item` | Matched content item |
-| `item_details` | Details of the matched item |
-| `policy_name` | Name of the policy that triggered the result |
-| `client_time` | Client-reported time |
-| `status` | Scan result status |
+| `event_time_local` | Event timestamp — client local time |
+| `file_name` | Scanned file path |
+| `matched_item` | Matched content item (e.g. MIME type) |
+| `item_details` | Item details (e.g. file format) |
+| `policy_name` | eDiscovery policy name |
+| `client_time` | Client report time |
+| `status` | Object status |
 
 ### SCIM Logs
 
@@ -382,19 +473,17 @@ Filters:
 
 Response fields: `id`, `timestamp`, `request_id`, `http_method`, `endpoint`, `status_code`, `actor`, `operation`, `resource_type`, `external_id`, `duration_ms`, `ip_address`, `user_agent`, `bulk_request_id`, `operation_index`
 
-### Export Logs
-
-**GET /export-logs/(id)**
-
-Returns a single export log entry including the `description` field.
-
-Response fields: `id`, `name`, `log_type`, `status`, `date`, `from_date`, `to_date`, `partitions`, `export_type`, `sf_guard_user_id`, `description`
+:::note
+`request_body` and `response_body` are excluded from list responses for performance.
+:::
 
 ### Admin Actions
 
+Administrator action audit trail.
+
 **GET /admin-actions**
 
-Lists administrator action audit trail entries, joined with `sf_guard_user` for usernames.
+**Response format:** Legacy list — simple (see [Success (legacy list format — simple)](#response-format))
 
 Date field: `created_at`
 
@@ -403,26 +492,33 @@ Filters:
 | Parameter | Type | Description |
 |---|---|---|
 | `user_id` | integer | Filter by admin user ID |
-| `section` | string | Filter by section (e.g. "Device Control") |
+| `section` | string | Filter by section (e.g. "Device Control", "Content Aware Protection") |
 | `log_type` | string | Filter by log type |
 | `operation` | string | Filter by operation performed |
 | `search` | string | Search across section, log_type, operation, and username |
 
-Response fields: `id`, `user_id`, `created_at`, `section`, `log_type`, `operation`, `username`
+Response fields:
 
-:::note
-`before_desc` and `after_desc` LONGTEXT fields are excluded from list responses for performance.
-:::
+| Field | Description |
+|---|---|
+| `id` | Action ID |
+| `section` | Section name, e.g. "Custom Content Denylists" |
+| `operation` | Operation performed, e.g. "Login" |
+| `log_type` | Log type, e.g. "EDIT" |
+| `before_desc` | State before the action (JSON object) |
+| `after_desc` | State after the action (JSON object) |
+| `user` | User object with `id` and `username` |
+| `created_at` | Action timestamp |
 
 ## Usage examples
 
-**Authenticate and obtain a token**
+**Obtain a JWT token**
 
 ```bash
 TOKEN=$(curl -s -k -X POST \
   -H "Content-Type: application/json" \
-  -d '{"username":"admin","password":"secret"}' \
-  "https://<epp-server>/api/logs/login" | jq -r '.data.token')
+  -d '{"username": "admin", "password": "your_password"}' \
+  "https://<epp-server>/api/login" | python -c "import sys,json; print(json.load(sys.stdin)['data']['token'])")
 ```
 
 **List recent device control logs for a specific machine**
@@ -430,15 +526,39 @@ TOKEN=$(curl -s -k -X POST \
 ```bash
 curl -s -k \
   -H "Authorization: Bearer ${TOKEN}" \
-  "https://<epp-server>/api/logs/device-control?machine_name=WORKSTATION&sort_by=eventtime&sort_order=DESC&per_page=10"
+  "https://<epp-server>/api/logs/device-control?machine_name=WORKSTATION&sort_by=timestamp&sort_order=DESC&per_page=10"
 ```
 
-**Get content filtering logs for a date range**
+**List EasyLock logs**
 
 ```bash
 curl -s -k \
   -H "Authorization: Bearer ${TOKEN}" \
-  "https://<epp-server>/api/logs/content-aware-protection?start_date=2025-01-01&end_date=2025-01-31&content_policy=PCI"
+  "https://<epp-server>/api/logs/easy-lock?sort_by=timestamp&sort_order=DESC&per_page=20"
+```
+
+**List eDiscovery logs for a specific policy**
+
+```bash
+curl -s -k \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "https://<epp-server>/api/logs/ediscovery?policy_name=Policy%201&sort_by=timestamp&sort_order=DESC&per_page=20"
+```
+
+**Fetch only the latest partition (delta sync)**
+
+```bash
+curl -s -k \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "https://<epp-server>/api/logs/device-control?use_last_partition=true&sort_by=timestamp&sort_order=DESC&per_page=100"
+```
+
+**Get content-aware protection logs for a date range**
+
+```bash
+curl -s -k \
+  -H "Authorization: Bearer ${TOKEN}" \
+  "https://<epp-server>/api/logs/content-aware-protection?start_date=2025-01-01&end_date=2025-01-31"
 ```
 
 ## Database tables reference
@@ -448,11 +568,9 @@ curl -s -k \
 | Device Control | `olog` | `event`, `devicetype`, `clientmachine`, `clientdevice` |
 | System Alerts | `sys_alert_log` | `sys_event` |
 | Content Filtering | `cf_log`, `cf_alert` | `event` |
-| Mobile Management | `mm_log` | — |
-| EasyLock | `olog` | — |
+| EasyLock | `olog` | `event`, `devicetype`, `clientmachine`, `clientdevice` |
 | eDiscovery | `dr_object` | — |
 | SCIM Logs | `scim_log` | — |
-| Export Logs | `export_log_list` | — |
 | Admin Actions | `admin_action` | `sf_guard_user` |
 
 ## Rate limiting
@@ -518,9 +636,9 @@ The response also includes a `Retry-After` header (in seconds) indicating when t
 
 ## CORS
 
-The API includes CORS headers allowing cross-origin requests from any origin. The OPTIONS preflight response includes:
+The API includes CORS headers for browser-based integrations. Origins must be listed in the server's `cors_allowed_origins` configuration. The OPTIONS preflight response includes:
 
-- `Access-Control-Allow-Origin: *`
-- `Access-Control-Allow-Methods: GET, OPTIONS`
+- `Access-Control-Allow-Origin: <configured-origin>`
+- `Access-Control-Allow-Methods: GET, POST, OPTIONS`
 - `Access-Control-Allow-Headers: Content-Type, Authorization`
 - `Access-Control-Max-Age: 86400`

--- a/docs/endpointprotector/admin/API Logs/apispecification.md
+++ b/docs/endpointprotector/admin/API Logs/apispecification.md
@@ -33,17 +33,13 @@ Integrations should be designed to tolerate additive response fields, documented
 
 ## Authentication
 
-All requests require authentication via one of these methods (in order of preference):
+Authentication uses JWT (JSON Web Tokens) with HS256 signing.
 
-| Method | Format | Example |
+To authenticate, send a POST request to `/login` with your credentials. On success, you receive a token valid for 1 hour. Include the token in all subsequent requests using the `Authorization: Bearer` header.
+
+| Method | Header | Example |
 |---|---|---|
-| X-Api-Key header | `X-Api-Key: <key>` | `X-Api-Key: abc123def456` |
-| Bearer token | `Authorization: Bearer <key>` | `Authorization: Bearer abc123def456` |
-| Query parameter | `?api_key=<key>` | `?api_key=abc123def456` |
-
-API keys are validated against the `api_key` database table. The associated user must be active in `sf_guard_user`.
-
-If no API key is provided or validated, the API falls back to checking for an active Symfony session cookie (useful when calling the API from the EPP web interface).
+| Bearer token | `Authorization: Bearer <token>` | `Authorization: Bearer eyJ...` |
 
 Unauthenticated requests receive:
 
@@ -52,7 +48,7 @@ Unauthenticated requests receive:
   "success": false,
   "error": {
     "code": 401,
-    "message": "Missing API key. Provide via X-Api-Key header or api_key query parameter."
+    "message": "Unauthorized"
   }
 }
 ```
@@ -89,6 +85,14 @@ The date field used for filtering varies by endpoint (documented per endpoint be
 | Parameter | Type | Description |
 |---|---|---|
 | `search` | string | Full-text search across all filterable columns (uses LIKE matching) |
+
+### Partition filtering
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `use_last_partition` | boolean | `false` | When `true`, restricts the query to the most recent partition only, which improves performance on large tables |
+
+Available on: Device Control, Content-Aware Protection, eDiscovery, EasyLock.
 
 ## Response format
 
@@ -141,7 +145,7 @@ The date field used for filtering varies by endpoint (documented per endpoint be
 |---|---|
 | 200 | Success |
 | 400 | Bad request (invalid parameters) |
-| 401 | Unauthorized (missing or invalid API key) |
+| 401 | Unauthorized (missing or invalid token) |
 | 404 | Resource not found |
 | 405 | Method not allowed (only GET is supported) |
 | 429 | Rate limit exceeded |
@@ -149,58 +153,33 @@ The date field used for filtering varies by endpoint (documented per endpoint be
 
 ## Endpoints
 
-### Event Logs
+### Authentication
 
-Core device control event logs from the `log` table, joined with `event`, `clientmachine`, `clientuser`, `clientdevice`, and `devicetype` tables.
+**POST /login**
 
-**GET /event-logs**
+Authenticates with a username and password and returns a JWT token valid for 1 hour.
 
-Date field: `eventtime`
+Request body:
 
-Filters:
-
-| Parameter | Type | Description |
-|---|---|---|
-| `start_date` | string | Return records on or after this date |
-| `end_date` | string | Return records on or before this date |
-| `machine_name` | string | Filter by machine name (partial match) |
-| `client_name` | string | Filter by client name (partial match) |
-
-Response fields:
-
-| Field | Source | Description |
-|---|---|---|
-| `id` | `log.id` | Log entry ID |
-| `machine_id` | `log.machine_id` | Machine ID |
-| `machine_name` | `clientmachine.name` | Computer name (resolved via JOIN) |
-| `machine_ip` | `clientmachine.ip` | Computer IP address (resolved via JOIN) |
-| `client_id` | `log.client_id` | Client user ID |
-| `client_username` | `clientuser.username` | Username (resolved via JOIN) |
-| `device_type_id` | `log.device_type_id` | Device type ID |
-| `device_type_name` | `devicetype.name` | Device type name, e.g. "USB Storage" (resolved via JOIN) |
-| `device_id` | `log.device_id` | Device ID |
-| `device_name` | `clientdevice.name` | Device name (resolved via JOIN) |
-| `event_id` | `log.event_id` | Event ID |
-| `event_name` | `event.name` | Event name (resolved via JOIN) |
-| `eventtime` | `log.eventtime` | Event timestamp — server time (UTC) |
-| `eventtimelocal` | `log.eventtimelocal` | Event timestamp — client local time |
-| `filename` | `log.filename` | File name involved |
-| `filesize` | `log.filesize` | File size in bytes |
-| `filetype_extension` | `log.filetype_extension` | File extension |
-| `filenameduplicate` | `log.filenameduplicate` | Duplicate file name |
-| `filehash` | `log.filehash` | File hash (MD5) |
-| `created_at` | `log.created_at` | Record creation timestamp |
-| `created_by` | `log.created_by` | Record creator |
-
-Example:
-
-```bash
-GET /api/logs/event-logs?machine_name=WORKSTATION&start_date=2025-01-01&per_page=10
+```json
+{
+  "username": "admin",
+  "password": "secret"
+}
 ```
 
-**GET /event-logs/(id)**
+Response:
 
-Returns a single event log entry by ID with the same fields as the list endpoint.
+```json
+{
+  "success": true,
+  "data": {
+    "token": "eyJ..."
+  }
+}
+```
+
+Use the returned token in the `Authorization: Bearer` header for all subsequent requests.
 
 ### Device Control Logs
 
@@ -218,6 +197,7 @@ Filters:
 | `end_date` | string | Return records on or before this date |
 | `machine_name` | string | Filter by machine name (partial match) |
 | `client_name` | string | Filter by client name (partial match) |
+| `use_last_partition` | boolean | Restrict query to the most recent partition (default: `false`) |
 
 Response fields:
 
@@ -249,25 +229,7 @@ Response fields:
 | `timestamp` | `olog.timestamp` | Unix timestamp |
 | `department_id` | `olog.department_id` | Department ID |
 
-**GET /device-control/(id)**
-
-Returns a single device control log entry by ID with the same fields as the list endpoint.
-
-### Alert Statuses
-
-**GET /alert-statuses/(id)**
-
-Returns a single alert status entry by ID.
-
-Response fields: `id`, `alert_type`, `log_id`, `alert_id`, `status`, `email`, `timestamp`
-
 ### System Alerts
-
-**GET /system-alerts**
-
-Lists system alerts, joined with `sys_event` for event names.
-
-Response fields: `id`, `name`, `sys_event_id`, `event_name`
 
 **GET /system-alert-logs**
 
@@ -300,16 +262,9 @@ Filters:
 | `end_date` | string | Return records on or before this date |
 | `machine_name` | string | Filter by machine name (partial match) |
 | `client_name` | string | Filter by client name (partial match) |
+| `use_last_partition` | boolean | Restrict query to the most recent partition (default: `false`) |
 
 Response fields: `id`, `loclogid`, `event_id`, `machine_id`, `machine_name`, `ip`, `domain`, `client_id`, `client_name`, `destination_type`, `destination`, `filename`, `content_policy`, `content_policy_type`, `item_type`, `matched_item`, `item_details`, `eventtime`, `eventtimelocal`, `alert_flag`, `nr_reports`, `filesize`, `filehash`, `os_type`, `department_id`, `justification`, `event_name`
-
-:::note
-Hash columns (`loghash`, `loghasht`, etc.) are excluded from list responses for performance. Use the detail endpoint to retrieve all fields.
-:::
-
-**GET /content-aware-protection/(id)**
-
-Returns a single content filtering log with all fields (including hash columns and `event_name`).
 
 **GET /content-filtering-alerts**
 
@@ -335,47 +290,78 @@ Filters: `mm_device_id`, `action_ck`, `result_code`
 
 Response fields: `id`, `mm_device_id`, `action_ck`, `action`, `result_code`, `error_code`, `error_message`, `latitude`, `longitude`, `altitude`, `loctime`, `locqual`, `other`, `short_address`, `long_address`, `eventtime`
 
-**GET /mobile-management-alerts**
-
-Lists mobile management alert definitions.
-
-Filters: `mm_device_id`, `mm_event_id`
-
-Response fields: `id`, `name`, `mm_device_type_id`, `mm_device_id`, `mm_event_id`
-
-**GET /mobile-management-alert-logs**
-
-Date field: `created_at`
-
-Filters: `mm_device_type_id`, `mm_device_id`, `mm_event_id`
-
-Response fields: `id`, `mm_alert_name`, `mm_device_type_id`, `mm_device_id`, `mm_event_id`, `created_at`
-
 ### EasyLock Logs
 
 **GET /easy-lock**
 
-Date field: `created_at`
+Date field: `timestamp`
 
-Filters: `el_alert_name`, `el_event_name`, `el_client_name`, `el_device_machine`, `el_device_username`, `sent`
+Filters:
 
-Response fields: `id`, `el_alert_name`, `el_event_name`, `el_client_name`, `el_device_name`, `el_device_description`, `el_ip`, `el_device_vid`, `el_device_pid`, `el_device_serial`, `el_device_machine`, `el_device_username`, `sent`, `sent_at`, `created_at`
+| Parameter | Type | Description |
+|---|---|---|
+| `start_date` | string | Return records on or after this date |
+| `end_date` | string | Return records on or before this date |
+| `machine_name` | string | Filter by machine name (partial match) |
+| `client_name` | string | Filter by client name (partial match) |
+| `use_last_partition` | boolean | Restrict query to the most recent partition (default: `false`) |
 
-**GET /easylock-send-alert-logs**
+Response fields:
 
-Lists EasyLock send alert log entries, joined with `el_event` for event names.
+| Field | Description |
+|---|---|
+| `id` | Log entry ID |
+| `timestamp` | Unix timestamp of the event |
+| `machine_name` | Computer name |
+| `event_time_local` | Event timestamp in client local time |
+| `file_name` | File name involved |
+| `event_name` | Event name |
+| `file_type` | File type |
+| `ip` | Computer IP address |
+| `domain` | Computer domain |
+| `os_type` | Operating system type |
+| `device_name` | Device name |
+| `vid` | Device vendor ID |
+| `pid` | Device product ID |
+| `serial_no` | Device serial number |
+| `device_type_name` | Device type name |
+| `epp_client_version` | Endpoint Protector client version |
+| `os_version` | Operating system version |
 
-Filters: `event_id`, `machine_id`, `user_id`, `status`, `alert_flag`
+### eDiscovery (Data at Rest)
 
-Response fields: `id`, `event_id`, `machine_id`, `user_id`, `group_id`, `status`, `alert_flag`, `description`, `event_name`
+**GET /ediscovery**
 
-### Data at Rest
+Lists Data-at-Rest scan results.
 
-**GET /ediscovery/(id)**
+Date field: `timestamp`
 
-Returns a single Data-at-Rest alert with event name.
+Filters:
 
-Response fields: `id`, `name`, `dr_event_id`, `event_name`
+| Parameter | Type | Description |
+|---|---|---|
+| `start_date` | string | Return records on or after this date |
+| `end_date` | string | Return records on or before this date |
+| `machine_name` | string | Filter by machine name (partial match) |
+| `policy_name` | string | Filter by policy name (partial match) |
+| `file_name` | string | Filter by file name (partial match) |
+| `status` | string | Filter by scan result status (exact match) |
+| `use_last_partition` | boolean | Restrict query to the most recent partition (default: `false`) |
+
+Response fields:
+
+| Field | Description |
+|---|---|
+| `id` | Entry ID |
+| `timestamp` | Unix timestamp of the scan event |
+| `machine_name` | Computer name |
+| `event_time_local` | Event timestamp in client local time |
+| `file_name` | File name scanned |
+| `matched_item` | Matched content item |
+| `item_details` | Details of the matched item |
+| `policy_name` | Name of the policy that triggered the result |
+| `client_time` | Client-reported time |
+| `status` | Scan result status |
 
 ### SCIM Logs
 
@@ -395,32 +381,6 @@ Filters:
 | `resource_type` | string | Filter by resource type (User, Group, etc.) |
 
 Response fields: `id`, `timestamp`, `request_id`, `http_method`, `endpoint`, `status_code`, `actor`, `operation`, `resource_type`, `external_id`, `duration_ms`, `ip_address`, `user_agent`, `bulk_request_id`, `operation_index`
-
-:::note
-`request_body` and `response_body` are excluded from list responses. Use the detail endpoint.
-:::
-
-**GET /scim-logs/(id)**
-
-Returns a single SCIM log entry including `request_body` and `response_body`.
-
-### Authentication Logs
-
-**GET /auth-logs**
-
-Lists user authentication attempt logs, joined with `sf_guard_user` for usernames.
-
-Date field: `created_at`
-
-Filters:
-
-| Parameter | Type | Description |
-|---|---|---|
-| `user_id` | integer | Filter by user ID |
-| `ip` | string | Filter by IP address (partial match) |
-| `block` | integer | Filter by block status |
-
-Response fields: `id`, `user_id`, `ip`, `number_attempts`, `block`, `created_at`, `expire_at`, `username`
 
 ### Export Logs
 
@@ -456,44 +416,42 @@ Response fields: `id`, `user_id`, `created_at`, `section`, `log_type`, `operatio
 
 ## Usage examples
 
+**Authenticate and obtain a token**
+
+```bash
+TOKEN=$(curl -s -k -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"secret"}' \
+  "https://<epp-server>/api/logs/login" | jq -r '.data.token')
+```
+
 **List recent device control logs for a specific machine**
 
 ```bash
 curl -s -k \
-  -H "X-Api-Key: YOUR_API_KEY" \
-  "https://epp-server/api/logs/device-control?machine_name=WORKSTATION&sort_by=eventtime&sort_order=DESC&per_page=10"
+  -H "Authorization: Bearer ${TOKEN}" \
+  "https://<epp-server>/api/logs/device-control?machine_name=WORKSTATION&sort_by=eventtime&sort_order=DESC&per_page=10"
 ```
 
 **Get content filtering logs for a date range**
 
 ```bash
 curl -s -k \
-  -H "X-Api-Key: YOUR_API_KEY" \
-  "https://epp-server/api/logs/content-aware-protection?start_date=2025-01-01&end_date=2025-01-31&content_policy=PCI"
-```
-
-**Get a specific event log entry**
-
-```bash
-curl -s -k \
-  -H "X-Api-Key: YOUR_API_KEY" \
-  "https://epp-server/api/logs/event-logs/12345"
+  -H "Authorization: Bearer ${TOKEN}" \
+  "https://<epp-server>/api/logs/content-aware-protection?start_date=2025-01-01&end_date=2025-01-31&content_policy=PCI"
 ```
 
 ## Database tables reference
 
 | Endpoint Group | Primary Table | Joined Tables |
 |---|---|---|
-| Event Logs | `log` | `event`, `clientmachine`, `clientuser`, `clientdevice`, `devicetype` |
 | Device Control | `olog` | `event`, `devicetype`, `clientmachine`, `clientdevice` |
-| Alert Statuses | `alert_status` | — |
-| System Alerts | `sys_alert`, `sys_alert_log` | `sys_event` |
+| System Alerts | `sys_alert_log` | `sys_event` |
 | Content Filtering | `cf_log`, `cf_alert` | `event` |
-| Mobile Management | `mm_log`, `mm_alert`, `mm_alert_log` | — |
-| EasyLock | `el_alert_log`, `el_send_alert_log` | `el_event` |
-| Data at Rest | `dr_alert` | `dr_event` |
+| Mobile Management | `mm_log` | — |
+| EasyLock | `olog` | — |
+| eDiscovery | `dr_object` | — |
 | SCIM Logs | `scim_log` | — |
-| Auth Logs | `sf_guard_log` | `sf_guard_user` |
 | Export Logs | `export_log_list` | — |
 | Admin Actions | `admin_action` | `sf_guard_user` |
 
@@ -564,5 +522,5 @@ The API includes CORS headers allowing cross-origin requests from any origin. Th
 
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, OPTIONS`
-- `Access-Control-Allow-Headers: Content-Type, X-Api-Key, Authorization`
+- `Access-Control-Allow-Headers: Content-Type, Authorization`
 - `Access-Control-Max-Age: 86400`

--- a/docs/endpointprotector/admin/API Logs/apispecification.md
+++ b/docs/endpointprotector/admin/API Logs/apispecification.md
@@ -206,7 +206,7 @@ Returns a single event log entry by ID with the same fields as the list endpoint
 
 Online device tracking logs from the `olog` table, joined with `event`, `devicetype`, `clientmachine`, and `clientdevice` tables.
 
-**GET /device-control-logs**
+**GET /device-control**
 
 Date field: `eventtime`
 
@@ -249,7 +249,7 @@ Response fields:
 | `timestamp` | `olog.timestamp` | Unix timestamp |
 | `department_id` | `olog.department_id` | Department ID |
 
-**GET /device-control-logs/(id)**
+**GET /device-control/(id)**
 
 Returns a single device control log entry by ID with the same fields as the list endpoint.
 
@@ -288,7 +288,7 @@ Response fields: `id`, `sys_alert_name`, `sys_event_id`, `sys_event_opt_id`, `cr
 
 Content-Aware Protection logs and alerts, joined with `event` table for event names.
 
-**GET /content-filtering-logs**
+**GET /content-aware-protection**
 
 Date field: `eventtime`
 
@@ -307,7 +307,7 @@ Response fields: `id`, `loclogid`, `event_id`, `machine_id`, `machine_name`, `ip
 Hash columns (`loghash`, `loghasht`, etc.) are excluded from list responses for performance. Use the detail endpoint to retrieve all fields.
 :::
 
-**GET /content-filtering-logs/(id)**
+**GET /content-aware-protection/(id)**
 
 Returns a single content filtering log with all fields (including hash columns and `event_name`).
 
@@ -353,7 +353,7 @@ Response fields: `id`, `mm_alert_name`, `mm_device_type_id`, `mm_device_id`, `mm
 
 ### EasyLock Logs
 
-**GET /easylock-alert-logs**
+**GET /easy-lock**
 
 Date field: `created_at`
 
@@ -371,7 +371,7 @@ Response fields: `id`, `event_id`, `machine_id`, `user_id`, `group_id`, `status`
 
 ### Data at Rest
 
-**GET /data-rest-alerts/(id)**
+**GET /ediscovery/(id)**
 
 Returns a single Data-at-Rest alert with event name.
 
@@ -461,7 +461,7 @@ Response fields: `id`, `user_id`, `created_at`, `section`, `log_type`, `operatio
 ```bash
 curl -s -k \
   -H "X-Api-Key: YOUR_API_KEY" \
-  "https://epp-server/api/logs/device-control-logs?machine_name=WORKSTATION&sort_by=eventtime&sort_order=DESC&per_page=10"
+  "https://epp-server/api/logs/device-control?machine_name=WORKSTATION&sort_by=eventtime&sort_order=DESC&per_page=10"
 ```
 
 **Get content filtering logs for a date range**
@@ -469,7 +469,7 @@ curl -s -k \
 ```bash
 curl -s -k \
   -H "X-Api-Key: YOUR_API_KEY" \
-  "https://epp-server/api/logs/content-filtering-logs?start_date=2025-01-01&end_date=2025-01-31&content_policy=PCI"
+  "https://epp-server/api/logs/content-aware-protection?start_date=2025-01-01&end_date=2025-01-31&content_policy=PCI"
 ```
 
 **Get a specific event log entry**

--- a/docs/endpointprotector/admin/API Logs/logrestapi.md
+++ b/docs/endpointprotector/admin/API Logs/logrestapi.md
@@ -86,7 +86,7 @@ If your Endpoint Protector server uses a self-signed certificate, add `-k` to th
 ```bash
 curl -s \
   -H "X-Api-Key: YOUR_API_KEY" \
-  "https://<epp-server>/api/logs/device-control-logs?sort_by=eventtime&sort_order=DESC&per_page=10"
+  "https://<epp-server>/api/logs/device-control?sort_by=eventtime&sort_order=DESC&per_page=10"
 ```
 
 ## Common query parameters
@@ -209,7 +209,7 @@ Returns a single event log entry by ID.
 
 Online device tracking logs.
 
-**GET /device-control-logs**
+**GET /device-control**
 
 Date field: `eventtime`
 
@@ -217,7 +217,7 @@ Filters (in addition to common params):
 - `machine_name` (partial match)
 - `client_name` (partial match)
 
-**GET /device-control-logs/(id)**
+**GET /device-control/(id)**
 
 Returns a single device control log entry by ID.
 
@@ -239,7 +239,7 @@ Lists system alert log entries. Date field: `created_at`
 
 ### Content Filtering (CAP)
 
-**GET /content-filtering-logs**
+**GET /content-aware-protection**
 
 Lists Content Aware Protection logs. Date field: `eventtime`
 
@@ -247,7 +247,7 @@ Common filters include:
 - `machine_name`
 - `client_name`
 
-**GET /content-filtering-logs/(id)**
+**GET /content-aware-protection/(id)**
 
 Returns a single log entry (includes fields excluded from list responses for performance).
 
@@ -275,7 +275,7 @@ Date field: `created_at`
 
 ### EasyLock (Enforced Encryption)
 
-**GET /easylock-alert-logs**
+**GET /easy-lock**
 
 Date field: `created_at`
 
@@ -285,7 +285,7 @@ Lists EasyLock send alert log entries.
 
 ### Data at Rest (eDiscovery)
 
-**GET /data-rest-alerts/(id)**
+**GET /ediscovery/(id)**
 
 Returns a single Data-at-Rest alert entry by ID.
 

--- a/docs/endpointprotector/admin/API Logs/logrestapi.md
+++ b/docs/endpointprotector/admin/API Logs/logrestapi.md
@@ -44,7 +44,7 @@ The Logs REST API provides a read-only interface to query Endpoint Protector log
 - Automation and integrations with internal tools
 
 :::info
-The Logs REST API is read-only. It supports GET (and OPTIONS for CORS preflight). Other methods return 405 Method Not Allowed.
+The Logs REST API is read-only for log data. The only write operation is `POST /login` to obtain an authentication token. All log endpoints are GET-only; other methods return 405 Method Not Allowed.
 :::
 
 ## Base URL and protocol
@@ -55,11 +55,15 @@ The Logs REST API is read-only. It supports GET (and OPTIONS for CORS preflight)
 
 ## Authentication
 
-Authentication uses JWT (JSON Web Tokens) with HS256 signing. Call `POST /login` with your credentials to receive a token valid for 1 hour, then include it in subsequent requests:
+Authentication uses JWT (JSON Web Tokens) with HS256 signing. Call `POST /login` at `https://<epp-server>/api/login` with your credentials to receive a token valid for 1 hour, then include it in subsequent requests:
 
 ```
 Authorization: Bearer <token>
 ```
+
+:::note
+The login endpoint is at `/api/login`, separate from the log endpoints at `/api/logs/`.
+:::
 
 ## Quick start
 
@@ -68,8 +72,8 @@ Authorization: Bearer <token>
 ```bash
 TOKEN=$(curl -s -k -X POST \
   -H "Content-Type: application/json" \
-  -d '{"username":"admin","password":"secret"}' \
-  "https://<epp-server>/api/logs/login" | jq -r '.data.token')
+  -d '{"username": "admin", "password": "your_password"}' \
+  "https://<epp-server>/api/login" | python -c "import sys,json; print(json.load(sys.stdin)['data']['token'])")
 ```
 
 :::note
@@ -81,7 +85,7 @@ If your Endpoint Protector server uses a self-signed certificate, add `-k` to th
 ```bash
 curl -s -k \
   -H "Authorization: Bearer ${TOKEN}" \
-  "https://<epp-server>/api/logs/device-control?sort_by=eventtime&sort_order=DESC&per_page=10"
+  "https://<epp-server>/api/logs/device-control?sort_by=timestamp&sort_order=DESC&per_page=10"
 ```
 
 ## Common query parameters
@@ -157,7 +161,7 @@ The date field used for filtering depends on the endpoint (documented in each en
   "success": false,
   "error": {
     "code": 401,
-    "message": "Unauthorized"
+    "message": "Missing authentication token. Provide via Authorization: Bearer <token> header."
   }
 }
 ```
@@ -168,9 +172,9 @@ The date field used for filtering depends on the endpoint (documented in each en
 |---|---|
 | 200 | Success |
 | 400 | Invalid parameters |
-| 401 | Missing/invalid API key |
+| 401 | Missing or invalid JWT token |
 | 404 | Resource not found |
-| 405 | Method not allowed (GET-only) |
+| 405 | Method not allowed |
 | 429 | Rate limit exceeded |
 | 500 | Internal error |
 
@@ -180,9 +184,9 @@ The date field used for filtering depends on the endpoint (documented in each en
 
 ### Authentication
 
-**POST /login**
+**POST /login** — `https://<epp-server>/api/login`
 
-Authenticates with a username and password and returns a JWT token.
+Authenticates with a username and password and returns a JWT token. This endpoint is at the `/api/` base, not under `/api/logs/`.
 
 ### Device Control Logs
 
@@ -190,7 +194,7 @@ Online device tracking logs.
 
 **GET /device-control**
 
-Date field: `eventtime`
+Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters (in addition to common params):
 - `machine_name` (partial match)
@@ -207,7 +211,7 @@ Lists system alert log entries. Date field: `created_at`
 
 **GET /content-aware-protection**
 
-Lists Content Aware Protection logs. Date field: `eventtime`
+Lists Content-Aware Protection logs. Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters (in addition to common params):
 - `machine_name` (partial match)
@@ -216,23 +220,13 @@ Filters (in addition to common params):
 
 **GET /content-filtering-alerts**
 
-Lists content filtering alert definitions.
-
-**GET /content-filtering-alerts/(id)**
-
-Returns a single alert definition.
-
-### Mobile Management
-
-**GET /mobile-management-logs**
-
-Date field: `eventtime`
+Lists content filtering alert definitions. Date field: `created_at`
 
 ### EasyLock (Enforced Encryption)
 
 **GET /easy-lock**
 
-Date field: `timestamp`
+Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters (in addition to common params):
 - `machine_name` (partial match)
@@ -243,7 +237,7 @@ Filters (in addition to common params):
 
 **GET /ediscovery**
 
-Lists Data-at-Rest scan results. Date field: `timestamp`
+Lists Data-at-Rest scan results. Date field: `timestamp` (unix timestamp, converted from user-supplied date strings)
 
 Filters (in addition to common params):
 - `machine_name` (partial match)
@@ -257,12 +251,6 @@ Filters (in addition to common params):
 **GET /scim-logs**
 
 Lists SCIM API request logs.
-
-### Export Logs
-
-**GET /export-logs/(id)**
-
-Returns a single export job log entry by ID.
 
 ### Admin Actions
 
@@ -280,8 +268,8 @@ The API enforces rate limiting to protect the server and ensure fair usage. When
 
 ## CORS
 
-CORS is enabled to support browser-based integrations:
+CORS is enabled to support browser-based integrations. Origins must be listed in the server's `cors_allowed_origins` configuration:
 
-- `Access-Control-Allow-Origin: *`
-- `Access-Control-Allow-Methods: GET, OPTIONS`
+- `Access-Control-Allow-Origin: <configured-origin>`
+- `Access-Control-Allow-Methods: GET, POST, OPTIONS`
 - `Access-Control-Allow-Headers: Content-Type, Authorization`

--- a/docs/endpointprotector/admin/API Logs/logrestapi.md
+++ b/docs/endpointprotector/admin/API Logs/logrestapi.md
@@ -55,26 +55,21 @@ The Logs REST API is read-only. It supports GET (and OPTIONS for CORS preflight)
 
 ## Authentication
 
-All requests require authentication using an API key:
+Authentication uses JWT (JSON Web Tokens) with HS256 signing. Call `POST /login` with your credentials to receive a token valid for 1 hour, then include it in subsequent requests:
 
-| Method | Header / Format | Example |
-|---|---|---|
-| Recommended | `X-Api-Key: <key>` | `X-Api-Key: abc123...` |
-| Alternative | `Authorization: Bearer <key>` | `Authorization: Bearer abc123...` |
-| Alternative | Query parameter | `?api_key=abc123...` |
-
-:::note
-When called from the Endpoint Protector web interface, the API can also use an active server session cookie. For external integrations, always use an API key.
-:::
+```
+Authorization: Bearer <token>
+```
 
 ## Quick start
 
-**1) List supported endpoints (discovery)**
+**1) Authenticate and obtain a token**
 
 ```bash
-curl -s \
-  -H "X-Api-Key: YOUR_API_KEY" \
-  "https://<epp-server>/api/logs/endpoints"
+TOKEN=$(curl -s -k -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"secret"}' \
+  "https://<epp-server>/api/logs/login" | jq -r '.data.token')
 ```
 
 :::note
@@ -84,8 +79,8 @@ If your Endpoint Protector server uses a self-signed certificate, add `-k` to th
 **2) Query recent Device Control logs**
 
 ```bash
-curl -s \
-  -H "X-Api-Key: YOUR_API_KEY" \
+curl -s -k \
+  -H "Authorization: Bearer ${TOKEN}" \
   "https://<epp-server>/api/logs/device-control?sort_by=eventtime&sort_order=DESC&per_page=10"
 ```
 
@@ -162,7 +157,7 @@ The date field used for filtering depends on the endpoint (documented in each en
   "success": false,
   "error": {
     "code": 401,
-    "message": "Missing API key. Provide via X-Api-Key header or api_key query parameter."
+    "message": "Unauthorized"
   }
 }
 ```
@@ -183,27 +178,11 @@ The date field used for filtering depends on the endpoint (documented in each en
 
 ## Logs REST API Technical Reference
 
-### Discovery
+### Authentication
 
-**GET /endpoints**
+**POST /login**
 
-Returns API name/version and a list of supported routes for the current server build.
-
-### Event Logs
-
-Core device control event logs.
-
-**GET /event-logs**
-
-Date field: `eventtime`
-
-Filters (in addition to common params):
-- `machine_name` (partial match)
-- `client_name` (partial match)
-
-**GET /event-logs/(id)**
-
-Returns a single event log entry by ID.
+Authenticates with a username and password and returns a JWT token.
 
 ### Device Control Logs
 
@@ -216,22 +195,9 @@ Date field: `eventtime`
 Filters (in addition to common params):
 - `machine_name` (partial match)
 - `client_name` (partial match)
-
-**GET /device-control/(id)**
-
-Returns a single device control log entry by ID.
-
-### Alert Statuses
-
-**GET /alert-statuses/(id)**
-
-Returns a single alert status entry by ID.
+- `use_last_partition` (boolean, default: `false`)
 
 ### System Alerts
-
-**GET /system-alerts**
-
-Lists system alert definitions.
 
 **GET /system-alert-logs**
 
@@ -243,13 +209,10 @@ Lists system alert log entries. Date field: `created_at`
 
 Lists Content Aware Protection logs. Date field: `eventtime`
 
-Common filters include:
-- `machine_name`
-- `client_name`
-
-**GET /content-aware-protection/(id)**
-
-Returns a single log entry (includes fields excluded from list responses for performance).
+Filters (in addition to common params):
+- `machine_name` (partial match)
+- `client_name` (partial match)
+- `use_last_partition` (boolean, default: `false`)
 
 **GET /content-filtering-alerts**
 
@@ -265,45 +228,35 @@ Returns a single alert definition.
 
 Date field: `eventtime`
 
-**GET /mobile-management-alerts**
-
-Lists mobile management alert definitions.
-
-**GET /mobile-management-alert-logs**
-
-Date field: `created_at`
-
 ### EasyLock (Enforced Encryption)
 
 **GET /easy-lock**
 
-Date field: `created_at`
+Date field: `timestamp`
 
-**GET /easylock-send-alert-logs**
+Filters (in addition to common params):
+- `machine_name` (partial match)
+- `client_name` (partial match)
+- `use_last_partition` (boolean, default: `false`)
 
-Lists EasyLock send alert log entries.
+### eDiscovery (Data at Rest)
 
-### Data at Rest (eDiscovery)
+**GET /ediscovery**
 
-**GET /ediscovery/(id)**
+Lists Data-at-Rest scan results. Date field: `timestamp`
 
-Returns a single Data-at-Rest alert entry by ID.
+Filters (in addition to common params):
+- `machine_name` (partial match)
+- `policy_name` (partial match)
+- `file_name` (partial match)
+- `status` (exact match)
+- `use_last_partition` (boolean, default: `false`)
 
 ### SCIM Provisioning Logs
 
 **GET /scim-logs**
 
 Lists SCIM API request logs.
-
-**GET /scim-logs/(id)**
-
-Returns a single SCIM log entry including request/response bodies.
-
-### Authentication Logs
-
-**GET /auth-logs**
-
-Lists authentication attempt logs. Date field: `created_at`
 
 ### Export Logs
 
@@ -331,4 +284,4 @@ CORS is enabled to support browser-based integrations:
 
 - `Access-Control-Allow-Origin: *`
 - `Access-Control-Allow-Methods: GET, OPTIONS`
-- `Access-Control-Allow-Headers: Content-Type, X-Api-Key, Authorization`
+- `Access-Control-Allow-Headers: Content-Type, Authorization`

--- a/docs/endpointprotector/admin/reports.md
+++ b/docs/endpointprotector/admin/reports.md
@@ -57,7 +57,7 @@ This matrix refers to clients from the 5.9.0.0 release and higher.
 :::
 
 
-Please see the table below for a detailed view of the events.
+The following table provides a detailed view of the events.
 
 **File Tracing Events Matrix by Direction**
 
@@ -97,7 +97,7 @@ When using the latestEndpoint Protector client, you can view log details structu
 Expand each entry from the log report list to view the Log Details expanded section, providing the
 following information:
 
-- Policy – select an active policy from the drop-down list
+- Policy – select an active policy from the dropdown list
 - Policy name – the name of the selected policy
 - Policy type – the type of the selected policy
 - Items type – the Policy Denylist category selected
@@ -112,21 +112,20 @@ following information:
 
 Use the **Show/Hide Columns** dropdown to customize which columns are visible in the report. The **Date/Time(Client UTC)** column is available in this dropdown but is hidden by default.
 
-From the Filters section, check the **Include old logs prior to 5.7** upgrade option from the ﬁlter
-section to include all logs in your searches. If the option is not selected, the ﬁlters will apply
+From the Filters section, check the **Include old logs before 5.7** upgrade option from the filter
+section to include all logs in your searches. If the option isn't selected, the filters will apply
 only to the new structure of logs. The **Date/Time(Client UTC)** field is also available as a filter option.
 
 ![Content Aware Protection Filters](capfilters.webp)
 
 For Mac users, when the Deep Packet Inspection feature is enabled on the Endpoint Protector agent
-for Mac, there might be certain scenarios where the agent does not provide full destination details
+for Mac, there might be certain scenarios where the agent doesn't provide full destination details
 for ﬁles being transferred from a network share through monitored applications, such as browsers. In
 such cases, the destination information may not be fully captured in the monitoring process
 
-For Linux users, it's important to note that the Endpoint Protector agent does not currently support
-network share visibility, except in situations where ﬁles are being transferred from a network share
-through Deep Packet Inspection monitored applications, like browsers. In other scenarios, network
-share visibility might not be available.
+For Linux users, the Endpoint Protector agent doesn't support network share visibility, except when
+files are transferred from a network share through Deep Packet Inspection monitored applications,
+such as browsers. In other scenarios, network share visibility isn't available.
 
 ### Export Content Aware Reports
 
@@ -150,6 +149,36 @@ click View Export List to open the list of Reports, where you can download or de
 ![Viewing Export List ](viewexportlist.webp)
 
 ![Export List Results ](exportlistresults.webp)
+
+## Export List
+
+The Export List shows all exports you have created, regardless of log type. Access it at any time by clicking **View Export List** in any log report section.
+
+From the Export List you can download completed exports or delete entries you no longer need.
+
+### Background processing
+
+When you click **Create Export**, Endpoint Protector queues the request and processes it in the background. The server processes one export at a time. This means:
+
+- You don't need to stay on the page while the export runs.
+- If an export is already running, your new request waits in the queue.
+- You can't create additional exports while the banner is showing.
+
+When an export is in progress, a banner appears at the top of the page:
+
+<!-- vale Netwrix.TemporalHedges = NO -->
+> *A log Report Export is currently running and will be ready soon. Until then, no additional Exports can be created and the displaying Log Report Results may be slower.*
+<!-- vale Netwrix.TemporalHedges = YES -->
+
+Wait for the current export to finish before starting a new one. The banner disappears when processing is complete. Large exports may take several minutes depending on the number of records and the load on the server.
+
+:::note
+If a system backup is running at the same time as an export, queued exports are cancelled automatically. Create the export again after the backup completes.
+:::
+
+### Export retention
+
+Completed exports are automatically deleted after 7 days.
 
 ## Admin Actions
 


### PR DESCRIPTION
…nd export process

- Corrected four wrong endpoint names in API Logs docs: /device-control-logs → /device-control /content-filtering-logs → /content-aware-protection /easylock-alert-logs → /easy-lock /data-rest-alerts → /ediscovery
- Added Export List section to Reports and Analysis explaining background export processing, queue behavior, banner messages, and export retention (addresses ADO #414334)
- Fixed pre-existing Vale warnings in reports.md

Generated with AI