### PR TITLE
NPS-D: remove sudo from docker login in AWS configuration

### DIFF
--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -43,7 +43,7 @@ After configuring credentials, authenticate Docker with the Netwrix ECR registry
 ```bash
 # Log in to ECR:
 aws ecr get-login-password --region us-west-2 | \
-  sudo docker login --username AWS --password-stdin \
+  docker login --username AWS --password-stdin \
   176947481038.dkr.ecr.us-west-2.amazonaws.com
 ```
 

--- a/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
+++ b/docs/privilegesecurediscovery/2.22/installation/containerbaseddeployment/awsconfiguration.md
@@ -6,7 +6,7 @@ sidebar_position: 30
 
 # AWS Configuration
 
-Netwrix hosts NPS-D container images in a private Amazon Elastic Container Registry (ECR). You must
+Netwrix hosts Netwrix Privilege Secure for Discovery (NPS-D) container images in a private Amazon Elastic Container Registry (ECR). You must
 authenticate each Ubuntu machine in the deployment with ECR before `secureone.sh` can pull images.
 
 Complete these steps on every node — primary and secondary — before running the deployment script.
@@ -20,7 +20,7 @@ credentials.
 ## Configure AWS Credentials
 
 Run the following command and follow the prompts to enter the AWS Access Key ID, Secret Access Key,
-and region. Use the credentials provided to you by Netwrix Support.
+and region. Use the credentials Netwrix Support provides.
 
 ```bash
 # Configure AWS:


### PR DESCRIPTION
## Summary

- Removed `sudo` from the `docker login` command in the AWS configuration guide — the command should run as the current user, not root, consistent with the secureone.sh help output

## Test plan

- [ ] Verify docker login command in awsconfiguration.md has no sudo
- [ ] Confirm build passes

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>