### PR TITLE
fix: cap sidebar collapse animation to 200ms

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -531,6 +531,17 @@ html {
 }
 
 /* ============================================================
+   API Reference — sidebar collapse animation
+   Docusaurus calculates collapse transition duration proportional to
+   content height. With 112 tag groups (~4340px), the default formula
+   produces ~800ms — noticeably slow. Cap it to match --ifm-transition-fast.
+   !important is required to override the inline style set by useCollapsible.
+   ============================================================ */
+.theme-doc-sidebar-menu .menu__list {
+    transition-duration: 200ms !important;
+}
+
+/* ============================================================
    API Reference — HTTP method badges in sidebar
    Classes (e.g. "api-method get") come from docusaurus-plugin-openapi-docs
    generated sidebar.ts. The theme does not ship this CSS.


### PR DESCRIPTION
## Summary

- Docusaurus calculates sidebar collapse transition duration proportional to content height
- The API Reference section (112 tag groups, ~4340px) triggered a ~778ms animation — nearly a second of perceived delay when collapsing the category
- One CSS rule in `src/css/custom.css` caps `transition-duration` to `200ms` (`--ifm-transition-fast`) across all sidebar menu lists, eliminating the sluggishness

## Why `!important`

The duration is set as an **inline style** by Docusaurus's `useCollapsible` hook (`transition: height 778ms ease-in-out`). CSS stylesheets cannot override inline styles without `!important`. The rule is scoped to `.theme-doc-sidebar-menu .menu__list` to limit its reach to the sidebar only.

## Test plan

- [ ] Navigate to any Change Tracker 8.1 API endpoint (e.g. `/docs/changetracker/8_1/api/reference/acknowledge-events-get`)
- [ ] Click the **API Reference** chevron to collapse — should snap closed in ~200ms with no perceptible delay
- [ ] Verify other collapsible sections (Requirements, Administration, etc.) still animate normally

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>