### PR TITLE
fix: skip codeowner notification for kb/review issues

### DIFF
--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -111,6 +111,12 @@ jobs:
             exit 0
           fi
 
+          # Skip codeowner notification for KB PR review tracking issues
+          if echo "$LABELS" | grep -q "kb/review"; then
+            echo "Issue has kb/review label — skipping codeowner notification"
+            exit 0
+          fi
+
           # Read the mapping file
           MAPPING=$(cat .github/label-codeowners.json)
 


### PR DESCRIPTION
  ### Summary:
  - KB PR review tracking issues were unintentionally triggering codeowner team notifications via the issue labeler workflow
  - Added an early exit in Step 4 of claude-issue-labeler.yml when a kb/review label is present

###   Changes:
  - .github/workflows/claude-issue-labeler.yml — added 3-line guard before the codeowner mapping lookup
  - issues with kb/review label now exit Step 4 early with a log message instead of pinging product teams

 ###  Testing:
  - Verified logic locally with two bash tests:
    - Labels including kb/review → exits early, no notification sent 
    - Labels without kb/review (e.g. auditor, bug) → proceeds to notify codeowners as expected 
