### PR TITLE
emove unsupported semver cooldown props from github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,5 +15,3 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-minor-days: 2
-      semver-patch-days: 2


### PR DESCRIPTION
The github-actions ecosystem only supports default-days in the cooldown block; semver-minor-days and semver-patch-days are npm-only.

Generated with AI