### PR TITLE
fix(deps): group all @docusaurus/* packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       default-days: 7
       semver-minor-days: 2
       semver-patch-days: 2
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Docusaurus 3.10.1 added a startup check requiring all @docusaurus/* packages to be at exactly the same version as @docusaurus/core. Without grouping, Dependabot opens separate PRs per package, creating partial-update states that fail the version consistency check.
