### PR TITLE
feat: add Claude code review bot for non-doc PRs

### DIFF
--- a/.github/workflows/claude-code-followup.yml
+++ b/.github/workflows/claude-code-followup.yml
@@ -1,0 +1,90 @@
+name: Code Review Followup
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  code-followup:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    concurrency:
+      group: code-followup-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository,headRefOid)
+          BASE_BRANCH=$(echo "$PR_DATA" | jq -r '.baseRefName')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
+          echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$(echo "$PR_DATA" | jq -r '.isCrossRepository')" >> "$GITHUB_OUTPUT"
+          if [ "$BASE_BRANCH" = "dev" ]; then
+            echo "targets_dev=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "targets_dev=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post fork notice
+        if: steps.pr-info.outputs.is_fork == 'true' && steps.pr-info.outputs.targets_dev == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ steps.pr-info.outputs.number }} --repo ${{ github.repository }} \
+            --body "This PR is from a fork. I can suggest changes but cannot push fixes directly."
+
+      - name: React with eyes
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST -f content="eyes"
+
+      - name: Checkout base repository
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.VALE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Switch to PR branch
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        env:
+          BRANCH: ${{ steps.pr-info.outputs.branch }}
+          SHA: ${{ steps.pr-info.outputs.sha }}
+        run: |
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "$SHA"
+
+      - name: Handle @claude request
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        uses: anthropics/claude-code-action@24492741e0ccfdef4c1d19da8e11e0f373d07494 # v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          prompt: |
+            A contributor has tagged @claude on PR #${{ steps.pr-info.outputs.number }} in ${{ github.repository }}.
+
+            Their request: ${{ github.event.comment.body }}
+
+            Read the PR diff, understand the change, and fulfill the request. You can read and edit
+            files, run git commands, and push commits to the branch. If asked to fix something,
+            apply the fix and commit it. If asked a question, answer it as a PR comment.
+          claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -125,7 +125,9 @@ jobs:
 
       - name: Attach to branch
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        run: git checkout -B "${{ steps.pr-info.outputs.branch }}"
+        env:
+          BRANCH: ${{ steps.pr-info.outputs.branch }}
+        run: git checkout -B "$BRANCH"
 
       - name: Handle @claude request
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,12 +10,9 @@ on:
       - 'docs/kb/**'
       - 'static/**'
 
-  issue_comment:
-    types: [created]
-
 jobs:
   code-review:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false
     concurrency:
       group: code-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -64,86 +61,3 @@ jobs:
             Post your findings as a single PR comment starting with "## Code Review".
             If there are no issues, say so briefly.
           claude_args: '--allowedTools "Bash(gh:*),Read,Glob,Grep"'
-
-  code-followup:
-    if: >-
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '@claude') &&
-      github.event.comment.user.type != 'Bot' &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-    concurrency:
-      group: code-followup-${{ github.event.issue.number }}
-      cancel-in-progress: false
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Get PR info
-        id: pr-info
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER="${{ github.event.issue.number }}"
-          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository,headRefOid)
-          BASE_BRANCH=$(echo "$PR_DATA" | jq -r '.baseRefName')
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
-          echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
-          echo "is_fork=$(echo "$PR_DATA" | jq -r '.isCrossRepository')" >> "$GITHUB_OUTPUT"
-          if [ "$BASE_BRANCH" = "dev" ]; then
-            echo "targets_dev=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "targets_dev=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Post fork notice
-        if: steps.pr-info.outputs.is_fork == 'true' && steps.pr-info.outputs.targets_dev == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr comment ${{ steps.pr-info.outputs.number }} --repo ${{ github.repository }} \
-            --body "This PR is from a fork. I can suggest changes but cannot push fixes directly."
-
-      - name: React with eyes
-        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
-            --method POST -f content="eyes"
-
-      - name: Checkout repository
-        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          ref: ${{ steps.pr-info.outputs.sha }}
-          token: ${{ secrets.VALE_TOKEN }}
-          fetch-depth: 0
-
-      - name: Attach to branch
-        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        env:
-          BRANCH: ${{ steps.pr-info.outputs.branch }}
-        run: git checkout -B "$BRANCH"
-
-      - name: Handle @claude request
-        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        uses: anthropics/claude-code-action@24492741e0ccfdef4c1d19da8e11e0f373d07494 # v1
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          show_full_output: true
-          prompt: |
-            A contributor has tagged @claude on PR #${{ steps.pr-info.outputs.number }} in ${{ github.repository }}.
-
-            Their request: ${{ github.event.comment.body }}
-
-            Read the PR diff, understand the change, and fulfill the request. You can read and edit
-            files, run git commands, and push commits to the branch. If asked to fix something,
-            apply the fix and commit it. If asked a question, answer it as a PR comment.
-          claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -38,7 +37,7 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
           COMMENT_IDS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments --paginate \
-            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Code Review"))) | .id] | .[]' 2>/dev/null || true)
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("## Code Review"))) | .id] | .[]' 2>/dev/null || true)
           for ID in $COMMENT_IDS; do
             gh api repos/${{ github.repository }}/issues/comments/${ID} -X DELETE 2>/dev/null || true
           done
@@ -71,7 +70,7 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude') &&
-      !startsWith(github.event.comment.user.login, 'github-actions') &&
+      github.event.comment.user.type != 'Bot' &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     concurrency:
       group: code-followup-${{ github.event.issue.number }}
@@ -81,7 +80,6 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Get PR info
         id: pr-info
@@ -124,6 +122,10 @@ jobs:
           ref: ${{ steps.pr-info.outputs.sha }}
           token: ${{ secrets.VALE_TOKEN }}
           fetch-depth: 0
+
+      - name: Attach to branch
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        run: git checkout -B "${{ steps.pr-info.outputs.branch }}"
 
       - name: Handle @claude request
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -89,10 +89,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ github.event.issue.number }}"
-          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository)
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository,headRefOid)
           BASE_BRANCH=$(echo "$PR_DATA" | jq -r '.baseRefName')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
+          echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
           echo "is_fork=$(echo "$PR_DATA" | jq -r '.isCrossRepository')" >> "$GITHUB_OUTPUT"
           if [ "$BASE_BRANCH" = "dev" ]; then
             echo "targets_dev=true" >> "$GITHUB_OUTPUT"
@@ -120,7 +121,7 @@ jobs:
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ steps.pr-info.outputs.branch }}
+          ref: ${{ steps.pr-info.outputs.sha }}
           token: ${{ secrets.VALE_TOKEN }}
           fetch-depth: 0
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,145 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - dev
+    paths-ignore:
+      - 'docs/**/*.md'
+      - 'docs/**/CLAUDE.md'
+      - 'docs/**/SKILL.md'
+      - 'docs/kb/**'
+      - 'static/**'
+
+  issue_comment:
+    types: [created]
+
+jobs:
+  code-review:
+    if: github.event_name == 'pull_request'
+    concurrency:
+      group: code-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Delete previous bot review comments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          COMMENT_IDS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Code Review"))) | .id] | .[]' 2>/dev/null || true)
+          for ID in $COMMENT_IDS; do
+            gh api repos/${{ github.repository }}/issues/comments/${ID} -X DELETE 2>/dev/null || true
+          done
+
+      - name: Run code review
+        uses: anthropics/claude-code-action@24492741e0ccfdef4c1d19da8e11e0f373d07494 # v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          prompt: |
+            Review this PR for correctness issues. Focus on:
+            - Bugs, broken logic, or unintended side effects
+            - Security issues (injection, exposed secrets, unsafe eval, etc.)
+            - Docusaurus config changes that could break the build or routing (products.js, docusaurus.config.js, sidebars)
+            - Script changes that could break the KB copy pipeline or build process
+            - GitHub Actions workflow changes — correct triggers, permissions, and secret usage
+
+            Do NOT review documentation content or style — a separate workflow handles that.
+
+            Use `gh pr diff ${{ github.event.pull_request.number }}` to read the diff.
+            Post your findings as a single PR comment starting with "## Code Review".
+            If there are no issues, say so briefly.
+          claude_args: '--allowedTools "Bash(gh:*),Read,Glob,Grep"'
+
+  code-followup:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      !startsWith(github.event.comment.user.login, 'github-actions')
+    concurrency:
+      group: code-followup-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository)
+          BASE_BRANCH=$(echo "$PR_DATA" | jq -r '.baseRefName')
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$(echo "$PR_DATA" | jq -r '.isCrossRepository')" >> "$GITHUB_OUTPUT"
+          if [ "$BASE_BRANCH" = "dev" ]; then
+            echo "targets_dev=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "targets_dev=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post fork notice
+        if: steps.pr-info.outputs.is_fork == 'true' && steps.pr-info.outputs.targets_dev == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ steps.pr-info.outputs.number }} --repo ${{ github.repository }} \
+            --body "This PR is from a fork. I can suggest changes but cannot push fixes directly."
+
+      - name: React with eyes
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST -f content="eyes"
+
+      - name: Checkout repository
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ steps.pr-info.outputs.branch }}
+          token: ${{ secrets.VALE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Handle @claude request
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        uses: anthropics/claude-code-action@24492741e0ccfdef4c1d19da8e11e0f373d07494 # v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          show_full_output: true
+          prompt: |
+            A contributor has tagged @claude on PR #${{ steps.pr-info.outputs.number }} in ${{ github.repository }}.
+
+            Their request: ${{ github.event.comment.body }}
+
+            Read the PR diff, understand the change, and fulfill the request. You can read and edit
+            files, run git commands, and push commits to the branch. If asked to fix something,
+            apply the fix and commit it. If asked a question, answer it as a PR comment.
+          claude_args: '--max-turns 50 --allowedTools "Bash(gh:*),Bash(git:*),Read,Write,Edit,Glob,Grep"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,8 +7,6 @@ on:
       - dev
     paths-ignore:
       - 'docs/**/*.md'
-      - 'docs/**/CLAUDE.md'
-      - 'docs/**/SKILL.md'
       - 'docs/kb/**'
       - 'static/**'
 
@@ -17,7 +15,7 @@ on:
 
 jobs:
   code-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     concurrency:
       group: code-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -39,7 +37,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
-          COMMENT_IDS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments \
+          COMMENT_IDS=$(gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments --paginate \
             --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | contains("Code Review"))) | .id] | .[]' 2>/dev/null || true)
           for ID in $COMMENT_IDS; do
             gh api repos/${{ github.repository }}/issues/comments/${ID} -X DELETE 2>/dev/null || true
@@ -73,7 +71,8 @@ jobs:
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@claude') &&
-      !startsWith(github.event.comment.user.login, 'github-actions')
+      !startsWith(github.event.comment.user.login, 'github-actions') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     concurrency:
       group: code-followup-${{ github.event.issue.number }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/claude-code-review.yml` — a Claude-powered code review bot that fires on PRs to `dev` containing non-documentation changes
- Uses `paths-ignore` (mirroring the doc reviewer's exclusions) so the two workflows have a clean, non-overlapping boundary and any future paths are covered automatically
- Supports `@claude` natural language commands in PR comments (read, edit, commit fixes, or answer questions)

## How it works

**`code-review` job** — triggers on PR open/sync for any file outside `docs/**`, `static/**`. Posts a single "## Code Review" comment focused on bugs, security issues, Docusaurus config correctness, and workflow safety. Cleans up its own previous comment on re-runs.

**`code-followup` job** — triggers on `@claude` mentions in PR comments. Claude reads the diff and fulfills the request (apply a fix and commit, explain something, answer a question). Fork PRs get a notice that fixes can't be pushed directly.

## Relationship to existing Claude workflows

| Workflow | Scope |
|---|---|
| `claude-doc-pr.yml` | `docs/**/*.md` only |
| `claude-code-review.yml` (this PR) | Everything else |
| `claude-issue-labeler.yml` | Issues only |

## Test plan

- [ ] Open a PR with a config/script change targeting `dev` — verify "## Code Review" comment appears
- [ ] Open a pure-doc PR — verify this workflow does NOT fire
- [ ] Comment `@claude explain this change` on a code PR — verify followup responds
- [ ] Confirm `ANTHROPIC_API_KEY` secret is present in repo settings (already used by existing workflows)

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>