### PR TITLE
fix(claude-doc-pr): close untrusted-checkout alerts #82 and #61

### DIFF
--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   doc-review:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     concurrency:
       group: doc-pr-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
@@ -143,10 +143,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ github.event.issue.number }}"
-          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository)
+          PR_DATA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefName,baseRefName,isCrossRepository,headRefOid)
           BASE_BRANCH=$(echo "$PR_DATA" | jq -r '.baseRefName')
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "branch=$(echo "$PR_DATA" | jq -r '.headRefName')" >> "$GITHUB_OUTPUT"
+          echo "sha=$(echo "$PR_DATA" | jq -r '.headRefOid')" >> "$GITHUB_OUTPUT"
           echo "is_fork=$(echo "$PR_DATA" | jq -r '.isCrossRepository')" >> "$GITHUB_OUTPUT"
           # Check target branch using the shell variable to avoid
           # re-interpolating the output via expressions (code injection risk).
@@ -176,9 +177,13 @@ jobs:
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ steps.pr-info.outputs.branch }}
+          ref: ${{ steps.pr-info.outputs.sha }}
           token: ${{ secrets.VALE_TOKEN }}
           fetch-depth: 0
+
+      - name: Attach to branch
+        if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
+        run: git checkout -B "${{ steps.pr-info.outputs.branch }}"
 
       - name: Handle @claude request
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'

--- a/.github/workflows/claude-doc-pr.yml
+++ b/.github/workflows/claude-doc-pr.yml
@@ -183,7 +183,9 @@ jobs:
 
       - name: Attach to branch
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        run: git checkout -B "${{ steps.pr-info.outputs.branch }}"
+        env:
+          BRANCH: ${{ steps.pr-info.outputs.branch }}
+        run: git checkout -B "$BRANCH"
 
       - name: Handle @claude request
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'


### PR DESCRIPTION
## Summary

Applies the same security fixes from #986 to `claude-doc-pr.yml`, which has two open CodeQL high-severity alerts.

- **Alert #82** (`doc-review` job, line 19): Add `github.event.pull_request.head.repo.fork == false` to the job condition — skips the workflow cleanly on fork PRs instead of failing with a read-only token.
- **Alert #61** (`doc-followup` job, line 175): Capture `headRefOid` in `pr-info` and pin the checkout to that SHA to eliminate the TOCTOU race between the fork/trust check and the actual checkout. Add `git checkout -B` step after checkout so Claude isn't in detached HEAD state when it needs to push commits.

## Test plan

- [ ] Open a doc PR from a fork — verify `doc-review` job is skipped (not red)
- [ ] Comment `@claude` on a non-fork doc PR — verify `doc-followup` runs, can commit, and pushes successfully
- [ ] Confirm alerts #82 and #61 close after merge and CodeQL rescan

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>