### PR TITLE
feat(automation): add GitHub Actions workflow to auto-create project board tracking issues on PR review request

### DIFF
--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -1,0 +1,155 @@
+name: Auto-create PR tracking issues on review request
+
+on:
+  pull_request:
+    types: [review_requested]
+
+jobs:
+  # -------------------------------------------------------
+  # Job 1: Non-KB PR — hilram7 directly requested as reviewer
+  # Creates Admin Support tracking issue
+  # -------------------------------------------------------
+  create-admin-issue:
+    name: Non-KB PR — create Admin Support issue
+    if: |
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.requested_reviewer != null &&
+      github.event.requested_reviewer.login == 'hilram7'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Create tracking issue, link PR, add to project board
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.KB_OPS_PAT }}
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const PROJECT_ID = 'PVT_kwDOB435Ds4A7py9';
+
+            // Idempotency: skip if tracking issue already exists for this PR
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue "Admin: PR review" "PR #${pr.number}" in:title`
+            });
+            if (existing.data.total_count > 0) {
+              console.log('Tracking issue already exists, skipping.');
+              return;
+            }
+
+            // 1. Create tracking issue
+            const { data: issue } = await github.rest.issues.create({
+              owner, repo,
+              title: `Admin: PR review — ${pr.title} (PR #${pr.number})`,
+              body: `Admin review of ${owner}/${repo} PR #${pr.number} (author: @${pr.user.login}).\n\nPR: ${pr.html_url}`,
+              assignees: ['hilram7']
+            });
+
+            // 2. Append closing keyword to PR body — populates "Linked pull requests" column
+            await github.rest.pulls.update({
+              owner, repo,
+              pull_number: pr.number,
+              body: (pr.body || '') + `\n\nCloses #${issue.number}`
+            });
+
+            // 3. Add issue to project board
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                  item { id }
+                }
+              }
+            `, { projectId: PROJECT_ID, contentId: issue.node_id });
+
+            // Helper: set a single-select project field
+            const setField = (fieldId, optionId) => github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $p, itemId: $i, fieldId: $f,
+                  value: { singleSelectOptionId: $o }
+                }) { projectV2Item { id } }
+              }
+            `, { p: PROJECT_ID, i: item.id, f: fieldId, o: optionId });
+
+            // 4. Set project fields
+            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', 'c0f74161'); // Work Category = Admin Support
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b'); // Priority = P2
+
+            console.log(`✓ Created issue #${issue.number} linked to PR #${pr.number}`);
+
+  # -------------------------------------------------------
+  # Job 2: KB PR — kb-docs team requested via CODEOWNERS
+  # Creates Publishing Pipeline tracking issue
+  # -------------------------------------------------------
+  create-kb-issue:
+    name: KB PR — create Publishing Pipeline issue
+    if: |
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.requested_team != null &&
+      github.event.requested_team.slug == 'kb-docs'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Create tracking issue, link PR, add to project board
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.KB_OPS_PAT }}
+          script: |
+            const pr = context.payload.pull_request;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const PROJECT_ID = 'PVT_kwDOB435Ds4A7py9';
+
+            // Idempotency: skip if tracking issue already exists for this PR
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue "KB review:" "PR #${pr.number}" in:title`
+            });
+            if (existing.data.total_count > 0) {
+              console.log('Tracking issue already exists, skipping.');
+              return;
+            }
+
+            // 1. Create tracking issue
+            const { data: issue } = await github.rest.issues.create({
+              owner, repo,
+              title: `KB review: ${pr.title} (PR #${pr.number})`,
+              body: `KB article PR review — ${owner}/${repo} PR #${pr.number} (author: @${pr.user.login}).\n\nPR: ${pr.html_url}`,
+              assignees: ['hilram7'],
+              labels: ['kb/review']
+            });
+
+            // 2. Append closing keyword to PR body — populates "Linked pull requests" column
+            await github.rest.pulls.update({
+              owner, repo,
+              pull_number: pr.number,
+              body: (pr.body || '') + `\n\nCloses #${issue.number}`
+            });
+
+            // 3. Add issue to project board
+            const { addProjectV2ItemById: { item } } = await github.graphql(`
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                  item { id }
+                }
+              }
+            `, { projectId: PROJECT_ID, contentId: issue.node_id });
+
+            const setField = (fieldId, optionId) => github.graphql(`
+              mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: $p, itemId: $i, fieldId: $f,
+                  value: { singleSelectOptionId: $o }
+                }) { projectV2Item { id } }
+              }
+            `, { p: PROJECT_ID, i: item.id, f: fieldId, o: optionId });
+
+            // 4. Set project fields
+            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', '7d3f2431'); // Work Category = Publishing Pipeline
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b'); // Priority = P2
+            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXY', '8f39fde1'); // Pipeline Stage = PR Open
+
+            console.log(`✓ Created issue #${issue.number} linked to PR #${pr.number}`);

--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -20,6 +20,9 @@ jobs:
       github.event.requested_reviewer.login == 'hilram7'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: pr-${{ github.event.pull_request.number }}-admin
+      cancel-in-progress: false
     steps:
       - name: Create tracking issue, link PR, add to project board
         uses: actions/github-script@v7
@@ -61,13 +64,20 @@ jobs:
             });
 
             // 3. Add issue to project board
-            const { addProjectV2ItemById: { item } } = await github.graphql(`
-              mutation($projectId: ID!, $contentId: ID!) {
-                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-                  item { id }
+            let item;
+            try {
+              ({ addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                    item { id }
+                  }
                 }
-              }
-            `, { projectId: PROJECT_ID, contentId: issue.node_id });
+              `, { projectId: PROJECT_ID, contentId: issue.node_id }));
+            } catch (err) {
+              console.error(`✗ Failed to add issue #${issue.number} to project board: ${err.message}`);
+              console.error(`  Issue created and PR body updated — manually add to board: https://github.com/orgs/netwrix/projects/2`);
+              return;
+            }
 
             // Helper: set a single-select project field
             const setField = async (fieldId, optionId, label) => {
@@ -107,6 +117,9 @@ jobs:
       github.event.requested_team.slug == 'kb-docs'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: pr-${{ github.event.pull_request.number }}-kb
+      cancel-in-progress: false
     steps:
       - name: Create tracking issue, link PR, add to project board
         uses: actions/github-script@v7
@@ -149,13 +162,20 @@ jobs:
             });
 
             // 3. Add issue to project board
-            const { addProjectV2ItemById: { item } } = await github.graphql(`
-              mutation($projectId: ID!, $contentId: ID!) {
-                addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-                  item { id }
+            let item;
+            try {
+              ({ addProjectV2ItemById: { item } } = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                    item { id }
+                  }
                 }
-              }
-            `, { projectId: PROJECT_ID, contentId: issue.node_id });
+              `, { projectId: PROJECT_ID, contentId: issue.node_id }));
+            } catch (err) {
+              console.error(`✗ Failed to add issue #${issue.number} to project board: ${err.message}`);
+              console.error(`  Issue created and PR body updated — manually add to board: https://github.com/orgs/netwrix/projects/2`);
+              return;
+            }
 
             // Helper: set a single-select project field
             const setField = async (fieldId, optionId, label) => {

--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -36,11 +36,12 @@ jobs:
             // Field/option IDs are stable in practice; if the project is recreated, update these.
             const PROJECT_ID = 'PVT_kwDOB435Ds4A7py9';
 
-            // Idempotency: skip if tracking issue already exists for this PR.
-            // Note: search indexing has ~10–60s latency — this check is best-effort if the
-            // event fires twice in quick succession (e.g., reviewer removed and immediately re-added).
+            // Idempotency: skip if an open tracking issue already exists for this PR.
+            // state:open ensures a closed/deleted tracking issue doesn't block re-creation.
+            // Note: search indexing has ~10–60s latency — concurrency group reduces but does not
+            // fully eliminate the race if the event fires twice in very quick succession.
             const existing = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} is:issue "Admin: PR review" "PR #${pr.number}" in:title`
+              q: `repo:${owner}/${repo} is:issue state:open "Admin: PR review" "PR #${pr.number}" in:title`
             });
             if (existing.data.total_count > 0) {
               console.log('Tracking issue already exists, skipping.');
@@ -48,20 +49,28 @@ jobs:
             }
 
             // 1. Create tracking issue
+            const prTitle = pr.title.length > 220 ? pr.title.slice(0, 220) + '…' : pr.title;
             const { data: issue } = await github.rest.issues.create({
               owner, repo,
-              title: `Admin: PR review — ${pr.title} (PR #${pr.number})`,
+              title: `Admin: PR review — ${prTitle} (PR #${pr.number})`,
               body: `Admin review of ${owner}/${repo} PR #${pr.number} (author: @${pr.user.login}).\n\nPR: ${pr.html_url}`,
               assignees: ['hilram7']
             });
 
-            // 2. Fetch current PR body (avoid clobbering edits made after the event fired)
-            const { data: freshPr } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
-            await github.rest.pulls.update({
-              owner, repo,
-              pull_number: pr.number,
-              body: (freshPr.body || '') + `\n\nCloses #${issue.number}`
-            });
+            // 2. Fetch current PR body and append closing keyword
+            // Fetch avoids clobbering edits made after the event fired.
+            let freshPr;
+            try {
+              ({ data: freshPr } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number }));
+              await github.rest.pulls.update({
+                owner, repo,
+                pull_number: pr.number,
+                body: (freshPr.body || '') + `\n\nCloses #${issue.number}`
+              });
+            } catch (err) {
+              console.error(`✗ Failed to update PR body: ${err.message}`);
+              console.error(`  Issue #${issue.number} created but not linked — manually append: Closes #${issue.number}`);
+            }
 
             // 3. Add issue to project board
             let item;
@@ -133,11 +142,12 @@ jobs:
             // Field/option IDs are stable in practice; if the project is recreated, update these.
             const PROJECT_ID = 'PVT_kwDOB435Ds4A7py9';
 
-            // Idempotency: skip if tracking issue already exists for this PR.
-            // Note: search indexing has ~10–60s latency — this check is best-effort if the
-            // event fires twice in quick succession (e.g., reviewer removed and immediately re-added).
+            // Idempotency: skip if an open tracking issue already exists for this PR.
+            // state:open ensures a closed/deleted tracking issue doesn't block re-creation.
+            // Note: search indexing has ~10–60s latency — concurrency group reduces but does not
+            // fully eliminate the race if the event fires twice in very quick succession.
             const existing = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${owner}/${repo} is:issue "KB review:" "PR #${pr.number}" in:title`
+              q: `repo:${owner}/${repo} is:issue state:open "KB review:" "PR #${pr.number}" in:title`
             });
             if (existing.data.total_count > 0) {
               console.log('Tracking issue already exists, skipping.');
@@ -145,21 +155,29 @@ jobs:
             }
 
             // 1. Create tracking issue
+            const prTitle = pr.title.length > 220 ? pr.title.slice(0, 220) + '…' : pr.title;
             const { data: issue } = await github.rest.issues.create({
               owner, repo,
-              title: `KB review: ${pr.title} (PR #${pr.number})`,
+              title: `KB review: ${prTitle} (PR #${pr.number})`,
               body: `KB article PR review — ${owner}/${repo} PR #${pr.number} (author: @${pr.user.login}).\n\nPR: ${pr.html_url}`,
               assignees: ['hilram7'],
               labels: ['kb/review']
             });
 
-            // 2. Fetch current PR body (avoid clobbering edits made after the event fired)
-            const { data: freshPr } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
-            await github.rest.pulls.update({
-              owner, repo,
-              pull_number: pr.number,
-              body: (freshPr.body || '') + `\n\nCloses #${issue.number}`
-            });
+            // 2. Fetch current PR body and append closing keyword
+            // Fetch avoids clobbering edits made after the event fired.
+            let freshPr;
+            try {
+              ({ data: freshPr } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number }));
+              await github.rest.pulls.update({
+                owner, repo,
+                pull_number: pr.number,
+                body: (freshPr.body || '') + `\n\nCloses #${issue.number}`
+              });
+            } catch (err) {
+              console.error(`✗ Failed to update PR body: ${err.message}`);
+              console.error(`  Issue #${issue.number} created but not linked — manually append: Closes #${issue.number}`);
+            }
 
             // 3. Add issue to project board
             let item;

--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [review_requested]
 
+# Explicitly lock GITHUB_TOKEN to no permissions — all API calls use KB_OPS_PAT.
+permissions: {}
+
 jobs:
   # -------------------------------------------------------
   # Job 1: Non-KB PR — hilram7 directly requested as reviewer
@@ -16,8 +19,7 @@ jobs:
       github.event.requested_reviewer != null &&
       github.event.requested_reviewer.login == 'hilram7'
     runs-on: ubuntu-latest
-    # Note: permissions block omitted — all API calls use KB_OPS_PAT, not GITHUB_TOKEN.
-    # GITHUB_TOKEN permissions have no effect here.
+    timeout-minutes: 5
     steps:
       - name: Create tracking issue, link PR, add to project board
         uses: actions/github-script@v7
@@ -104,8 +106,7 @@ jobs:
       github.event.requested_team != null &&
       github.event.requested_team.slug == 'kb-docs'
     runs-on: ubuntu-latest
-    # Note: permissions block omitted — all API calls use KB_OPS_PAT, not GITHUB_TOKEN.
-    # GITHUB_TOKEN permissions have no effect here.
+    timeout-minutes: 5
     steps:
       - name: Create tracking issue, link PR, add to project board
         uses: actions/github-script@v7

--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -16,9 +16,8 @@ jobs:
       github.event.requested_reviewer != null &&
       github.event.requested_reviewer.login == 'hilram7'
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
+    # Note: permissions block omitted — all API calls use KB_OPS_PAT, not GITHUB_TOKEN.
+    # GITHUB_TOKEN permissions have no effect here.
     steps:
       - name: Create tracking issue, link PR, add to project board
         uses: actions/github-script@v7
@@ -28,9 +27,13 @@ jobs:
             const pr = context.payload.pull_request;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            // Project board: https://github.com/orgs/netwrix/projects/2
+            // Field/option IDs are stable in practice; if the project is recreated, update these.
             const PROJECT_ID = 'PVT_kwDOB435Ds4A7py9';
 
-            // Idempotency: skip if tracking issue already exists for this PR
+            // Idempotency: skip if tracking issue already exists for this PR.
+            // Note: search indexing has ~10–60s latency — this check is best-effort if the
+            // event fires twice in quick succession (e.g., reviewer removed and immediately re-added).
             const existing = await github.rest.search.issuesAndPullRequests({
               q: `repo:${owner}/${repo} is:issue "Admin: PR review" "PR #${pr.number}" in:title`
             });
@@ -47,11 +50,12 @@ jobs:
               assignees: ['hilram7']
             });
 
-            // 2. Append closing keyword to PR body — populates "Linked pull requests" column
+            // 2. Fetch current PR body (avoid clobbering edits made after the event fired)
+            const { data: freshPr } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
             await github.rest.pulls.update({
               owner, repo,
               pull_number: pr.number,
-              body: (pr.body || '') + `\n\nCloses #${issue.number}`
+              body: (freshPr.body || '') + `\n\nCloses #${issue.number}`
             });
 
             // 3. Add issue to project board
@@ -64,24 +68,34 @@ jobs:
             `, { projectId: PROJECT_ID, contentId: issue.node_id });
 
             // Helper: set a single-select project field
-            const setField = (fieldId, optionId) => github.graphql(`
-              mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $p, itemId: $i, fieldId: $f,
-                  value: { singleSelectOptionId: $o }
-                }) { projectV2Item { id } }
+            const setField = async (fieldId, optionId, label) => {
+              try {
+                await github.graphql(`
+                  mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $p, itemId: $i, fieldId: $f,
+                      value: { singleSelectOptionId: $o }
+                    }) { projectV2Item { id } }
+                  }
+                `, { p: PROJECT_ID, i: item.id, f: fieldId, o: optionId });
+                console.log(`✓ ${label}`);
+              } catch (err) {
+                console.error(`✗ Failed to set ${label}: ${err.message}`);
               }
-            `, { p: PROJECT_ID, i: item.id, f: fieldId, o: optionId });
+            };
 
             // 4. Set project fields
-            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', 'c0f74161'); // Work Category = Admin Support
-            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b'); // Priority = P2
+            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', 'c0f74161', 'Work Category = Admin Support');
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b', 'Priority = P2');
 
             console.log(`✓ Created issue #${issue.number} linked to PR #${pr.number}`);
 
   # -------------------------------------------------------
   # Job 2: KB PR — kb-docs team requested via CODEOWNERS
   # Creates Publishing Pipeline tracking issue
+  # Note: if hilram7 is also directly requested on the same KB PR, both jobs will fire
+  # and create separate tracking issues. In practice this shouldn't happen — CODEOWNERS
+  # auto-requests kb-docs; hilram7 is only directly requested on non-KB PRs.
   # -------------------------------------------------------
   create-kb-issue:
     name: KB PR — create Publishing Pipeline issue
@@ -90,9 +104,8 @@ jobs:
       github.event.requested_team != null &&
       github.event.requested_team.slug == 'kb-docs'
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
+    # Note: permissions block omitted — all API calls use KB_OPS_PAT, not GITHUB_TOKEN.
+    # GITHUB_TOKEN permissions have no effect here.
     steps:
       - name: Create tracking issue, link PR, add to project board
         uses: actions/github-script@v7
@@ -102,9 +115,13 @@ jobs:
             const pr = context.payload.pull_request;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            // Project board: https://github.com/orgs/netwrix/projects/2
+            // Field/option IDs are stable in practice; if the project is recreated, update these.
             const PROJECT_ID = 'PVT_kwDOB435Ds4A7py9';
 
-            // Idempotency: skip if tracking issue already exists for this PR
+            // Idempotency: skip if tracking issue already exists for this PR.
+            // Note: search indexing has ~10–60s latency — this check is best-effort if the
+            // event fires twice in quick succession (e.g., reviewer removed and immediately re-added).
             const existing = await github.rest.search.issuesAndPullRequests({
               q: `repo:${owner}/${repo} is:issue "KB review:" "PR #${pr.number}" in:title`
             });
@@ -122,11 +139,12 @@ jobs:
               labels: ['kb/review']
             });
 
-            // 2. Append closing keyword to PR body — populates "Linked pull requests" column
+            // 2. Fetch current PR body (avoid clobbering edits made after the event fired)
+            const { data: freshPr } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
             await github.rest.pulls.update({
               owner, repo,
               pull_number: pr.number,
-              body: (pr.body || '') + `\n\nCloses #${issue.number}`
+              body: (freshPr.body || '') + `\n\nCloses #${issue.number}`
             });
 
             // 3. Add issue to project board
@@ -138,18 +156,26 @@ jobs:
               }
             `, { projectId: PROJECT_ID, contentId: issue.node_id });
 
-            const setField = (fieldId, optionId) => github.graphql(`
-              mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $p, itemId: $i, fieldId: $f,
-                  value: { singleSelectOptionId: $o }
-                }) { projectV2Item { id } }
+            // Helper: set a single-select project field
+            const setField = async (fieldId, optionId, label) => {
+              try {
+                await github.graphql(`
+                  mutation($p: ID!, $i: ID!, $f: ID!, $o: String!) {
+                    updateProjectV2ItemFieldValue(input: {
+                      projectId: $p, itemId: $i, fieldId: $f,
+                      value: { singleSelectOptionId: $o }
+                    }) { projectV2Item { id } }
+                  }
+                `, { p: PROJECT_ID, i: item.id, f: fieldId, o: optionId });
+                console.log(`✓ ${label}`);
+              } catch (err) {
+                console.error(`✗ Failed to set ${label}: ${err.message}`);
               }
-            `, { p: PROJECT_ID, i: item.id, f: fieldId, o: optionId });
+            };
 
             // 4. Set project fields
-            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', '7d3f2431'); // Work Category = Publishing Pipeline
-            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b'); // Priority = P2
-            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXY', '8f39fde1'); // Pipeline Stage = PR Open
+            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', '7d3f2431', 'Work Category = Publishing Pipeline');
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b', 'Priority = P2');
+            await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXY', '8f39fde1', 'Pipeline Stage = PR Open');
 
             console.log(`✓ Created issue #${issue.number} linked to PR #${pr.number}`);


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically creates a `netwrix/projects/2` tracking issue whenever a PR in `netwrix/docs` is assigned for review — eliminating manual issue creation for all PR-based work.

## Changes
- `.github/workflows/auto-create-pr-tracking-issues.yml` — new workflow with two jobs:
  - **Job 1 (Admin Support):** fires when `hilram7` is directly requested as reviewer; creates an Admin Support tracking issue assigned to `hilram7`, sets Work Category = Admin Support + Priority = P2 on the project board, and appends `Closes #<issue>` to the PR body
  - **Job 2 (Publishing Pipeline):** fires when `kb-docs` team is requested via CODEOWNERS; creates a KB tracking issue assigned to `hilram7` with `kb/review` label, sets Work Category = Publishing Pipeline + Priority = P2 + Pipeline Stage = PR Open, and appends `Closes #<issue>` to the PR body
  - Both jobs are idempotent (skip if a matching tracking issue already exists) and include a fork guard

## Testing
- `actionlint` — no issues
- Dry-run script (`test-auto-create-pr-tracking-issues.js`) validated against `data-export-staging#55` — all field IDs and option IDs resolved correctly
- Live run confirmed: all five `updateProjectV2ItemFieldValue` mutations succeeded against the project board
- Auth: uses `KB_OPS_PAT` repo secret (already in `netwrix/docs` settings)