### PR TITLE
docs(aa2601): add Enterprise tier and update deployment sizing

### DIFF
--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -27,11 +27,12 @@ Before running the installer, confirm the following:
 
 Choose a deployment size based on your environment:
 
-| Size | CPU | Memory | Disk | Typical Environment |
+| Size | CPU | Memory | Disk | Data Threshold |
 | --- | --- | --- | --- | --- |
-| **Small** | 8 cores | 24 GB | 1 TB SSD | Evaluation, pilots, up to ~1,000 assets |
-| **Medium** | 16 cores | 48 GB | 1 TB SSD | Up to ~5,000 assets |
-| **Large** | 32 cores | 64 GB | 1 TB SSD | 5,000+ assets / enterprise |
+| **Small** | 8 cores | 24 GB | 250 GB SSD | Up to 5 TB |
+| **Medium** | 16 cores | 48 GB | 500 GB SSD | 5 TB – 100 TB |
+| **Large** | 32 cores | 64 GB | 1 TB SSD | 100 TB – 1 PB |
+| **Enterprise** | 48 cores | 128 GB | 3 TB+ SSD | 1 PB+ |
 
 **Disk space** — the installer validates free space on multiple paths:
 

--- a/docs/accessanalyzer/2601/install/quickinstall.md
+++ b/docs/accessanalyzer/2601/install/quickinstall.md
@@ -83,7 +83,7 @@ The installer offers three ways to provision the server's TLS certificate. Choos
 | **Bring your own certificate** | You provide a pre-existing certificate, private key, and CA bundle | Environments with a centralized PKI team, or where AD CS isn't available | Three PEM files — see [file requirements](#bring-your-own-certificate-file-requirements) |
 
 :::note
-**AD/DC Root CA Bundle is always required regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
+**You must always provide an AD/DC Root CA Bundle regardless of which TLS option you choose.** Even if the installer generates your server certificate, it still needs a separate CA file to trust the connection to your domain controller. See [Active Directory information](#bring-your-own-certificate-file-requirements).
 :::
 
 #### Bring your own certificate file requirements

--- a/docs/accessanalyzer/2601/install/system/requirements.md
+++ b/docs/accessanalyzer/2601/install/system/requirements.md
@@ -14,11 +14,12 @@ The installer enforces absolute minimums via preflight checks — the installer 
 
 **Absolute installer minimums (enforced by preflight):** 6 vCPUs, 24 GB RAM, 20 GB free disk.
 
-| Size | Recommended CPU | Recommended Memory | Recommended Disk | Typical Environment |
+| Size | Recommended CPU | Recommended Memory | Recommended Disk | Data Threshold |
 | --- | --- | --- | --- | --- |
-| **Small** | 8 cores | 24 GB | 1 TB SSD | Evaluation, pilots, up to ~1,000 assets |
-| **Medium** | 16 cores | 48 GB | 1 TB SSD | Up to ~5,000 assets |
-| **Large** | 32 cores | 64 GB | 1 TB SSD | 5,000+ assets / enterprise |
+| **Small** | 8 cores | 24 GB | 250 GB SSD | Up to 5 TB |
+| **Medium** | 16 cores | 48 GB | 500 GB SSD | 5 TB – 100 TB |
+| **Large** | 32 cores | 64 GB | 1 TB SSD | 100 TB – 1 PB |
+| **Enterprise** | 48 cores | 128 GB | 3 TB+ SSD | 1 PB+ |
 
 
 ## Disk Space Requirements

--- a/docs/accessanalyzer/2601/install/system/requirements.md
+++ b/docs/accessanalyzer/2601/install/system/requirements.md
@@ -44,7 +44,7 @@ The installer also verifies write access for `/var`, `/tmp`, and `/etc`.
 | **Architecture** | x86_64 (amd64) |
 | **Kernel** | 5.15 or later |
 
-**Compatible distributions (engineer-validated):** Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are compatible with the installer. Ubuntu is Debian-based, so Debian stable releases are also supported.
+**Compatible distributions (engineer-validated):** Red Hat Enterprise Linux (RHEL) 8 and 9, CentOS, Fedora, and Debian stable releases are compatible with the installer. Ubuntu is Debian-based, so Debian stable releases are also compatible.
 
 **Not supported:** AIX and other non-Linux operating systems aren't compatible. The installer requires a 64-bit Linux distribution with kernel capabilities including cgroups v1/v2, Linux namespaces, and overlay filesystem support.
 
@@ -97,7 +97,7 @@ Use hugepages for better memory performance. Add the following to your VM XML co
 | 32 GB or more | Optional |
 | Less than 32 GB | 2–4 GB recommended |
 
-If no swap is configured on a system with less than 32 GB of RAM, the installer issues a warning. To create a swap file:
+If a system with less than 32 GB of RAM has no swap, the installer issues a warning. To create a swap file:
 
 ```bash
 sudo fallocate -l 4G /swapfile


### PR DESCRIPTION
## Summary

- Added **Enterprise** deployment size (48 cores, 128 GB RAM, 3 TB+ SSD, 1 PB+ data threshold)
- Replaced "Typical Environment" column with **Data Threshold** volume ranges across all sizing tiers
- Updated disk recommendations: Small 250 GB, Medium 500 GB, Large 1 TB, Enterprise 3 TB+

Files changed: `install/system/requirements.md`, `install/quickinstall.md`

## Test plan

- [ ] Verify Enterprise row renders in both Quick Install and System Requirements pages
- [ ] Confirm no broken links or build errors

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>