### PR TITLE
docs(auditor): verify and correct permissions for NetApp Auditing [Doc Task 439286]

### DIFF
--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -54,8 +54,28 @@ The account on the target server requires the following permissions:
     |  /api/protocols/cifs/shares   |    readonly            |
 
 
-See Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access section for
+See [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access) for
 additional information.
+
+## ONTAPI vs. REST API
+
+NetApp ONTAP supports two API protocols for SVM access. The choice affects how roles are created and assigned.
+
+**ONTAPI is applicable when:**
+
+- The environment runs ONTAP 9.9 or earlier, where REST API support may be limited or unavailable.
+- The existing configuration already uses ONTAPI and migration is not needed.
+
+**REST API is applicable when:**
+
+- The environment runs ONTAP 9.10 or later — REST API is the recommended interface in modern ONTAP versions.
+- The security or network policy prefers REST-based communication over the legacy ONTAPI (ZAPI) protocol.
+
+:::note
+In ONTAP 9.10 and higher, an ONTAPI role (e.g., `netwrix_role`) and a REST API role (e.g., `netwrix_rest_role`) cannot be assigned to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
+:::
+
+For more information, see [Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html) in the NetApp ONTAP Automation documentation.
 
 ## Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access
 
@@ -113,10 +133,7 @@ security login rest-role show -vserver svm1 -role netwrix_rest_role
 NetApp. If you want to use an AD account for collecting data, enable it to access SVM through
 ONTAPI. For example:
 
-**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (e.g., netwrix_role) and a
-RESTAPI role (e.g., netwrix_rest_role) to one AD user. To allow a user access to both the ONTAPI and
-RESTAPI, you can use different AD groups by assigning roles to them and including the user in these
-groups.
+See [ONTAPI vs. REST API](#ontapi-vs-rest-api) for guidance on choosing the right protocol and handling AD group assignments.
 
 Create login for ONTAPI role:
 
@@ -150,5 +167,6 @@ As an alternative to custom roles, the built-in **vsadmin** role can be assigned
 
 ## Related Resources
 
-- [Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html) — NetApp ONTAP documentation
+- [NetApp ONTAP documentation: Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html)
+- [NetApp ONTAP Automation documentation: Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html)
 - [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -59,7 +59,7 @@ NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZA
 **ONTAPI is applicable when:**
 
 - The environment runs ONTAP 9.9 or earlier, where REST API support may be limited or unavailable.
-- The existing configuration already uses ONTAPI and you don't need to migrate. ONTAPI remains supported on ONTAP 9.10 and later for backward compatibility, but NetApp recommends transitioning to REST API for new deployments on 9.10+.
+- The existing configuration already uses ONTAPI and you don't need to migrate. NetApp continues to support ONTAPI on ONTAP 9.10 and later for backward compatibility but recommends transitioning to REST API for new deployments on 9.10+.
 
 **REST API is applicable when:**
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -132,21 +132,21 @@ security login create -vserver svm1 -user-or-group-name domain\user -application
 
 where `domain\user` is your data collecting account.
 
-## Use the Built-in vsadmin Role
+## Built-in vsadmin Role
 
-You can assign the built-in **vsadmin** role instead of creating a custom role. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
+As an alternative to custom roles, the built-in **vsadmin** role can be assigned to the data collection account. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
 
-**Use vsadmin when:**
+**vsadmin is suitable when:**
 
-- You want a simple setup without custom role configuration.
+- A simple setup without custom role configuration is acceptable.
 - There are no restrictions on using a highly privileged SVM account.
-- You're troubleshooting collection issues to rule out insufficient permissions.
+- Troubleshooting collection issues — `vsadmin` helps rule out insufficient permissions as the cause.
 
-**Use granular roles when:**
+**Granular roles are preferable when:**
 
 - The environment follows a least-privilege security policy.
 - The SVM is shared or has strict access controls.
-- You're using an AD domain account for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+- An AD domain account is used for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 ## Related Resources
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -59,7 +59,7 @@ NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZA
 **ONTAPI is applicable when:**
 
 - The environment runs ONTAP 9.9 or earlier, where REST API support may be limited or unavailable.
-- The existing configuration already uses ONTAPI and you don't need to migrate.
+- The existing configuration already uses ONTAPI and you don't need to migrate. ONTAPI remains supported on ONTAP 9.10 and later for backward compatibility, but NetApp recommends transitioning to REST API for new deployments on 9.10+.
 
 **REST API is applicable when:**
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -6,7 +6,7 @@ sidebar_position: 60
 
 # Permissions for NetApp Auditing
 
-Before you start creating a monitoring plan to audit your NetApp file storage system, plan for the
+Before you create a monitoring plan to audit your NetApp file storage system, plan for the
 account you will use for data collection — it must meet the following requirements.
 
 If you want to authenticate with an AD user account, you must enable it to access a Storage Virtual Machine (SVM) through ONTAPI or REST API (see [ONTAPI vs. REST API](#ontapi-vs-rest-api) and [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
@@ -156,7 +156,7 @@ As an alternative to custom roles, you can assign the built-in **vsadmin** role 
 
 - Security is a priority — granular roles follow the principle of least privilege and limit the data collection account to only the permissions Netwrix Auditor requires.
 - The SVM is shared or has strict access controls.
-- You use an AD domain account for data collection — AD accounts must be assigned a custom role because the vsadmin role can't be directly assigned to domain accounts via the ONTAPI or HTTP login mechanism (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+- You use an AD domain account for data collection — AD accounts require a custom role because you can't directly assign the vsadmin role to domain accounts via the ONTAPI or HTTP login mechanism (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 ## Related Resources
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -134,10 +134,20 @@ where `domain\user` is your data collecting account.
 
 ## Use the Built-in vsadmin Role
 
-:::tip
-Instead of creating a custom role with granular permissions (such as `netwrix_role` for ONTAPI or `netwrix_rest_role` for REST API), you can assign the built-in **vsadmin** role to the data collection account.
+You can assign the built-in **vsadmin** role instead of creating a custom role. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
 
-The `vsadmin` role is a NetApp predefined SVM-level role that grants full administrative access to the SVM. It covers all the API capabilities that Netwrix Auditor requires, so no manual role configuration is needed.
+**Use vsadmin when:**
 
-For more information, see [Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html) in the NetApp ONTAP documentation.
-:::
+- You want a simple setup without custom role configuration.
+- There are no restrictions on using a highly privileged SVM account.
+- You're troubleshooting collection issues to rule out insufficient permissions.
+
+**Use granular roles when:**
+
+- The environment follows a least-privilege security policy.
+- The SVM is shared or has strict access controls.
+- You're using an AD domain account for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+
+## Related Resources
+
+- [Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html) — NetApp ONTAP documentation

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -54,9 +54,6 @@ The account on the target server requires the following permissions:
     |  /api/protocols/cifs/shares   |    readonly            |
 
 
-See [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access) for
-additional information.
-
 ## ONTAPI vs. REST API
 
 NetApp ONTAP supports two API protocols for SVM access. The choice affects how roles are created and assigned.
@@ -131,8 +128,6 @@ security login rest-role show -vserver svm1 -role netwrix_rest_role
 NetApp. If you want to use an AD account for collecting data, enable it to access SVM through
 ONTAPI. For example:
 
-See [ONTAPI vs. REST API](#ontapi-vs-rest-api) for guidance on choosing the right protocol and handling AD group assignments.
-
 Create login for ONTAPI role:
 
 ```
@@ -167,4 +162,3 @@ As an alternative to custom roles, the built-in **vsadmin** role can be assigned
 
 - [NetApp ONTAP documentation: Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html)
 - [NetApp ONTAP Automation documentation: Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html)
-- [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -9,7 +9,7 @@ sidebar_position: 60
 Before you start creating a monitoring plan to audit your NetApp file storage system, plan for the
 account you will use for data collection — it must meet the following requirements.
 
-If you want to authenticate with AD user account, you must enable it to access SVM through ONTAPI.
+If you want to authenticate with AD user account, you must enable it to access a Storage Virtual Machine (SVM) through ONTAPI.
 See the Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access section
 for additional information.
 
@@ -68,7 +68,7 @@ NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZA
 - The environment runs ONTAP 9.10 or later — REST API is the recommended interface from ONTAP 9.10 onward.
 - The security or network policy prefers REST-based communication over the legacy ONTAPI (ZAPI) protocol.
 
-**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (such as the `netwrix_role` created below) and a REST API role (such as the `netwrix_rest_role` created below) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
+**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (such as the `netwrix_role` created in the following section) and a REST API role (such as the `netwrix_rest_role` created in the following section) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
 
 If a simple setup without custom role configuration is acceptable, consider using the [NetApp Built-in vsadmin Role](#netapp-built-in-vsadmin-role) instead.
 
@@ -156,7 +156,7 @@ As an alternative to custom roles, you can assign the built-in **vsadmin** role 
 
 - Security is a priority — granular roles follow the least-privilege principle and limit the data collection account to only the permissions Netwrix Auditor requires.
 - The SVM is shared or has strict access controls.
-- An AD domain account is used for data collection — AD users must be granted access through a custom role on the SVM (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+- The data collection account is an AD domain account — you must grant AD users access through a custom role on the SVM (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 ## Related Resources
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -151,3 +151,4 @@ As an alternative to custom roles, the built-in **vsadmin** role can be assigned
 ## Related Resources
 
 - [Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html) — NetApp ONTAP documentation
+- [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -132,7 +132,7 @@ security login create -vserver svm1 -user-or-group-name domain\user -application
 
 where `domain\user` is your data collecting account.
 
-## Built-in vsadmin Role
+## NetApp Built-in vsadmin Role
 
 As an alternative to custom roles, the built-in **vsadmin** role can be assigned to the data collection account. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
 
@@ -144,7 +144,7 @@ As an alternative to custom roles, the built-in **vsadmin** role can be assigned
 
 **Granular roles are preferable when:**
 
-- The environment follows a least-privilege security policy.
+- Security is a priority — granular roles follow the least-privilege principle and limit the data collection account to only the permissions Netwrix Auditor requires.
 - The SVM is shared or has strict access controls.
 - An AD domain account is used for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -9,9 +9,7 @@ sidebar_position: 60
 Before you start creating a monitoring plan to audit your NetApp file storage system, plan for the
 account you will use for data collection — it must meet the following requirements.
 
-If you want to authenticate with AD user account, you must enable it to access a Storage Virtual Machine (SVM) through ONTAPI.
-See the Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access section
-for additional information.
+If you want to authenticate with an AD user account, you must enable it to access a Storage Virtual Machine (SVM) through ONTAPI or REST API (see [ONTAPI vs. REST API](#ontapi-vs-rest-api) and [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 The account on the target server requires the following permissions:
 
@@ -45,7 +43,7 @@ The account on the target server requires the following permissions:
     |   vserver audit rotate-log    |    all                 |
     |   vserver cifs                |    readonly            |
 
-   To connect using the RestAPI
+   To connect using the REST API
     |             API               |       Access Level     |
     | ----------------------------- | ---------------------- |
     |  /api/svm/svms                |    read_create_modify  |
@@ -56,7 +54,7 @@ The account on the target server requires the following permissions:
 
 ## ONTAPI vs. REST API
 
-NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZAPI) and REST API. The choice affects how you create and assign roles.
+NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZAPI) and REST API. The protocol you choose determines how you create and assign roles.
 
 **ONTAPI is applicable when:**
 
@@ -68,9 +66,9 @@ NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZA
 - The environment runs ONTAP 9.10 or later — REST API is the recommended interface from ONTAP 9.10 onward.
 - The security or network policy prefers REST-based communication over the legacy ONTAPI (ZAPI) protocol.
 
-**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (such as the `netwrix_role` created in the following section) and a REST API role (such as the `netwrix_rest_role` created in the following section) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
+**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (a custom role with ONTAPI capabilities) and a REST API role (a custom role with REST API capabilities) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
 
-If a simple setup without custom role configuration is acceptable, consider using the [NetApp Built-in vsadmin Role](#netapp-built-in-vsadmin-role) instead.
+If you don't need granular permissions and prefer to skip custom role configuration, use the [NetApp Built-in vsadmin Role](#netapp-built-in-vsadmin-role) instead.
 
 ## Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access
 
@@ -79,7 +77,7 @@ run the following commands.
 
 To create a role for enabling AD user access:
 
-**Step 1 –** Create a new role (e.g., netwrix_role for ONTAPI and netwrix_rest_role for RESTAPI) on
+**Step 1 –** Create a new role (e.g., netwrix_role for ONTAPI and netwrix_rest_role for REST API) on
 your SVM (e.g., svm1). For example:
 
 Create ONTAPI role:
@@ -92,7 +90,7 @@ security login role create -role netwrix_role -cmddirname "vserver audit rotate-
 security login role create -role netwrix_role -cmddirname "vserver cifs" -access readonly -vserver svm1
 ```
 
-Create RESTAPI role:
+Create REST API role:
 
 ```
 security login rest-role create -role netwrix_rest_role -api /api/svm/svms -access read_create_modify -vserver svm1 
@@ -118,7 +116,7 @@ ONTAPI role:
 security login role show -vserver svm1 -role netwrix_role
 ```
 
-RESTAPI role:
+REST API role:
 
 ```
 security login rest-role show -vserver svm1 -role netwrix_rest_role
@@ -134,7 +132,7 @@ Create login for ONTAPI role:
 security login create -vserver svm1 -user-or-group-name domain\user -application ontapi -authmethod domain -role netwrix_role
 ```
 
-Create login for RESTAPI role:
+Create login for REST API role:
 
 ```
 security login create -vserver svm1 -user-or-group-name domain\user -application http -authmethod domain -role netwrix_rest_role
@@ -146,17 +144,19 @@ where `domain\user` is your data collecting account.
 
 As an alternative to custom roles, you can assign the built-in **vsadmin** role to the data collection account. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
 
+**NOTE:** The vsadmin role grants broad SVM administrative privileges beyond what Netwrix Auditor requires. Use granular custom roles in production environments following the principle of least privilege.
+
 **vsadmin is suitable when:**
 
 - A simple setup without custom role configuration is acceptable.
 - There are no restrictions on using a highly privileged SVM account.
-- Troubleshooting collection issues — `vsadmin` helps eliminate insufficient permissions as the cause.
+- You're troubleshooting collection issues and want to eliminate insufficient permissions as a cause.
 
 **Granular roles are preferable when:**
 
-- Security is a priority — granular roles follow the least-privilege principle and limit the data collection account to only the permissions Netwrix Auditor requires.
+- Security is a priority — granular roles follow the principle of least privilege and limit the data collection account to only the permissions Netwrix Auditor requires.
 - The SVM is shared or has strict access controls.
-- The data collection account is an AD domain account — you must grant AD users access through a custom role on the SVM (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+- You use an AD domain account for data collection — AD accounts must be assigned a custom role because the vsadmin role can't be directly assigned to domain accounts via the ONTAPI or HTTP login mechanism (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 ## Related Resources
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -71,9 +71,7 @@ NetApp ONTAP supports two API protocols for SVM access. The choice affects how r
 - The environment runs ONTAP 9.10 or later — REST API is the recommended interface in modern ONTAP versions.
 - The security or network policy prefers REST-based communication over the legacy ONTAPI (ZAPI) protocol.
 
-:::note
-In ONTAP 9.10 and higher, an ONTAPI role (e.g., `netwrix_role`) and a REST API role (e.g., `netwrix_rest_role`) cannot be assigned to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
-:::
+**NOTE:** In ONTAP 9.10 and higher, an ONTAPI role (e.g., `netwrix_role`) and a REST API role (e.g., `netwrix_rest_role`) cannot be assigned to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
 
 For more information, see [Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html) in the NetApp ONTAP Automation documentation.
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -57,8 +57,6 @@ The account on the target server requires the following permissions:
 See Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access section for
 additional information.
 
-_Remember,_ that you can also assign the built-in vsadmin role instead of the permissions listed earlier.
-
 ## Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access
 
 **NOTE:** This article applies to NetApp 8.3.2 and later. You must be a **cluster administrator** to
@@ -134,5 +132,12 @@ security login create -vserver svm1 -user-or-group-name domain\user -application
 
 where `domain\user` is your data collecting account.
 
+## Use the Built-in vsadmin Role
 
+:::tip
+Instead of creating a custom role with granular permissions (such as `netwrix_role` for ONTAPI or `netwrix_rest_role` for REST API), you can assign the built-in **vsadmin** role to the data collection account.
 
+The `vsadmin` role is a NetApp predefined SVM-level role that grants full administrative access to the SVM. It covers all the API capabilities that Netwrix Auditor requires, so no manual role configuration is needed.
+
+For more information, see [Predefined roles for SVM administrators](https://docs.netapp.com/us-en/ontap/authentication/predefined-roles-svm-administrators-concept.html) in the NetApp ONTAP documentation.
+:::

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -56,7 +56,7 @@ The account on the target server requires the following permissions:
 
 ## ONTAPI vs. REST API
 
-NetApp ONTAP supports two API protocols for SVM access. The choice affects how you create and assign roles.
+NetApp ONTAP supports two API protocols for SVM access: ONTAPI (also known as ZAPI) and REST API. The choice affects how you create and assign roles.
 
 **ONTAPI is applicable when:**
 
@@ -65,12 +65,12 @@ NetApp ONTAP supports two API protocols for SVM access. The choice affects how y
 
 **REST API is applicable when:**
 
-- The environment runs ONTAP 9.10 or later — NetApp recommends the REST API for modern ONTAP versions.
+- The environment runs ONTAP 9.10 or later — REST API is the recommended interface from ONTAP 9.10 onward.
 - The security or network policy prefers REST-based communication over the legacy ONTAPI (ZAPI) protocol.
 
-**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (e.g., `netwrix_role`) and a REST API role (e.g., `netwrix_rest_role`) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
+**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (such as the `netwrix_role` created below) and a REST API role (such as the `netwrix_rest_role` created below) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
 
-For guidance on transitioning from ONTAPI to the REST API, see [Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html) in the NetApp ONTAP Automation documentation.
+If a simple setup without custom role configuration is acceptable, consider using the [NetApp Built-in vsadmin Role](#netapp-built-in-vsadmin-role) instead.
 
 ## Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access
 
@@ -156,7 +156,7 @@ As an alternative to custom roles, you can assign the built-in **vsadmin** role 
 
 - Security is a priority — granular roles follow the least-privilege principle and limit the data collection account to only the permissions Netwrix Auditor requires.
 - The SVM is shared or has strict access controls.
-- You use an AD domain account for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+- An AD domain account is used for data collection — AD users must be granted access through a custom role on the SVM (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 ## Related Resources
 

--- a/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
+++ b/docs/auditor/10.8/configuration/fileservers/netappcmode/permissions.md
@@ -56,21 +56,21 @@ The account on the target server requires the following permissions:
 
 ## ONTAPI vs. REST API
 
-NetApp ONTAP supports two API protocols for SVM access. The choice affects how roles are created and assigned.
+NetApp ONTAP supports two API protocols for SVM access. The choice affects how you create and assign roles.
 
 **ONTAPI is applicable when:**
 
 - The environment runs ONTAP 9.9 or earlier, where REST API support may be limited or unavailable.
-- The existing configuration already uses ONTAPI and migration is not needed.
+- The existing configuration already uses ONTAPI and you don't need to migrate.
 
 **REST API is applicable when:**
 
-- The environment runs ONTAP 9.10 or later — REST API is the recommended interface in modern ONTAP versions.
+- The environment runs ONTAP 9.10 or later — NetApp recommends the REST API for modern ONTAP versions.
 - The security or network policy prefers REST-based communication over the legacy ONTAPI (ZAPI) protocol.
 
-**NOTE:** In ONTAP 9.10 and higher, an ONTAPI role (e.g., `netwrix_role`) and a REST API role (e.g., `netwrix_rest_role`) cannot be assigned to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
+**NOTE:** In ONTAP 9.10 and higher, you can't assign an ONTAPI role (e.g., `netwrix_role`) and a REST API role (e.g., `netwrix_rest_role`) to the same AD user. To grant a single user access to both, assign the respective roles to separate AD groups and add the user to both groups.
 
-For more information, see [Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html) in the NetApp ONTAP Automation documentation.
+For guidance on transitioning from ONTAPI to the REST API, see [Migrate to the ONTAP REST API](https://docs.netapp.com/us-en/ontap-automation/migrate/overview.html) in the NetApp ONTAP Automation documentation.
 
 ## Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access
 
@@ -109,7 +109,7 @@ security login rest-role create -role netwrix_rest_role -api /api/svm/svms -acce
 security login rest-role create -role netwrix_rest_role -api /api/protocols/audit -access all -vserver svm1
 ```
 
-**Step 2 –** Assign the capabilities one by one. To review applied capabilities,
+**Step 2 –** Assign the capabilities individually. To review applied capabilities,
 use the following command:
 
 ONTAPI role:
@@ -144,19 +144,19 @@ where `domain\user` is your data collecting account.
 
 ## NetApp Built-in vsadmin Role
 
-As an alternative to custom roles, the built-in **vsadmin** role can be assigned to the data collection account. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
+As an alternative to custom roles, you can assign the built-in **vsadmin** role to the data collection account. The `vsadmin` role grants full SVM administrative access and covers all API capabilities that Netwrix Auditor requires.
 
 **vsadmin is suitable when:**
 
 - A simple setup without custom role configuration is acceptable.
 - There are no restrictions on using a highly privileged SVM account.
-- Troubleshooting collection issues — `vsadmin` helps rule out insufficient permissions as the cause.
+- Troubleshooting collection issues — `vsadmin` helps eliminate insufficient permissions as the cause.
 
 **Granular roles are preferable when:**
 
 - Security is a priority — granular roles follow the least-privilege principle and limit the data collection account to only the permissions Netwrix Auditor requires.
 - The SVM is shared or has strict access controls.
-- An AD domain account is used for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
+- You use an AD domain account for data collection (see [Create Role on NetApp Clustered Data ONTAP 8 or ONTAP 9 and Enabling AD User Access](#create-role-on-netapp-clustered-data-ontap-8-or-ontap-9-and-enabling-ad-user-access)).
 
 ## Related Resources
 


### PR DESCRIPTION
## Summary

- Moved _Remember_ note about `vsadmin` to a dedicated section at the bottom of the page with expanded description
- Added **ONTAPI vs. REST API** section with guidance on when to use each protocol, including the AD group limitation in ONTAP 9.10+
- Added **NetApp Built-in vsadmin Role** section with when-to-use / when-to-prefer-granular-roles guidance
- Moved NetApp documentation links to a **Related Resources** section
- Removed duplicate NOTE from Step 3 of Create Role procedure (now covered by the new ONTAPI vs. REST API section)

## Test plan

- [ ] Verify all internal anchor links resolve correctly
- [ ] Verify NetApp external links are reachable
- [ ] Review formatting of **NOTE:** blocks and tables

Relates to: Doc Task 439286 — [FSA] Verify and correct the "Permissions for NetApp Auditing" doc

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>