### PR TITLE
Add note about on-premises AD limitations for Azure Files SiT reports [Doc Task 439319]

### DIFF
--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -2,6 +2,13 @@
 
 This topic describes how to enable State-in-Time data collection for an Azure Files monitoring plan in Netwrix Auditor, configure the monitoring scope using omit lists, and set up optional Azure diagnostic settings for activity-based reports.
 
+> **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
+>
+> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group name appears in the report. The report does not list individual group members.
+> - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
+>
+> These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.
+
 ## Prerequisites
 
 - An Azure Files monitoring plan must already exist in Netwrix Auditor [Azure Files Configuration Overview](/docs/auditor/10_8/configuration/azurefiles/overview)

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -4,7 +4,7 @@ This topic describes how to enable State-in-Time data collection for an Azure Fi
 
 > **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
 >
-> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
+> - **Group expansion is not supported for on-premises AD groups that are not synced to Microsoft Entra ID.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
 > - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
 >
 > These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -4,8 +4,8 @@ This topic describes how to enable State-in-Time data collection for an Azure Fi
 
 > **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
 >
-> - **Group expansion is not supported for on-premises AD groups that are not synced to Microsoft Entra ID.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
-> - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
+> - **Group expansion is unavailable for on-premises AD groups that are not synced to Microsoft Entra ID.** If access to a file or folder is granted through such a group, the report does not list individual group members.
+> - **SID resolution is unavailable for on-premises AD groups and accounts that are not synced to Microsoft Entra ID.** These objects appear as unresolved SIDs instead of display names in permission reports.
 >
 > These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.
 

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -4,7 +4,7 @@ This topic describes how to enable State-in-Time data collection for an Azure Fi
 
 > **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
 >
-> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group name appears in the report. The report does not list individual group members.
+> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
 > - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
 >
 > These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.


### PR DESCRIPTION
## Summary
- Added a note before Prerequisites in the Azure Files State-in-Time configuration page explaining that on-premises AD groups are not expanded and non-synced account SIDs are not resolved in permission reports
- Addresses Doc Task 439319 (related to #438496 — on-prem AD/LDAP integration not yet implemented)

## Test plan
- [ ] Verify the note renders correctly on the docs site
- [ ] Confirm the note text accurately reflects the current limitations

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>