### PR TITLE
fix: skip codeowner notification for Admin Support tracking issues in claude-issue-labeler.yml

### DIFF
--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -105,6 +105,7 @@ jobs:
         if: steps.check-state.outputs.issue_state == 'OPEN' && github.event_name == 'issues'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           # Fetch current labels from the issue (post-Step 3)
           LABELS=$(gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json labels --jq '.labels[].name')
@@ -117,6 +118,12 @@ jobs:
           # Skip codeowner notification for KB PR review tracking issues
           if echo "$LABELS" | grep -q "kb/review"; then
             echo "Issue has kb/review label — skipping codeowner notification"
+            exit 0
+          fi
+
+          # Skip codeowner notification for Admin Support PR review tracking issues
+          if echo "$ISSUE_TITLE" | grep -q "^Admin: PR review"; then
+            echo "Admin Support tracking issue — skipping codeowner notification"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary
  - Extends the existing early-exit pattern in `claude-issue-labeler.yml` Step 4 to cover Admin Support PR review tracking issues, which were incorrectly triggering codeowner team mentions and product label application.
  
  ## Changes
  - `.github/workflows/claude-issue-labeler.yml`: Added `ISSUE_TITLE` env var to Step 4 and a new early-exit guard — skips codeowner notification when the issue title starts with `Admin: PR review` (the title pattern used by `auto-create-pr-tracking-issues.yml` for the admin path).
  
  ## Testing
  Dry-run of the Step 4 bash against issue #1035 (the admin tracking issue created for PR #1034 that triggered the bad labels):
  
  === Step 4 dry run ===
  ISSUE_TITLE: Admin: PR review — Training may29 (PR #1034)

  Labels found: AI:site                                                                                                              
  AI:docs
  1secure
  access-analyzer
  identity-manager
  pingcastle

  Admin Support tracking issue — skipping codeowner notification
  
  Labels are fetched, `kb/review` guard passes through, and the new title check exits before any codeowner comment is posted.

  Closes #1036
