### PR TITLE
feat(search): enhance Algolia search with product and version filters

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -394,6 +394,7 @@ html {
     border-bottom: 1px solid var(--docsearch-subtle-color);
     border-radius: 4px 4px 0 0;
     align-items: center;
+    overflow: visible;
 }
 
 /* Fix .DocSearch-Title — the library sets line-height: 0.5em which causes

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -394,7 +394,6 @@ html {
     border-bottom: 1px solid var(--docsearch-subtle-color);
     border-radius: 4px 4px 0 0;
     align-items: center;
-    overflow: visible;
 }
 
 /* Fix .DocSearch-Title — the library sets line-height: 0.5em which causes

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -432,7 +432,7 @@ function MultiSelectDropdown({label, options, selectedValues, onChange, placehol
     );
 }
 
-function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, selectedVersionsRef, ...props}) {
+function DocSearch({externalUrlRegex, onModalOpen, onModalClose, selectedProductsRef, selectedVersionsRef, ...props}) {
     const {i18n: {currentLocale}} = useDocusaurusContext();
     // Use ref for navigator to prevent identity change when filters change
     const navigator = useNavigator({externalUrlRegex, selectedProductsRef, selectedVersionsRef});
@@ -458,7 +458,8 @@ function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, selected
         setIsOpen(false);
         searchButtonRef.current?.focus();
         setInitialQuery(undefined);
-    }, []);
+        onModalClose?.();
+    }, [onModalClose]);
 
     const openModal = useCallback(() => {
         prepareSearchContainer();
@@ -560,17 +561,6 @@ export default function SearchBar() {
         selectedVersionsRef.current = selectedVersions;
     }, [selectedVersions]);
 
-    // Sync filters to sessionStorage so SearchPage fallback stays current
-    useEffect(() => {
-        if (typeof window !== 'undefined') {
-            sessionStorage.setItem('docs_product_filter', JSON.stringify(selectedProducts));
-        }
-    }, [selectedProducts]);
-    useEffect(() => {
-        if (typeof window !== 'undefined') {
-            sessionStorage.setItem('docs_version_filter', JSON.stringify(selectedVersions));
-        }
-    }, [selectedVersions]);
 
 
     // Keep track of the search input value
@@ -621,9 +611,12 @@ export default function SearchBar() {
     }, []);
 
     const onChangeProducts = useCallback((newProducts) => {
-        selectedProductsRef.current = newProducts; // Sync ref immediately so search uses new filters
+        selectedProductsRef.current = newProducts;
         setSelectedProducts(newProducts);
-        refreshSearch(); // Re-run current query with updated filters
+        if (typeof window !== 'undefined') {
+            sessionStorage.setItem('docs_product_filter', JSON.stringify(newProducts));
+        }
+        refreshSearch();
     }, [refreshSearch]);
 
     const onChangeVersions = useCallback((newVersions) => {
@@ -693,13 +686,17 @@ export default function SearchBar() {
             if (e.key !== 'Enter') return;
             // Let DocSearch handle Enter when focus is on its own input
             const active = document.activeElement;
-            if (active && (active.classList.contains('DocSearch-Input') || active.tagName === 'INPUT' && active.type === 'search')) return;
+            if (active && (active.classList.contains('DocSearch-Input') || (active.tagName === 'INPUT' && active.type === 'search'))) return;
             e.preventDefault();
             navigateToSearchPage();
         };
         document.addEventListener('keydown', handler);
         return () => document.removeEventListener('keydown', handler);
     }, [modalHeaderEl, navigateToSearchPage]);
+
+    const onModalClose = useCallback(() => {
+        setModalHeaderEl(null);
+    }, []);
 
     // Keep contextualSearch stable to prevent query reset
     // Product filters are handled via transformSearchClient instead
@@ -713,6 +710,7 @@ export default function SearchBar() {
                 selectedProductsRef={selectedProductsRef}
                 selectedVersionsRef={selectedVersionsRef}
                 onModalOpen={onModalOpen}
+                onModalClose={onModalClose}
             />
 
             {modalHeaderEl &&

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -560,14 +560,10 @@ export default function SearchBar() {
         selectedVersionsRef.current = selectedVersions;
     }, [selectedVersions]);
 
-    // Sync selectedProducts to sessionStorage and dispatch custom event for same-tab sync
+    // Sync selectedProducts to sessionStorage
     useEffect(() => {
         if (typeof window !== 'undefined') {
             sessionStorage.setItem('docs_product_filter', JSON.stringify(selectedProducts));
-            // Dispatch custom event for same-tab synchronization
-            window.dispatchEvent(new CustomEvent('productFilterChange', {
-                detail: {products: selectedProducts}
-            }));
         }
     }, [selectedProducts]);
 

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -159,8 +159,8 @@ function useTransformItems(props) {
     return transformItems;
 }
 
-function useResultsFooterComponent({closeModal, selectedProductsRef}) {
-    // Create footer component ONCE - read selectedProducts from ref at render time
+function useResultsFooterComponent({closeModal, selectedProductsRef, selectedVersionsRef}) {
+    // Create footer component ONCE - read filters from refs at render time
     // This prevents resultsFooterComponent identity from changing when filters change
     return useMemo(
         () =>
@@ -169,8 +169,9 @@ function useResultsFooterComponent({closeModal, selectedProductsRef}) {
                     state={state}
                     onClose={closeModal}
                     selectedProductsRef={selectedProductsRef}
+                    selectedVersionsRef={selectedVersionsRef}
                 />,
-        [closeModal, selectedProductsRef],
+        [closeModal, selectedProductsRef, selectedVersionsRef],
     );
 }
 
@@ -178,17 +179,21 @@ function Hit({hit, children}) {
     return <Link to={hit.url}>{children}</Link>;
 }
 
-function ResultsFooter({state, onClose, selectedProductsRef}) {
+function ResultsFooter({state, onClose, selectedProductsRef, selectedVersionsRef}) {
     const createSearchLink = useSearchLinkCreator();
     const baseLink = createSearchLink(state.query);
 
-    // Read selected products from ref at render time
+    // Read filters from refs at render time
     const selectedProducts = selectedProductsRef?.current || [];
+    const selectedVersions = selectedVersionsRef?.current || [];
 
-    // Add product filters as URL parameters
+    // Add product and version filters as URL parameters
     const params = new URLSearchParams();
     if (selectedProducts.length > 0) {
         params.set('products', selectedProducts.join(','));
+    }
+    if (selectedVersions.length > 0) {
+        params.set('versions', selectedVersions.join(','));
     }
 
     const linkWithFilters = params.toString()
@@ -263,6 +268,20 @@ const PRODUCT_OPTIONS = [
 });
 
 // Helper to get versions for selected products
+function getVersionsForProducts(selectedProducts) {
+    if (!selectedProducts || selectedProducts.length === 0 || selectedProducts.includes('__all__')) {
+        return [];
+    }
+    const versionsSet = new Set();
+    selectedProducts.forEach(productName => {
+        const product = PRODUCTS.find(p => p.name === productName);
+        if (product && product.versions) {
+            product.versions.forEach(v => versionsSet.add(v.label));
+        }
+    });
+    return Array.from(versionsSet).sort();
+}
+
 // Multi-select dropdown component with checkboxes
 function MultiSelectDropdown({label, options, selectedValues, onChange, placeholder}) {
     const [isOpen, setIsOpen] = useState(false);
@@ -382,7 +401,7 @@ function MultiSelectDropdown({label, options, selectedValues, onChange, placehol
     );
 }
 
-function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, ...props}) {
+function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, selectedVersionsRef, ...props}) {
     const {i18n: {currentLocale}} = useDocusaurusContext();
     // Use ref for navigator to prevent identity change when filters change
     const navigator = useNavigator({externalUrlRegex, selectedProductsRef});
@@ -434,6 +453,7 @@ function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, ...props
     const resultsFooterComponent = useResultsFooterComponent({
         closeModal,
         selectedProductsRef,
+        selectedVersionsRef,
     });
 
     useDocSearchKeyboardEvents({
@@ -504,12 +524,28 @@ export default function SearchBar() {
         }
     });
 
+    // Multi-select state for versions
+    const [selectedVersions, setSelectedVersions] = useState(() => {
+        if (typeof window === 'undefined') return [];
+        const saved = sessionStorage.getItem('docs_version_filter');
+        try {
+            return saved ? JSON.parse(saved) : [];
+        } catch {
+            return [];
+        }
+    });
+
     // Ref to access selectedProducts without causing re-renders
     // This is used by transformSearchClient to inject filters at request time
     const selectedProductsRef = useRef(selectedProducts);
     useEffect(() => {
         selectedProductsRef.current = selectedProducts;
     }, [selectedProducts]);
+
+    const selectedVersionsRef = useRef(selectedVersions);
+    useEffect(() => {
+        selectedVersionsRef.current = selectedVersions;
+    }, [selectedVersions]);
 
     // Sync selectedProducts to sessionStorage and dispatch custom event for same-tab sync
     useEffect(() => {
@@ -545,8 +581,15 @@ export default function SearchBar() {
             filters.push(realProducts.map(p => `product_name:${p}`)); // Array within array = OR logic
         }
 
+        // TODO: Version filtering disabled - 'version' facet not yet configured in Algolia
+        // To enable: add 'version' to attributesForFaceting in Algolia dashboard, re-index, then uncomment:
+        // const realVersions = selectedVersions.filter(v => v !== '__all__');
+        // if (realVersions.length > 0) {
+        //     filters.push(realVersions.map(v => `version:${v}`)); // Array within array = OR logic
+        // }
+
         return filters;
-    }, [selectedProducts]);
+    }, [selectedProducts, selectedVersions]);
 
     // Keep track of the search input value
     useEffect(() => {
@@ -601,6 +644,23 @@ export default function SearchBar() {
         refreshSearch(); // Re-run current query with updated filters
     }, [refreshSearch]);
 
+    const onChangeVersions = useCallback((newVersions) => {
+        selectedVersionsRef.current = newVersions;
+        setSelectedVersions(newVersions);
+        if (typeof window !== 'undefined') {
+            sessionStorage.setItem('docs_version_filter', JSON.stringify(newVersions));
+        }
+        // Note: refreshSearch() not called here — version filtering is disabled until Algolia is updated
+    }, []);
+
+    const availableVersions = useMemo(() => {
+        const versions = getVersionsForProducts(selectedProducts);
+        return [
+            {label: 'All versions', value: '__all__'},
+            ...versions.map(v => ({label: v, value: v})),
+        ];
+    }, [selectedProducts]);
+
     // This is where we will portal the filters into the modal DOM.
     const [modalHeaderEl, setModalHeaderEl] = useState(null);
     // Holds the closeModal function passed up from the inner DocSearch component.
@@ -627,13 +687,14 @@ export default function SearchBar() {
                 {...siteConfig.themeConfig.algolia}
                 contextualSearch={contextualSearch}
                 selectedProductsRef={selectedProductsRef}
+                selectedVersionsRef={selectedVersionsRef}
                 onModalOpen={onModalOpen}
             />
 
             {modalHeaderEl &&
                 createPortal(
                     <>
-                        {/* Custom controls: product filter */}
+                        {/* Custom controls: product + version filters */}
                         <div className="search-custom-controls">
                             <MultiSelectDropdown
                                 label="Products"
@@ -641,6 +702,14 @@ export default function SearchBar() {
                                 selectedValues={selectedProducts}
                                 onChange={onChangeProducts}
                                 placeholder="All products"
+                            />
+                            {/* Version filter UI — non-functional until 'version' facet is configured in Algolia */}
+                            <MultiSelectDropdown
+                                label="Versions"
+                                options={availableVersions}
+                                selectedValues={selectedVersions}
+                                onChange={onChangeVersions}
+                                placeholder="All versions"
                             />
                         </div>
                         {/* Our own close button — replaces the DocSearch-Close button

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -73,7 +73,7 @@ function useNavigator({externalUrlRegex, selectedProductsRef}) {
     return navigator;
 }
 
-function useTransformSearchClient(selectedProductsRef, currentLocale) {
+function useTransformSearchClient(selectedProductsRef, selectedVersionsRef, currentLocale) {
     const {
         siteMetadata: {docusaurusVersion},
     } = useDocusaurusContext();
@@ -83,16 +83,23 @@ function useTransformSearchClient(selectedProductsRef, currentLocale) {
 
             const originalSearch = searchClient.search.bind(searchClient);
 
-            // Override search to inject product filters at request time
+            // Override search to inject product and version filters at request time
             // This keeps searchParameters prop stable, preventing query reset
             searchClient.search = function(searchMethodParams, requestOptions) {
                 const products = selectedProductsRef.current || [];
+                const versions = selectedVersionsRef.current || [];
                 const typoTolerance = false;
 
                 // Build product filter (OR logic - any of selected products)
                 const realProducts = products.filter(p => p !== '__all__' && p !== '__none__');
                 const productFilter = realProducts.length > 0
                     ? realProducts.map(p => `product_name:${p}`)
+                    : null;
+
+                // Build version filter (OR logic - any of selected versions)
+                const realVersions = versions.filter(v => v !== '__all__');
+                const versionFilter = realVersions.length > 0
+                    ? realVersions.map(v => `product_version:${v}`)
                     : null;
 
                 // Language filter for internationalization
@@ -123,6 +130,11 @@ function useTransformSearchClient(selectedProductsRef, currentLocale) {
                             // Add product filter if we have selected products
                             if (productFilter) {
                                 newFilters.push(productFilter);
+                            }
+
+                            // Add version filter if we have selected versions
+                            if (versionFilter) {
+                                newFilters.push(versionFilter);
                             }
 
                             return {
@@ -409,7 +421,7 @@ function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, selected
     // Product filters are injected at request time via transformSearchClient
     const searchParameters = useSearchParameters({...props, productFacetFilters: []});
     const transformItems = useTransformItems(props);
-    const transformSearchClient = useTransformSearchClient(selectedProductsRef, currentLocale);
+    const transformSearchClient = useTransformSearchClient(selectedProductsRef, selectedVersionsRef, currentLocale);
     const searchContainer = useRef(null);
     const searchButtonRef = useRef(null);
     const [isOpen, setIsOpen] = useState(false);
@@ -571,26 +583,6 @@ export default function SearchBar() {
         return () => window.removeEventListener('productFilterChange', handleFilterChange);
     }, [selectedProducts]);
 
-    // Generate facetFilters for products
-    const productFacetFilters = useMemo(() => {
-        const filters = [];
-
-        // Add product filters (OR logic - any of the selected products)
-        const realProducts = selectedProducts.filter(p => p !== '__all__' && p !== '__none__');
-        if (realProducts.length > 0) {
-            filters.push(realProducts.map(p => `product_name:${p}`)); // Array within array = OR logic
-        }
-
-        // TODO: Version filtering disabled - 'version' facet not yet configured in Algolia
-        // To enable: add 'version' to attributesForFaceting in Algolia dashboard, re-index, then uncomment:
-        // const realVersions = selectedVersions.filter(v => v !== '__all__');
-        // if (realVersions.length > 0) {
-        //     filters.push(realVersions.map(v => `version:${v}`)); // Array within array = OR logic
-        // }
-
-        return filters;
-    }, [selectedProducts, selectedVersions]);
-
     // Keep track of the search input value
     useEffect(() => {
         const interval = setInterval(() => {
@@ -650,8 +642,8 @@ export default function SearchBar() {
         if (typeof window !== 'undefined') {
             sessionStorage.setItem('docs_version_filter', JSON.stringify(newVersions));
         }
-        // Note: refreshSearch() not called here — version filtering is disabled until Algolia is updated
-    }, []);
+        refreshSearch();
+    }, [refreshSearch]);
 
     const availableVersions = useMemo(() => {
         const versions = getVersionsForProducts(selectedProducts);
@@ -703,7 +695,6 @@ export default function SearchBar() {
                                 onChange={onChangeProducts}
                                 placeholder="All products"
                             />
-                            {/* Version filter UI — non-functional until 'version' facet is configured in Algolia */}
                             <MultiSelectDropdown
                                 label="Versions"
                                 options={availableVersions}

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -32,11 +32,11 @@ function importDocSearchModalIfNeeded() {
     });
 }
 
-function useNavigator({externalUrlRegex, selectedProductsRef}) {
+function useNavigator({externalUrlRegex, selectedProductsRef, selectedVersionsRef}) {
     const history = useHistory();
     const createSearchLink = useSearchLinkCreator();
 
-    // Create navigator ONCE and read selectedProducts from ref at navigation time
+    // Create navigator ONCE and read filters from refs at navigation time
     // This prevents navigator identity from changing when filters change
     const navigator = useMemo(() => {
         return {
@@ -47,8 +47,9 @@ function useNavigator({externalUrlRegex, selectedProductsRef}) {
                     document.querySelector('input[type="search"]');
                 const currentQuery = input ? input.value : '';
 
-                // Read selected products from ref at navigation time
+                // Read selected filters from refs at navigation time
                 const selectedProducts = selectedProductsRef?.current || [];
+                const selectedVersions = selectedVersionsRef?.current || [];
 
                 // If we have a search query, redirect to full search results page instead
                 if (currentQuery) {
@@ -56,6 +57,9 @@ function useNavigator({externalUrlRegex, selectedProductsRef}) {
                     const urlParams = new URLSearchParams();
                     if (selectedProducts.length > 0) {
                         urlParams.set('products', selectedProducts.join(','));
+                    }
+                    if (selectedVersions.length > 0) {
+                        urlParams.set('versions', selectedVersions.join(','));
                     }
                     const searchPageUrl = urlParams.toString()
                         ? `${baseLink}&${urlParams.toString()}`
@@ -68,7 +72,7 @@ function useNavigator({externalUrlRegex, selectedProductsRef}) {
                 }
             },
         };
-    }, [externalUrlRegex, history, createSearchLink, selectedProductsRef]);
+    }, [externalUrlRegex, history, createSearchLink, selectedProductsRef, selectedVersionsRef]);
 
     return navigator;
 }
@@ -217,9 +221,15 @@ function ResultsFooter({state, onClose, selectedProductsRef, selectedVersionsRef
     // Read refs at click time to guarantee current filter state
     const handleClick = useCallback((e) => {
         e.preventDefault();
+        // Snapshot filters into sessionStorage before navigation so SearchPage
+        // can fall back to them if URL params are lost for any reason
+        if (typeof window !== 'undefined') {
+            sessionStorage.setItem('docs_product_filter', JSON.stringify(selectedProductsRef?.current || []));
+            sessionStorage.setItem('docs_version_filter', JSON.stringify(selectedVersionsRef?.current || []));
+        }
         onClose();
         history.push(buildLink());
-    }, [onClose, history, buildLink]);
+    }, [onClose, history, buildLink, selectedProductsRef, selectedVersionsRef]);
 
     return (
         <Link to={buildLink()} onClick={handleClick}>
@@ -425,7 +435,7 @@ function MultiSelectDropdown({label, options, selectedValues, onChange, placehol
 function DocSearch({externalUrlRegex, onModalOpen, selectedProductsRef, selectedVersionsRef, ...props}) {
     const {i18n: {currentLocale}} = useDocusaurusContext();
     // Use ref for navigator to prevent identity change when filters change
-    const navigator = useNavigator({externalUrlRegex, selectedProductsRef});
+    const navigator = useNavigator({externalUrlRegex, selectedProductsRef, selectedVersionsRef});
     // Keep searchParameters stable - don't include product filters here
     // Product filters are injected at request time via transformSearchClient
     const searchParameters = useSearchParameters({...props, productFacetFilters: []});
@@ -534,27 +544,9 @@ export default function SearchBar() {
     // Store the current search query to preserve it across filter changes
     const searchQueryRef = useRef('');
 
-    // Multi-select state for products
-    const [selectedProducts, setSelectedProducts] = useState(() => {
-        if (typeof window === 'undefined') return [];
-        const saved = sessionStorage.getItem('docs_product_filter');
-        try {
-            return saved ? JSON.parse(saved) : [];
-        } catch {
-            return [];
-        }
-    });
-
-    // Multi-select state for versions
-    const [selectedVersions, setSelectedVersions] = useState(() => {
-        if (typeof window === 'undefined') return [];
-        const saved = sessionStorage.getItem('docs_version_filter');
-        try {
-            return saved ? JSON.parse(saved) : [];
-        } catch {
-            return [];
-        }
-    });
+    // Multi-select state — always starts empty; reset on every modal open
+    const [selectedProducts, setSelectedProducts] = useState([]);
+    const [selectedVersions, setSelectedVersions] = useState([]);
 
     // Ref to access selectedProducts without causing re-renders
     // This is used by transformSearchClient to inject filters at request time
@@ -579,18 +571,6 @@ export default function SearchBar() {
         }
     }, [selectedProducts]);
 
-    // Listen for filter changes from SearchPage (same-tab sync)
-    useEffect(() => {
-        const handleFilterChange = (e) => {
-            const newProducts = e.detail.products;
-            // Avoid infinite loop by checking if products actually changed
-            if (JSON.stringify(newProducts) !== JSON.stringify(selectedProducts)) {
-                setSelectedProducts(newProducts);
-            }
-        };
-        window.addEventListener('productFilterChange', handleFilterChange);
-        return () => window.removeEventListener('productFilterChange', handleFilterChange);
-    }, [selectedProducts]);
 
     // Keep track of the search input value
     useEffect(() => {
@@ -668,6 +648,13 @@ export default function SearchBar() {
     const closeModalRef = useRef(null);
 
     const onModalOpen = useCallback((closeModal) => {
+        // Reset filters to defaults each time the modal opens so stale
+        // state from a previous search or the full results page is cleared.
+        setSelectedProducts([]);
+        setSelectedVersions([]);
+        selectedProductsRef.current = [];
+        selectedVersionsRef.current = [];
+
         // Target .DocSearch-SearchBar so our controls are a sibling of .DocSearch-Form.
         // This lets us move them below the search row on mobile via flex-wrap.
         const el =
@@ -677,6 +664,41 @@ export default function SearchBar() {
         closeModalRef.current = closeModal ?? null;
         setModalHeaderEl(el || null);
     }, []);
+
+    // Navigate to full search results page with current filters
+    const history = useHistory();
+    const createSearchLink = useSearchLinkCreator();
+    const navigateToSearchPage = useCallback(() => {
+        const query = searchQueryRef.current;
+        if (!query) return;
+        const baseLink = createSearchLink(query);
+        const params = new URLSearchParams();
+        const products = selectedProductsRef.current || [];
+        const versions = selectedVersionsRef.current || [];
+        if (products.length > 0) params.set('products', products.join(','));
+        if (versions.length > 0) params.set('versions', versions.join(','));
+        if (typeof window !== 'undefined') {
+            sessionStorage.setItem('docs_product_filter', JSON.stringify(products));
+            sessionStorage.setItem('docs_version_filter', JSON.stringify(versions));
+        }
+        closeModalRef.current?.();
+        history.push(params.toString() ? `${baseLink}&${params.toString()}` : baseLink);
+    }, [createSearchLink, history]);
+
+    // Enter key anywhere in the modal (except the search input) → go to full results
+    useEffect(() => {
+        if (!modalHeaderEl) return;
+        const handler = (e) => {
+            if (e.key !== 'Enter') return;
+            // Let DocSearch handle Enter when focus is on its own input
+            const active = document.activeElement;
+            if (active && (active.classList.contains('DocSearch-Input') || active.tagName === 'INPUT' && active.type === 'search')) return;
+            e.preventDefault();
+            navigateToSearchPage();
+        };
+        document.addEventListener('keydown', handler);
+        return () => document.removeEventListener('keydown', handler);
+    }, [modalHeaderEl, navigateToSearchPage]);
 
     // Keep contextualSearch stable to prevent query reset
     // Product filters are handled via transformSearchClient instead

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -560,12 +560,17 @@ export default function SearchBar() {
         selectedVersionsRef.current = selectedVersions;
     }, [selectedVersions]);
 
-    // Sync selectedProducts to sessionStorage
+    // Sync filters to sessionStorage so SearchPage fallback stays current
     useEffect(() => {
         if (typeof window !== 'undefined') {
             sessionStorage.setItem('docs_product_filter', JSON.stringify(selectedProducts));
         }
     }, [selectedProducts]);
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            sessionStorage.setItem('docs_version_filter', JSON.stringify(selectedVersions));
+        }
+    }, [selectedVersions]);
 
 
     // Keep track of the search input value

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -616,6 +616,16 @@ export default function SearchBar() {
         if (typeof window !== 'undefined') {
             sessionStorage.setItem('docs_product_filter', JSON.stringify(newProducts));
         }
+        // Clear versions that don't exist for the new product selection
+        const validVersions = new Set(getVersionsForProducts(newProducts));
+        const cleaned = selectedVersionsRef.current.filter(v => validVersions.has(v));
+        if (cleaned.length !== selectedVersionsRef.current.length) {
+            selectedVersionsRef.current = cleaned;
+            setSelectedVersions(cleaned);
+            if (typeof window !== 'undefined') {
+                sessionStorage.setItem('docs_version_filter', JSON.stringify(cleaned));
+            }
+        }
         refreshSearch();
     }, [refreshSearch]);
 

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -193,27 +193,36 @@ function Hit({hit, children}) {
 
 function ResultsFooter({state, onClose, selectedProductsRef, selectedVersionsRef}) {
     const createSearchLink = useSearchLinkCreator();
-    const baseLink = createSearchLink(state.query);
+    const history = useHistory();
 
-    // Read filters from refs at render time
-    const selectedProducts = selectedProductsRef?.current || [];
-    const selectedVersions = selectedVersionsRef?.current || [];
+    // Build URL from refs — used for the href (right-click / middle-click)
+    const buildLink = useCallback(() => {
+        const baseLink = createSearchLink(state.query);
+        const selectedProducts = selectedProductsRef?.current || [];
+        const selectedVersions = selectedVersionsRef?.current || [];
 
-    // Add product and version filters as URL parameters
-    const params = new URLSearchParams();
-    if (selectedProducts.length > 0) {
-        params.set('products', selectedProducts.join(','));
-    }
-    if (selectedVersions.length > 0) {
-        params.set('versions', selectedVersions.join(','));
-    }
+        const params = new URLSearchParams();
+        if (selectedProducts.length > 0) {
+            params.set('products', selectedProducts.join(','));
+        }
+        if (selectedVersions.length > 0) {
+            params.set('versions', selectedVersions.join(','));
+        }
 
-    const linkWithFilters = params.toString()
-        ? `${baseLink}&${params.toString()}`
-        : baseLink;
+        return params.toString()
+            ? `${baseLink}&${params.toString()}`
+            : baseLink;
+    }, [state.query, createSearchLink, selectedProductsRef, selectedVersionsRef]);
+
+    // Read refs at click time to guarantee current filter state
+    const handleClick = useCallback((e) => {
+        e.preventDefault();
+        onClose();
+        history.push(buildLink());
+    }, [onClose, history, buildLink]);
 
     return (
-        <Link to={linkWithFilters} onClick={onClose}>
+        <Link to={buildLink()} onClick={handleClick}>
             <Translate id="theme.SearchBar.seeAll">
                 {'See all results'}
             </Translate>

--- a/src/theme/SearchBar/styles.css
+++ b/src/theme/SearchBar/styles.css
@@ -1,6 +1,16 @@
 :root {
   --docsearch-primary-color: var(--ifm-color-primary);
   --docsearch-text-color: var(--ifm-font-color-base);
+  --docsearch-muted-color: rgba(150, 159, 175, 0.5);
+  --docsearch-modal-background: #f5f7fa;
+  --docsearch-hit-background: rgba(150, 159, 175, 0.1);
+  --docsearch-hit-active-color: rgba(150, 159, 175, 0.2);
+}
+
+[data-theme='dark'] {
+  --docsearch-modal-background: #1c1e21;
+  --docsearch-hit-background: rgba(255, 255, 255, 0.05);
+  --docsearch-hit-active-color: rgba(255, 255, 255, 0.1);
 }
 
 .DocSearch-Button {
@@ -11,4 +21,56 @@
 
 .DocSearch-Container {
   z-index: calc(var(--ifm-z-index-fixed) + 1);
+}
+
+/* Multi-select dropdown styling */
+.DocSearch-MultiSelect {
+  font-family: inherit;
+}
+
+.DocSearch-MultiSelect-Button {
+  font-family: inherit;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+}
+
+.DocSearch-MultiSelect-Button:hover {
+  border-color: var(--docsearch-primary-color);
+}
+
+.DocSearch-MultiSelect-Button:focus {
+  outline: 2px solid var(--docsearch-primary-color);
+  outline-offset: 2px;
+}
+
+.DocSearch-MultiSelect-Dropdown {
+  animation: fadeIn 0.15s ease;
+}
+
+.DocSearch-MultiSelect-Dropdown::-webkit-scrollbar {
+  width: 8px;
+}
+
+.DocSearch-MultiSelect-Dropdown::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.DocSearch-MultiSelect-Dropdown::-webkit-scrollbar-thumb {
+  background: var(--docsearch-muted-color);
+  border-radius: 4px;
+}
+
+.DocSearch-MultiSelect-Dropdown::-webkit-scrollbar-thumb:hover {
+  background: var(--docsearch-primary-color);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -36,13 +36,11 @@ function stripHtmlTagsToText(input) {
 
 // Helper to get versions for selected products
 function getVersionsForProducts(selectedProducts) {
-    if (!selectedProducts || selectedProducts.length === 0 || selectedProducts.includes('__all__')) {
-        return [];
-    }
     const versionsSet = new Set();
-    selectedProducts.forEach(productName => {
-        const product = PRODUCTS.find(p => p.name === productName);
-        if (product && product.versions) {
+    const isAll = !selectedProducts || selectedProducts.length === 0 || selectedProducts.includes('__all__');
+    const source = isAll ? PRODUCTS : selectedProducts.map(name => PRODUCTS.find(p => p.name === name)).filter(Boolean);
+    source.forEach(product => {
+        if (product.versions) {
             product.versions.forEach(v => versionsSet.add(v.label));
         }
     });
@@ -254,20 +252,25 @@ function SearchPageContent() {
     // Initialize from URL if present, otherwise from localStorage
     const [selectedProducts, setSelectedProducts] = useState(() => {
         if (productsFromUrl.length > 0) return productsFromUrl;
-        if (typeof window === 'undefined') return [];
+        if (typeof window === 'undefined') return ['__all__'];
         const saved = sessionStorage.getItem('docs_product_filter');
         try {
-            return saved ? JSON.parse(saved) : [];
+            const parsed = saved ? JSON.parse(saved) : [];
+            // Normalize: empty array from modal means "all products"
+            return parsed.length === 0 ? ['__all__'] : parsed;
         } catch {
-            return [];
+            return ['__all__'];
         }
     });
     // Initialize from URL if present, otherwise from sessionStorage
     const [selectedVersions, setSelectedVersions] = useState(() => {
         if (versionsFromUrl.length > 0) return versionsFromUrl;
-        if (typeof window === 'undefined') return [];
+        if (typeof window === 'undefined') return ['__all__'];
         const saved = sessionStorage.getItem('docs_version_filter');
-        try { return saved ? JSON.parse(saved) : []; } catch { return []; }
+        try {
+            const parsed = saved ? JSON.parse(saved) : [];
+            return parsed.length === 0 ? ['__all__'] : parsed;
+        } catch { return ['__all__']; }
     });
     const [resultsPerPage, setResultsPerPage] = useState(resultsPerPageFromUrl);
 
@@ -282,14 +285,10 @@ function SearchPageContent() {
     // All sorted results for client-side pagination
     const allItemsRef = useRef([]);
 
-    // Sync selectedProducts to sessionStorage and dispatch custom event for same-tab sync
+    // Sync selectedProducts to sessionStorage
     useEffect(() => {
         if (typeof window !== 'undefined') {
             sessionStorage.setItem('docs_product_filter', JSON.stringify(selectedProducts));
-            // Dispatch custom event for same-tab synchronization
-            window.dispatchEvent(new CustomEvent('productFilterChange', {
-                detail: {products: selectedProducts}
-            }));
         }
     }, [selectedProducts]);
 
@@ -300,18 +299,6 @@ function SearchPageContent() {
         }
     }, [selectedVersions]);
 
-    // Listen for filter changes from SearchBar modal (same-tab sync)
-    useEffect(() => {
-        const handleFilterChange = (e) => {
-            const newProducts = e.detail.products;
-            // Avoid infinite loop by checking if products actually changed
-            if (JSON.stringify(newProducts) !== JSON.stringify(selectedProducts)) {
-                setSelectedProducts(newProducts);
-            }
-        };
-        window.addEventListener('productFilterChange', handleFilterChange);
-        return () => window.removeEventListener('productFilterChange', handleFilterChange);
-    }, [selectedProducts]);
 
     // Update state when URL changes (e.g., browser back/forward)
     // Skips initial mount — useState initializers already read URL params and sessionStorage
@@ -336,8 +323,8 @@ function SearchPageContent() {
         const newPage = parseInt(urlParams.get('page'), 10) || 1;
 
         setSearchQuery(newQuery);
-        setSelectedProducts(newProducts);
-        setSelectedVersions(newVersions);
+        setSelectedProducts(newProducts.length > 0 ? newProducts : ['__all__']);
+        setSelectedVersions(newVersions.length > 0 ? newVersions : ['__all__']);
         setResultsPerPage(newResultsPerPage);
 
         // Store target page for restoration

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -553,9 +553,14 @@ function SearchPageContent() {
             if (resultsPerPage !== 25) params.set('resultsPerPage', String(resultsPerPage));
             if (currentPage > 1) params.set('page', String(currentPage));
 
-            // Mark this as an internal navigation so location.search effect ignores it
-            isInternalNavigation.current = true;
-            history.replace({search: params.toString()});
+            // Only set the flag when the URL actually changes — otherwise the
+            // location.search effect never fires to reset it, and the next
+            // external navigation (e.g. from the modal) gets skipped.
+            const newSearch = params.toString();
+            if (newSearch !== location.search.replace(/^\?/, '')) {
+                isInternalNavigation.current = true;
+                history.replace({search: newSearch});
+            }
 
             prevFiltersRef.current = {searchQuery, selectedProducts, selectedVersions, resultsPerPage, page: currentPage};
         }

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -277,9 +277,21 @@ function SearchPageContent() {
 
     const availableVersions = useMemo(() => getVersionsForProducts(selectedProducts), [selectedProducts]);
 
-    // Track if we're restoring from URL (e.g., browser back button)
-    const restoringFromUrl = useRef(false);
-    const targetPageRef = useRef(null);
+    // Clear orphan versions when products change
+    const handleProductChange = useCallback((newProducts) => {
+        setSelectedProducts(newProducts);
+        const validVersions = new Set(getVersionsForProducts(newProducts));
+        setSelectedVersions(prev => {
+            const cleaned = prev.filter(v => v === '__all__' || validVersions.has(v));
+            return cleaned.length > 0 ? cleaned : ['__all__'];
+        });
+    }, []);
+
+    // Track if we're restoring from URL (e.g., browser back button).
+    // Initialize from pageFromUrl so landing on /search?page=3 works
+    // even though the location.search effect skips initial mount.
+    const restoringFromUrl = useRef(pageFromUrl > 1);
+    const targetPageRef = useRef(pageFromUrl > 1 ? pageFromUrl - 1 : null);
     const isInternalNavigation = useRef(false);
     const isInitialMount = useRef(true);
 
@@ -805,7 +817,7 @@ function SearchPageContent() {
                             label="Products"
                             options={PRODUCT_OPTIONS}
                             selectedValues={selectedProducts}
-                            onChange={setSelectedProducts}
+                            onChange={handleProductChange}
                         />
                         {availableVersions.length > 0 && (
                             <MultiSelect

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -34,6 +34,21 @@ function stripHtmlTagsToText(input) {
     return input.replace(/[<>]/g, '');
 }
 
+// Helper to get versions for selected products
+function getVersionsForProducts(selectedProducts) {
+    if (!selectedProducts || selectedProducts.length === 0 || selectedProducts.includes('__all__')) {
+        return [];
+    }
+    const versionsSet = new Set();
+    selectedProducts.forEach(productName => {
+        const product = PRODUCTS.find(p => p.name === productName);
+        if (product && product.versions) {
+            product.versions.forEach(v => versionsSet.add(v.label));
+        }
+    });
+    return Array.from(versionsSet).sort();
+}
+
 // Generate product options from PRODUCTS config
 const PRODUCT_OPTIONS = [
     {label: 'All products', value: '__all__'},
@@ -231,6 +246,7 @@ function SearchPageContent() {
     const urlParams = new URLSearchParams(location.search);
     const queryFromUrl = urlParams.get('q') || '';
     const productsFromUrl = urlParams.get('products')?.split(',').filter(Boolean) || [];
+    const versionsFromUrl = urlParams.get('versions')?.split(',').filter(Boolean) || [];
     const resultsPerPageFromUrl = parseInt(urlParams.get('resultsPerPage'), 10) || 25;
     const pageFromUrl = parseInt(urlParams.get('page'), 10) || 1;
 
@@ -246,7 +262,16 @@ function SearchPageContent() {
             return [];
         }
     });
+    // Initialize from URL if present, otherwise from sessionStorage
+    const [selectedVersions, setSelectedVersions] = useState(() => {
+        if (versionsFromUrl.length > 0) return versionsFromUrl;
+        if (typeof window === 'undefined') return [];
+        const saved = sessionStorage.getItem('docs_version_filter');
+        try { return saved ? JSON.parse(saved) : []; } catch { return []; }
+    });
     const [resultsPerPage, setResultsPerPage] = useState(resultsPerPageFromUrl);
+
+    const availableVersions = useMemo(() => getVersionsForProducts(selectedProducts), [selectedProducts]);
 
     // Track if we're restoring from URL (e.g., browser back button)
     const restoringFromUrl = useRef(false);
@@ -266,6 +291,13 @@ function SearchPageContent() {
             }));
         }
     }, [selectedProducts]);
+
+    // Sync selectedVersions to sessionStorage
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            sessionStorage.setItem('docs_version_filter', JSON.stringify(selectedVersions));
+        }
+    }, [selectedVersions]);
 
     // Listen for filter changes from SearchBar modal (same-tab sync)
     useEffect(() => {
@@ -292,11 +324,13 @@ function SearchPageContent() {
         const urlParams = new URLSearchParams(location.search);
         const newQuery = urlParams.get('q') || '';
         const newProducts = urlParams.get('products')?.split(',').filter(Boolean) || [];
+        const newVersions = urlParams.get('versions')?.split(',').filter(Boolean) || [];
         const newResultsPerPage = parseInt(urlParams.get('resultsPerPage'), 10) || 25;
         const newPage = parseInt(urlParams.get('page'), 10) || 1;
 
         setSearchQuery(newQuery);
         setSelectedProducts(newProducts);
+        setSelectedVersions(newVersions);
         setResultsPerPage(newResultsPerPage);
 
         // Store target page for restoration
@@ -466,6 +500,13 @@ function SearchPageContent() {
                 facetFilters.push(realProducts.map(p => `product_name:${p}`)); // Array within array = OR logic
             }
 
+            // TODO: Version filtering disabled - 'version' facet not yet configured in Algolia
+            // To enable: add 'version' to attributesForFaceting in Algolia dashboard, re-index, then uncomment:
+            // const realVersions = selectedVersions.filter(v => v !== '__all__');
+            // if (realVersions.length > 0) {
+            //     facetFilters.push(realVersions.map(v => `version:${v}`)); // Array within array = OR logic
+            // }
+
             // Always fetch page 0 — all results come back at once for client-side pagination
             algoliaHelper
                 .setQuery(searchQuery)
@@ -474,7 +515,7 @@ function SearchPageContent() {
                 .setPage(0)
                 .search();
         },
-        [searchQuery, algoliaHelper, currentLocale, selectedProducts],
+        [searchQuery, algoliaHelper, currentLocale, selectedProducts, selectedVersions],
     );
 
     // Navigate to a page client-side using already-fetched sorted results
@@ -497,7 +538,7 @@ function SearchPageContent() {
     );
 
     // Update URL when filters or pagination change
-    const prevFiltersRef = useRef({searchQuery: '', selectedProducts: [], resultsPerPage: 25, page: 1});
+    const prevFiltersRef = useRef({searchQuery: '', selectedProducts: [], selectedVersions: [], resultsPerPage: 25, page: 1});
 
     useEffect(() => {
         // Only update URL if values actually changed
@@ -507,6 +548,7 @@ function SearchPageContent() {
         if (
             prev.searchQuery !== searchQuery ||
             JSON.stringify(prev.selectedProducts) !== JSON.stringify(selectedProducts) ||
+            JSON.stringify(prev.selectedVersions) !== JSON.stringify(selectedVersions) ||
             prev.resultsPerPage !== resultsPerPage ||
             prev.page !== currentPage
         ) {
@@ -514,6 +556,8 @@ function SearchPageContent() {
             if (searchQuery) params.set('q', searchQuery);
             const urlProducts = selectedProducts.filter(p => p !== '__all__' && p !== '__none__');
             if (urlProducts.length > 0) params.set('products', urlProducts.join(','));
+            const urlVersions = selectedVersions.filter(v => v !== '__all__');
+            if (urlVersions.length > 0) params.set('versions', urlVersions.join(','));
             if (resultsPerPage !== 25) params.set('resultsPerPage', String(resultsPerPage));
             if (currentPage > 1) params.set('page', String(currentPage));
 
@@ -521,10 +565,10 @@ function SearchPageContent() {
             isInternalNavigation.current = true;
             history.replace({search: params.toString()});
 
-            prevFiltersRef.current = {searchQuery, selectedProducts, resultsPerPage, page: currentPage};
+            prevFiltersRef.current = {searchQuery, selectedProducts, selectedVersions, resultsPerPage, page: currentPage};
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [searchQuery, selectedProducts, resultsPerPage, searchResultState.lastPage]);
+    }, [searchQuery, selectedProducts, selectedVersions, resultsPerPage, searchResultState.lastPage]);
 
     // IntersectionObserver removed - using pagination buttons instead
 
@@ -538,7 +582,7 @@ function SearchPageContent() {
             }, 300);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [searchQuery, selectedProducts, resultsPerPage]);
+    }, [searchQuery, selectedProducts, selectedVersions, resultsPerPage]);
 
     // Scroll to top when page changes (except initial load)
     const isInitialLoad = useRef(true);
@@ -765,6 +809,18 @@ function SearchPageContent() {
                             selectedValues={selectedProducts}
                             onChange={setSelectedProducts}
                         />
+                        {/* Version filter UI — non-functional until 'version' facet is configured in Algolia */}
+                        {availableVersions.length > 0 && (
+                            <MultiSelect
+                                label="Versions"
+                                options={[
+                                    {label: 'All versions', value: '__all__'},
+                                    ...availableVersions.map(v => ({label: v, value: v})),
+                                ]}
+                                selectedValues={selectedVersions}
+                                onChange={setSelectedVersions}
+                            />
+                        )}
                     </div>{/* closes filters div */}
 
                     {/* Results area */}

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -277,6 +277,7 @@ function SearchPageContent() {
     const restoringFromUrl = useRef(false);
     const targetPageRef = useRef(null);
     const isInternalNavigation = useRef(false);
+    const isInitialMount = useRef(true);
 
     // All sorted results for client-side pagination
     const allItemsRef = useRef([]);
@@ -312,8 +313,14 @@ function SearchPageContent() {
         return () => window.removeEventListener('productFilterChange', handleFilterChange);
     }, [selectedProducts]);
 
-    // Update state when URL changes (e.g., when navigating from search modal or browser back)
+    // Update state when URL changes (e.g., browser back/forward)
+    // Skips initial mount — useState initializers already read URL params and sessionStorage
     useEffect(() => {
+        if (isInitialMount.current) {
+            isInitialMount.current = false;
+            return;
+        }
+
         // Skip if this was an internal navigation (we triggered the URL change ourselves)
         if (isInternalNavigation.current) {
             isInternalNavigation.current = false;

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -500,12 +500,10 @@ function SearchPageContent() {
                 facetFilters.push(realProducts.map(p => `product_name:${p}`)); // Array within array = OR logic
             }
 
-            // TODO: Version filtering disabled - 'version' facet not yet configured in Algolia
-            // To enable: add 'version' to attributesForFaceting in Algolia dashboard, re-index, then uncomment:
-            // const realVersions = selectedVersions.filter(v => v !== '__all__');
-            // if (realVersions.length > 0) {
-            //     facetFilters.push(realVersions.map(v => `version:${v}`)); // Array within array = OR logic
-            // }
+            const realVersions = selectedVersions.filter(v => v !== '__all__');
+            if (realVersions.length > 0) {
+                facetFilters.push(realVersions.map(v => `product_version:${v}`)); // Array within array = OR logic
+            }
 
             // Always fetch page 0 — all results come back at once for client-side pagination
             algoliaHelper
@@ -809,7 +807,6 @@ function SearchPageContent() {
                             selectedValues={selectedProducts}
                             onChange={setSelectedProducts}
                         />
-                        {/* Version filter UI — non-functional until 'version' facet is configured in Algolia */}
                         {availableVersions.length > 0 && (
                             <MultiSelect
                                 label="Versions"

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -256,8 +256,8 @@ function SearchPageContent() {
         const saved = sessionStorage.getItem('docs_product_filter');
         try {
             const parsed = saved ? JSON.parse(saved) : [];
-            // Normalize: empty array from modal means "all products"
-            return parsed.length === 0 ? ['__all__'] : parsed;
+            if (!Array.isArray(parsed) || parsed.length === 0) return ['__all__'];
+            return parsed;
         } catch {
             return ['__all__'];
         }
@@ -269,7 +269,8 @@ function SearchPageContent() {
         const saved = sessionStorage.getItem('docs_version_filter');
         try {
             const parsed = saved ? JSON.parse(saved) : [];
-            return parsed.length === 0 ? ['__all__'] : parsed;
+            if (!Array.isArray(parsed) || parsed.length === 0) return ['__all__'];
+            return parsed;
         } catch { return ['__all__']; }
     });
     const [resultsPerPage, setResultsPerPage] = useState(resultsPerPageFromUrl);


### PR DESCRIPTION
## Summary

- Add multi-select product and version filter dropdowns to the search modal (SearchBar) and full search results page (SearchPage)
- Version filtering uses the `product_version` Algolia facet to filter results by product version
- Filter state flows from modal → search page via URL params (primary) and sessionStorage (fallback)
- Modal resets filters to "All products" / "All versions" on every open for a clean search experience
- Full search results page normalizes empty filters to `['__all__']` so checkboxes display as checked when no filter is active
- Version filter panel is always visible on the search results page, aggregating versions across all selected products
- Enter key navigates from modal to full results when focus is on a filter dropdown

### Key files
- `src/theme/SearchBar/index.js` — search modal, filter state, refs, ResultsFooter, transformSearchClient, Enter key handler
- `src/theme/SearchPage/index.js` — full results page, filter initialization from URL/sessionStorage, client-side pagination
- `src/theme/SearchBar/styles.css` — dropdown styling for modal filter controls

### Bugs fixed during development
- ResultsFooter was reading version refs at render time (stale URL) — now reads at click time
- `useNavigator` was dropping version params entirely — now includes them
- `productFilterChange` custom event was overriding normalized state — removed in favor of URL + sessionStorage handoff
- `isInternalNavigation` flag stayed stale when `history.replace` was a no-op — now only set when URL actually changes
- Version sessionStorage was not synced on modal reset — added useEffect to match product sync

### Known limitation
- When multiple products are selected in the modal and one has significantly more results for a query, the modal preview may only show results from the larger collection. The full results page shows all filtered results correctly. This is a DocSearch preview slot limitation, not a filter bug.

## Test plan

### Dev server (`npm run start`)
- [x] Search modal opens with "All products" / "All versions" selected
- [x] Selecting a product populates the version dropdown with that product's versions
- [x] Selecting multiple products combines their versions in the dropdown
- [x] Version filter correctly narrows results in the modal
- [x] "See all results" carries both product and version selections to the full results page
- [x] Full results page shows correct product and version checkboxes as selected
- [x] Changing filters on the full results page updates results and URL
- [x] Returning to the modal resets filters to defaults
- [x] Searching with default "All products" / "All versions" shows all checkboxes selected on results page
- [x] Enter key from a filter dropdown navigates to full results
- [x] Consecutive searches from modal → results → home → modal preserve correct filter state
- [x] Browser back/forward restores filters and pagination

### Production build (`npm run build && npm run serve`)
- [x] Build completes successfully with no broken links or errors
- [x] Search filters work correctly on the production build
- [x] Filter selections persist correctly across modal → results page navigation

Closes #1008