### PR TITLE
docs(change-tracker): update 8.2 device registration and OIDC SSO docs

### DIFF
--- a/docs/changetracker/8.2/admin/devicediscoveryregistration/customgroupnameprefix.md
+++ b/docs/changetracker/8.2/admin/devicediscoveryregistration/customgroupnameprefix.md
@@ -6,7 +6,7 @@ sidebar_position: 20
 
 # Custom Group Name Prefix
 
-The `CustomGroupNamePrefix` setting adds a validation gate to the device registration process. When set, at least one group returned by the registration script must start with the configured prefix and exist in the directory. If that condition is not met, the device is held in the **New Devices** group and an audit event is created.
+The `CustomGroupNamePrefix` setting adds a validation gate to the device registration process. When set, at least one group returned by the registration script must start with the configured prefix and exist in the directory. If that condition isn't met, the system holds the device in the **New Devices** group and creates an audit event.
 
 This setting is intended for environments where a naming convention requires every device to belong to a customer-prefixed group — for example, `XYZ123_Linux Redhat 9`.
 
@@ -42,13 +42,13 @@ When a device registers and the registration script returns group names, the pre
 
 **Step 3 –** If `CustomGroupNamePrefix` is set and the script returned at least one group name, the system filters the returned names to those that start with the prefix.
 
-**Step 4 –** If no returned name starts with the prefix, the device is held in **New Devices** and an audit event is created listing the groups that were returned.
+**Step 4 –** If no returned name starts with the prefix, the system holds the device in **New Devices** and creates an audit event listing the returned groups.
 
 **Step 5 –** If at least one name starts with the prefix, the system checks whether any of those prefix-matching groups exist in the directory.
 
-**Step 6 –** If all prefix-matching groups are missing from the directory, the device is held in **New Devices** and an audit event is created listing the missing group names.
+**Step 6 –** If all prefix-matching groups are missing from the directory, the system holds the device in **New Devices** and creates an audit event listing the missing group names.
 
-**Step 7 –** If at least one prefix-matching group exists in the directory, the gate passes. The device is added to all groups from the script that exist — the same behavior as standard registration.
+**Step 7 –** If at least one prefix-matching group exists in the directory, the gate passes. The system adds the device to all groups from the script that exist — the same behavior as standard registration.
 
 :::note
 Groups that don't match the prefix, such as the default OS-type group, are still assigned normally. The prefix check only validates that at least one prefix-matching group is present and exists.
@@ -72,7 +72,7 @@ Groups that don't match the prefix, such as the default OS-type group, are still
 
 ## Audit events
 
-When the gate blocks a registration, Change Tracker creates an audit event under **Device Administration** events. The event message identifies both the device and the specific group names involved so the misconfiguration can be corrected without inspecting log files.
+When the gate blocks a registration, Change Tracker creates an audit event under **Device Administration** events. The event message identifies both the device and the specific group names involved so you can correct the misconfiguration without inspecting log files.
 
 **No prefix group in script results**:
 
@@ -80,7 +80,7 @@ When the gate blocks a registration, Change Tracker creates an audit event under
 
 **Prefix group returned but not found in directory**:
 
-> Device 'MyServer' registration group(s) with prefix 'XYZ123_' not found in directory: \[XYZ123_Linux Redhat 9\]
+> Device 'MyServer' registration groups with prefix 'XYZ123_' not found in directory: \[XYZ123_Linux Redhat 9\]
 
 ---
 
@@ -101,15 +101,15 @@ Both can be enabled at the same time. If either check blocks registration, the d
 
 ### Device stuck in New Devices with a prefix-related audit event
 
-1. Open the audit event to read the exact group name(s) listed.
+1. Open the audit event to read the exact group names listed.
 2. Compare the name in the audit event against the groups in the directory.
 3. Common causes:
    - Group was created with a typo (for example, `XYZ123_Redhat 9` instead of `XYZ123_Linux Redhat 9`).
    - Group hasn't been created in the directory yet.
    - The prefix value in settings doesn't match the convention used in the script — the match is case-sensitive.
-4. Once the group name in the directory matches what the script returns, re-register the device or assign it to the group manually.
+4. After the group name in the directory matches what the script returns, re-register the device or assign it to the group manually.
 
-### Prefix gate is not triggering
+### Prefix gate isn't triggering
 
 - Verify the `CustomGroupNamePrefix` value is saved in System Settings — an empty value disables the gate.
 - Verify the registration script is returning group names. If the script returns an empty list, the gate doesn't apply.

--- a/docs/changetracker/8.2/admin/devicediscoveryregistration/customgroupnameprefix.md
+++ b/docs/changetracker/8.2/admin/devicediscoveryregistration/customgroupnameprefix.md
@@ -1,0 +1,117 @@
+---
+title: "Custom Group Name Prefix"
+description: "Restrict agent registration to device groups that follow a configured naming convention using the CustomGroupNamePrefix setting"
+sidebar_position: 20
+---
+
+# Custom Group Name Prefix
+
+The `CustomGroupNamePrefix` setting adds a validation gate to the device registration process. When set, at least one group returned by the registration script must start with the configured prefix and exist in the directory. If that condition is not met, the device is held in the **New Devices** group and an audit event is created.
+
+This setting is intended for environments where a naming convention requires every device to belong to a customer-prefixed group — for example, `XYZ123_Linux Redhat 9`.
+
+---
+
+## Configure the custom group name prefix
+
+**Step 1 –** Navigate to **Settings > System Settings**.
+
+**Step 2 –** Open the **Advanced Configuration** grid.
+
+**Step 3 –** Locate the `CustomGroupNamePrefix` key. If it doesn't exist, add a new entry.
+
+**Step 4 –** Set the value to the prefix string exactly as it should appear at the start of group names. The match is case-sensitive. For example, entering `XYZ123_` matches `XYZ123_Linux Redhat 9` but not `xyz123_Linux Redhat 9`.
+
+**Step 5 –** Save the settings.
+
+To disable the feature, set the value back to an empty string.
+
+:::note
+`CustomGroupNamePrefix` is configured in the same Advanced Configuration grid as the `AllRegistrationGroupsExist` flag. The two settings are independent and can be enabled together. See [Relationship to AllRegistrationGroupsExist](#relationship-to-allregistrationgroupsexist).
+:::
+
+---
+
+## How prefix validation works
+
+When a device registers and the registration script returns group names, the prefix gate runs after the system has resolved which of those groups exist in the directory.
+
+**Step 1 –** The registration script returns a list of group display names (for example, `["XYZ123_Linux Redhat 9", "Linux Redhat 9"]`).
+
+**Step 2 –** The system resolves each name against the directory to find which groups exist.
+
+**Step 3 –** If `CustomGroupNamePrefix` is set and the script returned at least one group name, the system filters the returned names to those that start with the prefix.
+
+**Step 4 –** If no returned name starts with the prefix, the device is held in **New Devices** and an audit event is created listing the groups that were returned.
+
+**Step 5 –** If at least one name starts with the prefix, the system checks whether any of those prefix-matching groups exist in the directory.
+
+**Step 6 –** If all prefix-matching groups are missing from the directory, the device is held in **New Devices** and an audit event is created listing the missing group names.
+
+**Step 7 –** If at least one prefix-matching group exists in the directory, the gate passes. The device is added to all groups from the script that exist — the same behavior as standard registration.
+
+:::note
+Groups that don't match the prefix, such as the default OS-type group, are still assigned normally. The prefix check only validates that at least one prefix-matching group is present and exists.
+:::
+
+---
+
+## Behavior reference
+
+| Prefix set | Groups returned by script | Prefix group exists in directory | Outcome |
+|---|---|---|---|
+| No | Any | — | Standard behavior — no gate applied |
+| Yes | No groups match the prefix | — | Device stays in New Devices + audit event listing returned groups |
+| Yes | Groups match prefix | None exist | Device stays in New Devices + audit event listing the missing groups |
+| Yes | Groups match prefix | At least one exists | Device added to all valid script groups (gate passes) |
+| Yes | Script returns empty list | — | Device stays in New Devices — no audit event (not an error) |
+
+**Example**: An organization uses the convention `XYZ123_` for all device groups. The registration script returns `["XYZ123_Linux Redhat 9", "Linux Redhat 9"]`. If `XYZ123_Linux Redhat 9` exists in the directory, the gate passes and the device is placed in both groups. If the group was created with a typo — for example, `XYZ123_Redhat 9` — the gate blocks registration and creates an audit event identifying the missing group.
+
+---
+
+## Audit events
+
+When the gate blocks a registration, Change Tracker creates an audit event under **Device Administration** events. The event message identifies both the device and the specific group names involved so the misconfiguration can be corrected without inspecting log files.
+
+**No prefix group in script results**:
+
+> Device 'MyServer' has no registration group with prefix 'XYZ123_'. Groups returned: \[Linux Redhat 9\]
+
+**Prefix group returned but not found in directory**:
+
+> Device 'MyServer' registration group(s) with prefix 'XYZ123_' not found in directory: \[XYZ123_Linux Redhat 9\]
+
+---
+
+## Relationship to AllRegistrationGroupsExist
+
+`AllRegistrationGroupsExist` is a separate setting that blocks registration if any group returned by the script doesn't exist in the directory.
+
+The two settings apply different checks:
+
+- `AllRegistrationGroupsExist` applies to every group returned by the script.
+- `CustomGroupNamePrefix` applies only to groups whose names start with the prefix.
+
+Both can be enabled at the same time. If either check blocks registration, the device stays in **New Devices**.
+
+---
+
+## Troubleshooting
+
+### Device stuck in New Devices with a prefix-related audit event
+
+1. Open the audit event to read the exact group name(s) listed.
+2. Compare the name in the audit event against the groups in the directory.
+3. Common causes:
+   - Group was created with a typo (for example, `XYZ123_Redhat 9` instead of `XYZ123_Linux Redhat 9`).
+   - Group hasn't been created in the directory yet.
+   - The prefix value in settings doesn't match the convention used in the script — the match is case-sensitive.
+4. Once the group name in the directory matches what the script returns, re-register the device or assign it to the group manually.
+
+### Prefix gate is not triggering
+
+- Verify the `CustomGroupNamePrefix` value is saved in System Settings — an empty value disables the gate.
+- Verify the registration script is returning group names. If the script returns an empty list, the gate doesn't apply.
+- Confirm the prefix value matches the exact case and characters used in the group names returned by the script.
+- Enable DEBUG logging for `CollateComplianceReportDataBackgroundTaskWorker` to see the full list of groups returned by the registration script and the prefix check results.

--- a/docs/changetracker/8.2/admin/devicediscoveryregistration/customgroupnameprefix.md
+++ b/docs/changetracker/8.2/admin/devicediscoveryregistration/customgroupnameprefix.md
@@ -6,7 +6,7 @@ sidebar_position: 20
 
 # Custom Group Name Prefix
 
-The `CustomGroupNamePrefix` setting adds a validation gate to the device registration process. When set, at least one group returned by the registration script must start with the configured prefix and exist in the directory. If that condition isn't met, the system holds the device in the **New Devices** group and creates an audit event.
+The `CustomGroupNamePrefix` setting adds a validation gate to the device registration process. When set, at least one group returned by the device registration script (see [Device Discovery and Registration](./devicediscoveryregistration.md)) must start with the configured prefix and exist in the directory. If that condition isn't met, the system holds the device in the **New Devices** group and creates an audit event.
 
 This setting is intended for environments where a naming convention requires every device to belong to a customer-prefixed group — for example, `XYZ123_Linux Redhat 9`.
 
@@ -16,7 +16,7 @@ This setting is intended for environments where a naming convention requires eve
 
 **Step 1 –** Navigate to **Settings > System Settings**.
 
-**Step 2 –** Open the **Advanced Configuration** grid.
+**Step 2 –** In **System Settings**, scroll to the **Advanced Configuration** grid.
 
 **Step 3 –** Locate the `CustomGroupNamePrefix` key. If it doesn't exist, add a new entry.
 
@@ -36,19 +36,13 @@ To disable the feature, set the value back to an empty string.
 
 When a device registers and the registration script returns group names, the prefix gate runs after the system has resolved which of those groups exist in the directory.
 
-**Step 1 –** The registration script returns a list of group display names (for example, `["XYZ123_Linux Redhat 9", "Linux Redhat 9"]`).
-
-**Step 2 –** The system resolves each name against the directory to find which groups exist.
-
-**Step 3 –** If `CustomGroupNamePrefix` is set and the script returned at least one group name, the system filters the returned names to those that start with the prefix.
-
-**Step 4 –** If no returned name starts with the prefix, the system holds the device in **New Devices** and creates an audit event listing the returned groups.
-
-**Step 5 –** If at least one name starts with the prefix, the system checks whether any of those prefix-matching groups exist in the directory.
-
-**Step 6 –** If all prefix-matching groups are missing from the directory, the system holds the device in **New Devices** and creates an audit event listing the missing group names.
-
-**Step 7 –** If at least one prefix-matching group exists in the directory, the gate passes. The system adds the device to all groups from the script that exist — the same behavior as standard registration.
+1. The registration script returns a list of group display names (for example, `["XYZ123_Linux Redhat 9", "Linux Redhat 9"]`).
+2. The system resolves each name against the directory to find which groups exist.
+3. If `CustomGroupNamePrefix` is set and the script returned at least one group name, the system filters the returned names to those that start with the prefix.
+4. If no returned name starts with the prefix, the system holds the device in **New Devices** and creates an audit event listing the returned groups.
+5. If at least one name starts with the prefix, the system checks whether any of those prefix-matching groups exist in the directory.
+6. If all prefix-matching groups are missing from the directory, the system holds the device in **New Devices** and creates an audit event listing the missing group names.
+7. If at least one prefix-matching group exists in the directory, the gate passes. The system adds the device to every script-returned group that exists in the directory — the same behavior as standard registration.
 
 :::note
 Groups that don't match the prefix, such as the default OS-type group, are still assigned normally. The prefix check only validates that at least one prefix-matching group is present and exists.
@@ -114,4 +108,4 @@ Both can be enabled at the same time. If either check blocks registration, the d
 - Verify the `CustomGroupNamePrefix` value is saved in System Settings — an empty value disables the gate.
 - Verify the registration script is returning group names. If the script returns an empty list, the gate doesn't apply.
 - Confirm the prefix value matches the exact case and characters used in the group names returned by the script.
-- Enable DEBUG logging for `CollateComplianceReportDataBackgroundTaskWorker` to see the full list of groups returned by the registration script and the prefix check results.
+- Enable DEBUG logging for `CollateComplianceReportDataBackgroundTaskWorker` to see the full list of groups returned by the registration script and the prefix check results. See [Device Registration Logging](./devicediscoveryregistration.md#device-registration-logging) for how to enable DEBUG logging on this component.

--- a/docs/changetracker/8.2/admin/devicediscoveryregistration/devicediscoveryregistration.md
+++ b/docs/changetracker/8.2/admin/devicediscoveryregistration/devicediscoveryregistration.md
@@ -45,7 +45,7 @@ For the full list of supported operating systems, see the [Support Matrix](/docs
 
 #### Windows OS Type Detection
 
-Windows operating system detection uses **build numbers** to accurately identify the OS version, as the standard version information is not reliable for Windows Server 2012 R2 and later versions.
+Windows operating system detection uses **build numbers** to accurately identify the OS version, as the standard version information isn't reliable for Windows Server 2012 R2 and later versions.
 
 **Detection Process**:
 
@@ -62,7 +62,7 @@ Windows operating system detection uses **build numbers** to accurately identify
    - **21996+**: Windows 11
    - **26100+**: Windows Server 2025
 
-3. **Server vs Desktop**: The `ProductName` registry value is checked for the word "server" to distinguish between server and desktop editions
+3. **Server vs Desktop**: The system checks the `ProductName` registry value for the word "server" to distinguish between server and desktop editions
 
 **Example**: A system with build number 20348 and "server" in the product name is identified as Windows Server 2022, while the same build without "server" would be Windows 10.
 
@@ -81,7 +81,7 @@ The system first attempts to use the `lsb_release` command if available:
 
 **Method 2: Release Files**
 
-If LSB is not available, the system examines release files in `/etc/`:
+If LSB isn't available, the system examines release files in `/etc/`:
 
 1. Searches for files matching `/etc/*release` (including symlinks)
 2. Reads and parses these files as key-value pairs
@@ -98,9 +98,9 @@ If the previous methods fail, the system falls back to the `uname -a` command:
 
 1. Executes `uname -a` to get kernel and system information
 2. Searches the output for distribution-specific keywords
-3. Uses generic "Unix" or "Linux" classification if no specific match found
+3. Uses generic "Unix" or "Linux" classification if it finds no specific match
 
-**Version Refinement**: Once the distribution family is identified, the system maps the major version number to specific OS types (e.g., Ubuntu 20, Ubuntu 22, Ubuntu 24).
+**Version Refinement**: After the distribution family is identified, the system maps the major version number to specific OS types (e.g., Ubuntu 20, Ubuntu 22, Ubuntu 24).
 
 **Example Detection Sequence**:
 - System tries `lsb_release -sd` → Returns "Ubuntu 22.04.1 LTS"
@@ -115,7 +115,7 @@ The discovery process collects the following information:
 2. **Fully Qualified Domain Name (FQDN)**: Complete domain name if available
 3. **IP Addresses**: Both IPv4 and IPv6 addresses from active network interfaces
 4. **MAC Addresses**: Physical addresses of network adapters
-5. **Operating System**: Type, version, and edition (server vs. desktop) - detected using methods described above
+5. **Operating System**: Type, version, and edition (server vs. desktop) - detected using the methods in [Operating System Detection Methods](#operating-system-detection-methods)
 6. **Platform Information**: Architecture and system details
 7. **CPE Name**: Common Platform Enumeration identifier (for Linux systems)
 8. **Agent Version**: Version of the installed agent software
@@ -131,7 +131,7 @@ Device registration is the process of placing newly discovered devices into appr
 When a device is first discovered or re-registered, it follows this sequence:
 
 1. **Initial Placement**: The system places the device in both the "New Devices" and "Awaiting Registration" groups
-   - The "New Devices" group provides a fallback — if the registration process fails for any reason, the device can still be found here
+   - The "New Devices" group provides a fallback — if the registration process fails for any reason, you can still find the device here
    - This ensures devices are never "lost" during the registration process
 
 2. **Registration Report Execution**: The system runs a registration report to collect device characteristics
@@ -143,13 +143,13 @@ When a device is first discovered or re-registered, it follows this sequence:
    - If no custom script exists, default OS-based group assignment is used
 
 4. **Final Placement**: The system moves the device from "Awaiting Registration" to its target groups
-   - If appropriate groups are found, the system removes the device from "New Devices" and adds it to target groups
-   - If no appropriate groups are found or registration fails, the device **remains in "New Devices"** for manual review
+   - If the system finds appropriate groups, it removes the device from "New Devices" and adds it to the target groups
+   - If the system finds no appropriate groups or registration fails, the device **remains in "New Devices"** for manual review
    - The system always adds the device to the "All Devices" group regardless of other group assignments
 
 ### Default Group Assignment
 
-The registration process uses the "New Device Registration Process" report to determine group placement. By default, devices are assigned to groups based on their operating system. Each supported OS maps to a corresponding device group (for example, "Windows 2022" or "Linux Ubuntu 24"). For the full list of supported operating systems and their group mappings, see the [Support Matrix](/docs/changetracker/8.2/requirements/supportmatrix.md).
+The registration process uses the "New Device Registration Process" report to determine group placement. By default, the system assigns devices to groups based on their operating system. Each supported OS maps to a corresponding device group (for example, "Windows 2022" or "Linux Ubuntu 24"). For the full list of supported operating systems and their group mappings, see the [Support Matrix](/docs/changetracker/8.2/requirements/supportmatrix.md).
 
 ### Custom Registration Scripts
 
@@ -160,7 +160,7 @@ Organizations can customize the registration process by providing a custom regis
 - Assign devices to multiple groups based on complex criteria
 - Override default OS-based group assignments
 
-When a custom script identifies multiple groups for a device, all identified groups will be assigned (subject to the `AllRegistrationGroupsExist` configuration setting). To enforce a group naming convention during registration, see [Custom Group Name Prefix](./customgroupnameprefix.md).
+When a custom script identifies multiple groups for a device, the system assigns the device to all identified groups (subject to the `AllRegistrationGroupsExist` configuration setting). To enforce a group naming convention during registration, see [Custom Group Name Prefix](./customgroupnameprefix.md).
 
 ### Group Assignment Sequence
 
@@ -168,42 +168,42 @@ The system follows this sequence when assigning groups:
 
 1. **Initial State**: Device is already in both "New Devices" and "Awaiting Registration" groups (placed there during initial discovery)
 
-2. **Remove from Awaiting Registration**: Device is removed from the "Awaiting Registration" group
+2. **Remove from Awaiting Registration**: The system removes the device from the "Awaiting Registration" group
 
 3. **Evaluate Custom Script**: If a custom registration script exists, the system executes it with the device characteristics
 
-4. **Determine Target Groups**: Groups are identified based on:
+4. **Determine Target Groups**: The system identifies groups based on:
    - Custom script results (if script exists)
    - Default OS-based mapping from the registration report (if no script)
 
 5. **Validate Groups**: If `AllRegistrationGroupsExist` is enabled, all identified groups must exist
-   - If any group doesn't exist, the entire registration is aborted
-   - Device remains in "New Devices" for manual intervention
+   - If any group doesn't exist, the system aborts the entire registration
+   - The device remains in "New Devices" for manual intervention
 
 6. **Remove from Previous OS Groups**: If `EnableAutoReregisterAgentAfterOsChange` is enabled, the system removes the device from previous OS-specific groups (during re-registration scenarios)
 
 7. **Add to Target Groups**: The system adds the device to all identified groups (if validation passed)
 
-8. **Add to All Devices**: Device is always added to the "All Devices" group
+8. **Add to All Devices**: The system always adds the device to the "All Devices" group
 
 9. **Handle New Devices Group**:
-   - If custom or OS-specific groups were successfully assigned, device is removed from "New Devices"
-   - If no groups were found or registration failed, device **remains in "New Devices"** as a safety net
+   - If the system successfully assigned custom or OS-specific groups, it removes the device from "New Devices"
+   - If the system found no groups or registration failed, the device **remains in "New Devices"** as a fallback
    - This ensures administrators can always find devices that need manual group assignment
 
 ### Registration Failure Handling
 
-If the registration process encounters issues, the device remains in the "New Devices" group where it was initially placed:
+If the registration process encounters issues, the device remains in the "New Devices" group where the system initially placed it:
 
-- **No Response**: If a device doesn't respond to the registration report, it remains in "New Devices" group (never removed from it)
+- **No Response**: If a device doesn't respond to the registration report, it remains in the "New Devices" group (the system never removes it)
 
-- **Missing Groups**: If `AllRegistrationGroupsExist` is enabled and any identified group doesn't exist, the device remains in "New Devices" and a warning is logged
+- **Missing Groups**: If `AllRegistrationGroupsExist` is enabled and any identified group doesn't exist, the device remains in "New Devices" and the system logs a warning
 
-- **Script Errors**: If the custom registration script fails, the device remains in "New Devices" by default and the error is logged
+- **Script Errors**: If the custom registration script fails, the device remains in "New Devices" by default and the system logs the error
 
 - **Validation Failures**: Any validation failure during the registration process results in the device staying in "New Devices"
 
-This fallback approach ensures that devices requiring manual intervention can always be found in the "New Devices" group, preventing devices from being "lost" in the system.
+This fallback approach ensures you can always find devices requiring manual intervention in the "New Devices" group, preventing devices from being "lost" in the system.
 
 ---
 
@@ -211,27 +211,27 @@ This fallback approach ensures that devices requiring manual intervention can al
 
 ### AllRegistrationGroupsExist
 
-**Purpose**: Controls whether all groups identified for a device must exist before the device is moved from "New Devices".
+**Purpose**: Controls whether all groups identified for a device must exist before the system moves the device from "New Devices".
 
 **Default Value**: `false`
 
 **Behaviour**:
-- When `true`: If any identified group doesn't exist, the device remains in "New Devices" and a warning is logged
-- When `false`: Device is added to groups that exist; missing groups are logged as errors but don't prevent registration
+- When `true`: If any identified group doesn't exist, the device remains in "New Devices" and the system logs a warning
+- When `false`: The system adds the device to groups that exist and logs missing groups as errors, but missing groups don't prevent registration
 
-**Use Case**: Enable this setting in production environments to ensure devices are only registered when all required groups are properly configured.
+**Use Case**: Enable this setting in production environments to register devices only when all required groups exist and are properly configured.
 
 ### EnableAutoReregisterAgentAfterOsChange
 
-**Purpose**: Controls whether devices are automatically re-registered when an operating system change is detected.
+**Purpose**: Controls whether the system automatically re-registers devices when it detects an operating system change.
 
 **Default Value**: `false`
 
 **Behaviour**:
 - When `true`: If a device's OS changes (e.g., after an upgrade), the system automatically moves it back to "Awaiting Registration" and runs the registration process again
-- When `false`: OS changes do not trigger automatic re-registration
+- When `false`: OS changes don't trigger automatic re-registration
 
-**Use Case**: Enable this setting if you want devices to be automatically reassigned to appropriate OS-specific groups after operating system upgrades.
+**Use Case**: Enable this setting if you want the system to automatically reassign devices to appropriate OS-specific groups after operating system upgrades.
 
 For information about enforcing a group naming convention during registration, see [Custom Group Name Prefix](./customgroupnameprefix.md).
 
@@ -294,7 +294,7 @@ For comprehensive troubleshooting, you may also want to enable DEBUG logging for
 
 ### OS Type Not Correctly Identified
 
-**Impact**: If the agent cannot correctly identify the operating system type, the device registration process will encounter problems because both the registration report and custom registration scripts depend on accurate OS Type information.
+**Impact**: If the agent can't correctly identify the operating system type, the device registration process will encounter problems because both the registration report and custom registration scripts depend on accurate OS Type information.
 
 **Possible Causes**:
 1. **Outdated Agent**: Agent version doesn't recognize newer operating systems
@@ -336,7 +336,7 @@ For comprehensive troubleshooting, you may also want to enable DEBUG logging for
 
 4. **Update Agent**:
    - If a newer agent version is available that supports the OS, upgrade the agent
-   - After upgrade, the device may need to be re-registered (see `EnableAutoReregisterAgentAfterOsChange`)
+   - After upgrade, you may need to re-register the device (see `EnableAutoReregisterAgentAfterOsChange`)
 
 5. **Temporary Workaround**:
    - Manually assign device to appropriate groups

--- a/docs/changetracker/8.2/admin/devicediscoveryregistration/devicediscoveryregistration.md
+++ b/docs/changetracker/8.2/admin/devicediscoveryregistration/devicediscoveryregistration.md
@@ -179,6 +179,7 @@ The system follows this sequence when assigning groups:
 5. **Validate Groups**: If `AllRegistrationGroupsExist` is enabled, all identified groups must exist
    - If any group doesn't exist, the system aborts the entire registration
    - The device remains in "New Devices" for manual intervention
+   - If `CustomGroupNamePrefix` is set, an additional prefix-validation check runs as part of this step. See [Custom Group Name Prefix](./customgroupnameprefix.md) for details.
 
 6. **Remove from Previous OS Groups**: If `EnableAutoReregisterAgentAfterOsChange` is enabled, the system removes the device from previous OS-specific groups (during re-registration scenarios)
 
@@ -233,7 +234,9 @@ This fallback approach ensures you can always find devices requiring manual inte
 
 **Use Case**: Enable this setting if you want the system to automatically reassign devices to appropriate OS-specific groups after operating system upgrades.
 
-For information about enforcing a group naming convention during registration, see [Custom Group Name Prefix](./customgroupnameprefix.md).
+### CustomGroupNamePrefix
+
+Configure `CustomGroupNamePrefix` to require that at least one registration group follow a naming convention. See [Custom Group Name Prefix](./customgroupnameprefix.md).
 
 ---
 

--- a/docs/changetracker/8.2/admin/devicediscoveryregistration/devicediscoveryregistration.md
+++ b/docs/changetracker/8.2/admin/devicediscoveryregistration/devicediscoveryregistration.md
@@ -35,7 +35,7 @@ For remote devices accessed through credentials, the system:
 - Collects basic platform information including device name and network details
 - Handles special cases for cloud, ESX, Splunk, and database connections
 
-For ESXi/vCenter discovery, see [ESXi / vCenter Discovery](/docs/changetracker/8.2/admin/devicediscoveryregistration/esxidiscovery.md).
+For ESXi/vCenter discovery, see [ESXi / vCenter Discovery](./esxidiscovery.md).
 
 ### Supported Operating Systems
 
@@ -131,7 +131,7 @@ Device registration is the process of placing newly discovered devices into appr
 When a device is first discovered or re-registered, it follows this sequence:
 
 1. **Initial Placement**: The system places the device in both the "New Devices" and "Awaiting Registration" groups
-   - The "New Devices" group provides a fallback: if the registration process fails for any reason, the device can still be found here
+   - The "New Devices" group provides a fallback — if the registration process fails for any reason, the device can still be found here
    - This ensures devices are never "lost" during the registration process
 
 2. **Registration Report Execution**: The system runs a registration report to collect device characteristics
@@ -149,7 +149,7 @@ When a device is first discovered or re-registered, it follows this sequence:
 
 ### Default Group Assignment
 
-The registration process uses the "New Device Registration Process" report to determine group placement. By default, devices are assigned to groups based on their operating system. Each supported OS maps to a corresponding device group (e.g., "Windows 2022", "Linux Ubuntu 24"). For the full list of supported operating systems and their group mappings, see the [Support Matrix](/docs/changetracker/8.2/requirements/supportmatrix.md).
+The registration process uses the "New Device Registration Process" report to determine group placement. By default, devices are assigned to groups based on their operating system. Each supported OS maps to a corresponding device group (for example, "Windows 2022" or "Linux Ubuntu 24"). For the full list of supported operating systems and their group mappings, see the [Support Matrix](/docs/changetracker/8.2/requirements/supportmatrix.md).
 
 ### Custom Registration Scripts
 
@@ -160,7 +160,7 @@ Organizations can customize the registration process by providing a custom regis
 - Assign devices to multiple groups based on complex criteria
 - Override default OS-based group assignments
 
-When a custom script identifies multiple groups for a device, all identified groups will be assigned (subject to the `AllRegistrationGroupsExist` and `CustomGroupNamePrefix` configuration settings).
+When a custom script identifies multiple groups for a device, all identified groups will be assigned (subject to the `AllRegistrationGroupsExist` configuration setting). To enforce a group naming convention during registration, see [Custom Group Name Prefix](./customgroupnameprefix.md).
 
 ### Group Assignment Sequence
 
@@ -180,17 +180,13 @@ The system follows this sequence when assigning groups:
    - If any group doesn't exist, the entire registration is aborted
    - Device remains in "New Devices" for manual intervention
 
-6. **Validate Group Name Prefix**: If `CustomGroupNamePrefix` is set, at least one returned group must start with the configured prefix and exist in the directory
-   - If no group matches the prefix, registration is blocked and an audit event is created
-   - If at least one prefix-matching group exists, registration proceeds (missing prefix groups are logged as warnings)
+6. **Remove from Previous OS Groups**: If `EnableAutoReregisterAgentAfterOsChange` is enabled, the system removes the device from previous OS-specific groups (during re-registration scenarios)
 
-7. **Remove from Previous OS Groups**: If `EnableAutoReregisterAgentAfterOsChange` is enabled, the system removes the device from previous OS-specific groups (during re-registration scenarios)
+7. **Add to Target Groups**: The system adds the device to all identified groups (if validation passed)
 
-8. **Add to Target Groups**: The system adds the device to all identified groups (if validation passed)
+8. **Add to All Devices**: Device is always added to the "All Devices" group
 
-9. **Add to All Devices**: Device is always added to the "All Devices" group
-
-10. **Handle New Devices Group**:
+9. **Handle New Devices Group**:
    - If custom or OS-specific groups were successfully assigned, device is removed from "New Devices"
    - If no groups were found or registration failed, device **remains in "New Devices"** as a safety net
    - This ensures administrators can always find devices that need manual group assignment
@@ -202,8 +198,6 @@ If the registration process encounters issues, the device remains in the "New De
 - **No Response**: If a device doesn't respond to the registration report, it remains in "New Devices" group (never removed from it)
 
 - **Missing Groups**: If `AllRegistrationGroupsExist` is enabled and any identified group doesn't exist, the device remains in "New Devices" and a warning is logged
-
-- **No Matching Prefix Group**: If `CustomGroupNamePrefix` is set and no returned group name starts with the configured prefix (or all prefix-matching groups are missing from the directory), the device remains in "New Devices" and an audit event is created
 
 - **Script Errors**: If the custom registration script fails, the device remains in "New Devices" by default and the error is logged
 
@@ -227,30 +221,6 @@ This fallback approach ensures that devices requiring manual intervention can al
 
 **Use Case**: Enable this setting in production environments to ensure devices are only registered when all required groups are properly configured.
 
-### CustomGroupNamePrefix
-
-**Purpose**: Restricts agent registration to groups whose display name starts with a specified prefix. When set, at least one group returned by the registration script must match the prefix and exist in the directory. If no matching group is found, the device remains in "New Devices" and an audit event is created.
-
-**Default Value**: empty string (disabled)
-
-**Behaviour**:
-- When set (e.g. `TCM123_`): The Hub checks all group names returned by the registration script. At least one must start with the configured prefix (case-sensitive) **and** exist as a group in the directory. If no matching group exists, registration is blocked and the device remains in "New Devices".
-- When empty or not set: Existing registration behaviour is unchanged; no prefix validation is performed.
-
-**Matching rules**:
-- The comparison is **case-sensitive** and uses a **starts-with** check against each group's display name.
-- If the registration script returns multiple groups that match the prefix but only some exist in the directory, registration proceeds as long as at least one matching group exists. A warning is logged for the missing groups.
-- Groups that don't match the prefix (such as the default OS-type group) are still assigned normally; the prefix check only validates that at least one prefix-matching group is present.
-- When registration is blocked, an audit event of type **DeviceAdmin** is created with details of the device name, the configured prefix, and the groups that were returned.
-
-**Example**: An organization uses the naming convention `TCM123_` for all device groups. Setting `CustomGroupNamePrefix` to `TCM123_` ensures that agents only register into groups that follow this convention. If the registration script returns `TCM123_Linux Redhat 9` and that group exists, the agent is placed in both `TCM123_Linux Redhat 9` and the default OS group (`Linux Redhat 9`). If the script returns only `Linux Redhat 9` (no prefix match), the agent remains in "New Devices" for manual review.
-
-**Use Case**: Enable this setting when your organization uses a group naming convention and you want to prevent agents from registering into groups that don't follow the convention.
-
-:::note
-`CustomGroupNamePrefix` and `AllRegistrationGroupsExist` are independent checks that both run during registration. A device must pass both checks (if both are enabled) to be placed into its target groups.
-:::
-
 ### EnableAutoReregisterAgentAfterOsChange
 
 **Purpose**: Controls whether devices are automatically re-registered when an operating system change is detected.
@@ -262,6 +232,8 @@ This fallback approach ensures that devices requiring manual intervention can al
 - When `false`: OS changes do not trigger automatic re-registration
 
 **Use Case**: Enable this setting if you want devices to be automatically reassigned to appropriate OS-specific groups after operating system upgrades.
+
+For information about enforcing a group naming convention during registration, see [Custom Group Name Prefix](./customgroupnameprefix.md).
 
 ---
 
@@ -389,9 +361,8 @@ For comprehensive troubleshooting, you may also want to enable DEBUG logging for
 **Possible Causes**:
 1. Custom registration script returned unexpected group names
 2. Target group doesn't exist and `AllRegistrationGroupsExist` is enabled
-3. `CustomGroupNamePrefix` is set and no returned group matches the prefix
-4. Registration report didn't complete successfully
-5. Device didn't respond to registration report task
+3. Registration report didn't complete successfully
+4. Device didn't respond to registration report task
 
 **Resolution Steps**:
 1. Enable DEBUG logging for `CollateComplianceReportDataBackgroundTaskWorker`
@@ -399,25 +370,6 @@ For comprehensive troubleshooting, you may also want to enable DEBUG logging for
 3. Verify all target groups exist in the system
 4. Review custom registration script logic if applicable
 5. Check that device responded to registration report task
-
-### Device Blocked by Group Name Prefix Check
-
-**Possible Causes**:
-1. `CustomGroupNamePrefix` is set but the registration script doesn't return any group whose display name starts with the configured prefix
-2. The prefix-matching group was returned by the script but doesn't exist in the directory
-3. The prefix value is case-sensitive and doesn't match the group name casing
-
-**Symptoms**:
-- Device remains in "New Devices" after registration
-- An audit event of type **DeviceAdmin** appears with a message such as: "Device 'TestAgent' has no registration group with prefix 'TCM123_'"
-- Hub log contains a warning from `CollateComplianceReportDataBackgroundTaskWorker` referencing the prefix
-
-**Resolution Steps**:
-1. Check the configured `CustomGroupNamePrefix` value in the Hub configuration
-2. Verify that the target group's display name starts with the exact prefix (case-sensitive)
-3. Confirm the group exists in the directory; if it was recently created, it may not yet be in the cache
-4. Review the registration script to ensure it returns the prefixed group name
-5. Enable DEBUG logging for `CollateComplianceReportDataBackgroundTaskWorker` to see the full list of groups returned by the registration script
 
 ### Device Stuck in "Awaiting Registration"
 
@@ -471,13 +423,11 @@ For comprehensive troubleshooting, you may also want to enable DEBUG logging for
 
 5. **Use Descriptive Group Names**: Use clear, descriptive group names that match your organizational structure
 
-6. **Enforce Group Naming Conventions**: If your organization uses a naming convention for device groups, set `CustomGroupNamePrefix` to enforce it during registration and prevent agents from being placed in non-conforming groups
+6. **Document Custom Logic**: If using custom registration scripts, document the business rules and group assignment logic
 
-7. **Document Custom Logic**: If using custom registration scripts, document the business rules and group assignment logic
+7. **Plan for OS Upgrades**: If you perform OS upgrades, consider enabling `EnableAutoReregisterAgentAfterOsChange` to automatically reassign devices
 
-8. **Plan for OS Upgrades**: If you perform OS upgrades, consider enabling `EnableAutoReregisterAgentAfterOsChange` to automatically reassign devices
-
-9. **Regular Audits**: Periodically audit device group memberships to ensure they remain accurate
+8. **Regular Audits**: Periodically audit device group memberships to ensure they remain accurate
 
 ---
 

--- a/docs/changetracker/8.2/admin/settingstab/systemsettings/oidcsso.md
+++ b/docs/changetracker/8.2/admin/settingstab/systemsettings/oidcsso.md
@@ -34,13 +34,13 @@ Collect the following from your identity provider before configuring Change Trac
 | **Authorization endpoint URL** | The URL users are redirected to for authentication | IdP documentation or discovery document |
 | **Token endpoint URL** | The URL Change Tracker calls to exchange an authorization code for tokens | IdP documentation or discovery document |
 | **UserInfo endpoint URL** | The URL Change Tracker calls to retrieve user profile claims | IdP documentation or discovery document |
-| **Roles claim key** | The claim key in the token or UserInfo response that contains role assignments | IdP documentation or token inspection — see [The rolesClaimKey setting](#the-rolesclaimkey-setting) |
+| **Roles claim key** | The claim key in the token or UserInfo response that contains role assignments | IdP documentation, or by [decoding a sample token](#verify-your-idp-configuration) — see [The rolesClaimKey setting](#the-rolesclaimkey-setting) |
 
 :::note
 Most OIDC-compliant IdPs publish a discovery document at
 `https://<your-idp>/.well-known/openid-configuration` that lists all endpoint URLs. Change Tracker
-doesn't use this document automatically — endpoint URLs must be supplied individually — but it can
-save time locating them manually.
+doesn't use this document automatically — endpoint URLs must be supplied individually. However,
+the discovery document can save time locating each URL.
 :::
 
 ## Set up your identity provider
@@ -73,6 +73,8 @@ Configure your IdP to include role or group membership in that response:
 3. Note the exact claim key under which roles appear. This is the `rolesClaimKey` value — see
    [The rolesClaimKey setting](#the-rolesclaimkey-setting).
 
+#### Provider-specific notes
+
 **Auth0**: Auth0 doesn't include role assignments in the OIDC token by default. Create a
 **Post-Login Action** in the Auth0 dashboard to inject the user's roles as a custom claim:
 
@@ -83,8 +85,9 @@ exports.onExecutePostLogin = async (event, api) => {
 };
 ```
 
-The namespace prefix can be any URL-shaped string. Set `rolesClaimKey` in Change Tracker to the
-full claim key, for example `https://your-domain.com/roles`.
+The namespace prefix can be any URL-like string, such as `https://your-domain.com/`. Set
+`rolesClaimKey` in Change Tracker to the full claim key, for example
+`https://your-domain.com/roles`.
 
 **Keycloak**: Role claims are typically available under `realm_access.roles` or
 `resource_access.<client-id>.roles` in the access token, but the UserInfo endpoint may not include
@@ -102,7 +105,7 @@ such as Postman, and verify that the roles claim is present with the expected va
 
 ## Configure OIDC in Change Tracker
 
-All OIDC settings live under the `security:oauth:oidc` section of the Hub's
+All OIDC settings are defined under the `security:oauth:oidc` section of the Hub's
 `appsettings.Production.json` configuration file.
 
 ### Configuration keys
@@ -127,7 +130,7 @@ All OIDC settings live under the `security:oauth:oidc` section of the Hub's
 Run the Maintenance App with `--updateAppSettings` and `--targetEnvironment Production` to write
 the values directly to `appsettings.Production.json`:
 
-```
+```bat
 NNT.Hub.Service.Maintenance.App.exe --updateAppSettings --targetEnvironment Production ^
   --oidc-enabled true ^
   --oidc-client-id "<your-client-id>" ^
@@ -335,18 +338,12 @@ To resolve: update the user's `preferred_username` in the IdP to a different val
 If the IdP returns a `preferred_username` that matches an existing Change Tracker account that you
 created locally (not via OIDC), Change Tracker rejects the login.
 
-To resolve, update the existing local account's email address to match the email returned by the
-IdP. Change Tracker will then recognise the account by email address on the next OIDC login and
-link the OIDC identity to it, rather than attempting to create a duplicate.
-
-**Step 1 –** Log in to Change Tracker as an administrator.
-
-**Step 2 –** Go to **Administration** > **Users**.
-
-**Step 3 –** Find the existing account and update its email address to match exactly what the IdP
-returns.
-
-The user can then log in via OIDC successfully.
+To resolve: update the existing local account's email address to match the email returned by the
+IdP. Change Tracker then recognizes the account by email address on the next OIDC login and links
+the OIDC identity to it, rather than attempting to create a duplicate. To update the email address,
+log in as an administrator, go to **Administration** > **Users**, find the existing account, and
+update its email address to match exactly what the IdP returns. The user can then log in via OIDC
+successfully.
 
 ---
 
@@ -400,7 +397,7 @@ The following items aren't supported in the current release:
 - Verify `enabled` is set to `"true"` under `security:oauth:oidc` in
   `appsettings.Production.json`.
 - Confirm the Hub service has been restarted after the configuration change.
-- OIDC SSO isn't available in SaaS deployments. Verify you're running an on-premises Hub.
+- OIDC SSO is unavailable in SaaS deployments; confirm you're running an on-premises Hub.
 
 **Login redirects to the IdP but fails to return**
 

--- a/docs/changetracker/8.2/admin/settingstab/systemsettings/oidcsso.md
+++ b/docs/changetracker/8.2/admin/settingstab/systemsettings/oidcsso.md
@@ -11,8 +11,8 @@ Netwrix Change Tracker supports single sign-on (SSO) through any standards-compl
 Directory Federation Services (ADFS), OneLogin, Okta, Auth0, and others.
 
 When OIDC is enabled, the login page displays an SSO button that redirects users to the IdP for
-authentication. After successful authentication, the IdP redirects back to the Hub and the user is
-logged in automatically. Standard username/password login remains available alongside it.
+authentication. After successful authentication, the IdP redirects back to the Hub, which logs the
+user in automatically. Standard username/password login remains available alongside it.
 
 On a user's first login, Change Tracker automatically creates a local account — no
 pre-registration is required. On subsequent logins, the user's roles are updated to reflect any
@@ -39,7 +39,7 @@ Collect the following from your identity provider before configuring Change Trac
 :::note
 Most OIDC-compliant IdPs publish a discovery document at
 `https://<your-idp>/.well-known/openid-configuration` that lists all endpoint URLs. Change Tracker
-does not use this document automatically — endpoint URLs must be supplied individually — but it can
+doesn't use this document automatically — endpoint URLs must be supplied individually — but it can
 save time locating them manually.
 :::
 
@@ -188,7 +188,7 @@ All values — including booleans — are strings in the configuration file (not
 
 ## The rolesClaimKey setting
 
-Role or group membership is not a standard OIDC claim — there is no single agreed-upon name for
+Role or group membership isn't a standard OIDC claim — there is no single agreed-upon name for
 it, and different identity providers use different keys. The `rolesClaimKey` setting tells Change
 Tracker which claim key to read when resolving a user's role assignments.
 
@@ -240,12 +240,14 @@ resolves each role to a Change Tracker role using this sequence:
    used.
 2. If no mapping exists but the IdP role name exactly matches a known Change Tracker role name, it
    is used directly.
-3. If neither condition is met, the role is discarded and a warning is written to the Hub log.
+3. If neither condition is met, Change Tracker discards the role and writes a warning to the Hub
+   log.
 
-If no valid roles remain after this process, the user is assigned the default `user` role.
+If no valid roles remain after this process, Change Tracker assigns the user the default `user`
+role.
 
-Role assignments are re-evaluated on every login. Role changes made in the IdP take effect the
-next time the user logs in to Change Tracker.
+Change Tracker re-evaluates role assignments on every login. Role changes made in the IdP take
+effect the next time the user logs in to Change Tracker.
 
 ### Change Tracker roles
 
@@ -269,8 +271,8 @@ Role mapping is needed when your IdP uses role or group names that don't match C
 names. For example, if your Active Directory group is named `CT-Administrators` but you want those
 users to get the Change Tracker `admin` role, define a mapping.
 
-Mappings are stored as key-value pairs in **System Settings**. Each mapping uses the key format
-`oidc:rolemap:<IdP-role-name>` with the value set to the target Change Tracker role name.
+Change Tracker stores mappings as key-value pairs in **System Settings**. Each mapping uses the key
+format `oidc:rolemap:<IdP-role-name>`, with the value set to the target Change Tracker role name.
 
 **Step 1 –** In Change Tracker, go to **Administration** > **System Settings**.
 
@@ -324,14 +326,14 @@ situations.
 **Conflict with a system account**
 
 If the IdP returns a `preferred_username` that matches a reserved Change Tracker system account
-name (such as `admin` or `agent`), the login is rejected.
+name (such as `admin` or `agent`), Change Tracker rejects the login.
 
 To resolve: update the user's `preferred_username` in the IdP to a different value.
 
 **Conflict with an existing local account**
 
-If the IdP returns a `preferred_username` that matches an existing Change Tracker account that was
-created locally (not via OIDC), the login is rejected.
+If the IdP returns a `preferred_username` that matches an existing Change Tracker account that you
+created locally (not via OIDC), Change Tracker rejects the login.
 
 To resolve, update the existing local account's email address to match the email returned by the
 IdP. Change Tracker will then recognise the account by email address on the next OIDC login and
@@ -364,12 +366,12 @@ IdP session in the browser.
 
 This is intentional behavior for a security monitoring product: Change Tracker is often deployed
 on shared workstations where multiple users may use the same browser. Without forced
-re-authentication, a second user could be silently authenticated as the previous user.
+re-authentication, the IdP could silently authenticate a second user as the previous user.
 
 ### Multi-factor authentication
 
 Change Tracker respects MFA enforced by the IdP. If your IdP requires MFA as part of the
-authentication flow, users are prompted for their second factor before being redirected back to
+authentication flow, the IdP prompts users for their second factor before redirecting them back to
 Change Tracker. MFA enforcement is the responsibility of the IdP — Change Tracker doesn't enforce
 its own MFA for OIDC-authenticated users.
 
@@ -380,14 +382,14 @@ Tracker reflects the MFA status in the user's session. No additional configurati
 
 ## Limitations
 
-The following items are not supported in the current release:
+The following items aren't supported in the current release:
 
 - **Automatic OIDC endpoint discovery**: Endpoint URLs must be supplied individually. Automatic
-  discovery from a `.well-known/openid-configuration` URL is not supported.
+  discovery from a `.well-known/openid-configuration` URL isn't supported.
 - **Multiple simultaneous OIDC providers**: Only one OIDC provider can be configured at a time.
 - **Group-to-device group mapping**: Role mapping assigns Change Tracker roles only. Mapping IdP
-  groups to Change Tracker device access groups is not supported.
-- **SAML**: SAML-based SSO is not supported.
+  groups to Change Tracker device access groups isn't supported.
+- **SAML**: SAML-based SSO isn't supported.
 
 ---
 
@@ -431,7 +433,7 @@ The following items are not supported in the current release:
   address in Change Tracker to match what the IdP returns — see
   [Username conflicts](#username-conflicts).
 
-**Roles are not updating after being changed in the IdP**
+**Roles aren't updating after being changed in the IdP**
 
 - Roles are re-synced on every login. The user must log out and log back in via OIDC for role
   changes to take effect.

--- a/docs/changetracker/8.2/admin/settingstab/systemsettings/oidcsso.md
+++ b/docs/changetracker/8.2/admin/settingstab/systemsettings/oidcsso.md
@@ -1,69 +1,165 @@
 ---
 title: "Single Sign-On (OIDC)"
-description: "Configure generic OpenID Connect (OIDC) single sign-on for the ChangeTracker Hub on-premises deployment"
+description: "Configure generic OpenID Connect (OIDC) single sign-on for the Change Tracker Hub on-premises deployment"
 sidebar_position: 20
 ---
 
 # Single Sign-On (OIDC)
 
 Netwrix Change Tracker supports single sign-on (SSO) through any standards-compliant OpenID Connect
-(OIDC) identity provider (IdP). When OIDC is enabled, the login page displays an SSO button that
-redirects users to the IdP for authentication. After successful authentication, the IdP redirects
-back to the Hub and the user is logged in automatically.
+(OIDC) identity provider (IdP). Compatible providers include Keycloak, PingFederate, Active
+Directory Federation Services (ADFS), OneLogin, Okta, Auth0, and others.
 
-OIDC SSO supports automatic role assignment. Roles returned by the IdP in the userinfo response are
-mapped to ChangeTracker roles, either directly (if the IdP role names match ChangeTracker role
-names) or through configurable role mappings.
+When OIDC is enabled, the login page displays an SSO button that redirects users to the IdP for
+authentication. After successful authentication, the IdP redirects back to the Hub and the user is
+logged in automatically. Standard username/password login remains available alongside it.
+
+On a user's first login, Change Tracker automatically creates a local account — no
+pre-registration is required. On subsequent logins, the user's roles are updated to reflect any
+changes made in the IdP since their last login.
 
 :::note
-OIDC SSO is available for **on-premises deployments only**. SaaS deployments use Auth0 and don't
-require this configuration.
+OIDC SSO is available for **on-premises deployments only**. SaaS deployments use a separate
+authentication pathway managed by Netwrix.
 :::
 
-## Prerequisites
+## Before you begin
 
-- A registered application (client) in the OIDC identity provider with:
-  - **Client ID** and **Client Secret** (authorization code flow)
-  - **Redirect / callback URI** set to `https://<hub-host>:<port>/auth/oidc`
-  - Scopes: `openid`, `profile`, and `email` at minimum
-- The following endpoint URLs from the IdP:
-  - Authorization endpoint
-  - Token endpoint
-  - Userinfo endpoint
+Collect the following from your identity provider before configuring Change Tracker:
 
-:::info
-Change Tracker doesn't use OIDC Discovery (`.well-known/openid-configuration`). You must provide
-each endpoint URL individually.
+| Item | Description | Where to find it |
+|---|---|---|
+| **Client ID** | The unique identifier your IdP assigns to the Change Tracker application registration | IdP application / client settings |
+| **Client Secret** | A shared secret used to exchange an authorization code for tokens | IdP application / client settings |
+| **Authorization endpoint URL** | The URL users are redirected to for authentication | IdP documentation or discovery document |
+| **Token endpoint URL** | The URL Change Tracker calls to exchange an authorization code for tokens | IdP documentation or discovery document |
+| **UserInfo endpoint URL** | The URL Change Tracker calls to retrieve user profile claims | IdP documentation or discovery document |
+| **Roles claim key** | The claim key in the token or UserInfo response that contains role assignments | IdP documentation or token inspection — see [The rolesClaimKey setting](#the-rolesclaimkey-setting) |
+
+:::note
+Most OIDC-compliant IdPs publish a discovery document at
+`https://<your-idp>/.well-known/openid-configuration` that lists all endpoint URLs. Change Tracker
+does not use this document automatically — endpoint URLs must be supplied individually — but it can
+save time locating them manually.
 :::
 
-## Configuration
+## Set up your identity provider
 
-OIDC is configured in the Hub's `appsettings.Production.json` file, located at:
+Before Change Tracker can use your IdP for authentication, register Change Tracker as an
+application (also called a "client" or "relying party") in your IdP and configure it to return
+role information.
 
+### Register Change Tracker as an OIDC client
+
+Create a new application or client registration in your IdP with the following settings:
+
+- **Application type / grant type**: Confidential client using the **Authorization Code** flow
+- **Redirect URI (callback URL)**: `https://<your-hub-host>/api/auth/oidc`
+  - This must exactly match the address users use to reach Change Tracker Hub. If Hub is served on
+    a non-standard port, include it: `https://hub.example.com:5001/api/auth/oidc`
+- **Allowed scopes**: At minimum, `openid`, `profile`, and `email`. Add additional scopes if your
+  IdP requires them to include role or group claims in the token.
+
+After creating the registration, record the **Client ID** and generate a **Client Secret**.
+
+### Configure role claims
+
+Change Tracker reads role assignments from a configurable claim in the token or UserInfo response.
+Configure your IdP to include role or group membership in that response:
+
+1. Define the roles or groups in your IdP that correspond to Change Tracker roles (for example, an
+   Active Directory group `CT-Administrators` that maps to the Change Tracker `admin` role).
+2. Configure the IdP to include those roles in the token or UserInfo response.
+3. Note the exact claim key under which roles appear. This is the `rolesClaimKey` value — see
+   [The rolesClaimKey setting](#the-rolesclaimkey-setting).
+
+**Auth0**: Auth0 doesn't include role assignments in the OIDC token by default. Create a
+**Post-Login Action** in the Auth0 dashboard to inject the user's roles as a custom claim:
+
+```javascript
+exports.onExecutePostLogin = async (event, api) => {
+  const namespace = 'https://your-domain.com/';
+  api.idToken.setCustomClaim(namespace + 'roles', event.authorization.roles);
+};
 ```
-<Hub install directory>\Configs\appsettings.Production.json
-```
 
-All OIDC settings are nested under the `security:oauth:oidc` section.
+The namespace prefix can be any URL-shaped string. Set `rolesClaimKey` in Change Tracker to the
+full claim key, for example `https://your-domain.com/roles`.
+
+**Keycloak**: Role claims are typically available under `realm_access.roles` or
+`resource_access.<client-id>.roles` in the access token, but the UserInfo endpoint may not include
+them by default. Create a **Client Scope** with a User Client Role mapper or User Realm Role
+mapper configured to add roles to the UserInfo response, then add that scope to your client. Set
+`rolesClaimKey` to the claim name configured in the mapper.
+
+### Verify your IdP configuration
+
+Before configuring Change Tracker, confirm that your IdP returns the expected claims. Decode a
+sample ID token at [jwt.io](https://jwt.io) or inspect the UserInfo endpoint response with a tool
+such as Postman, and verify that the roles claim is present with the expected values.
+
+---
+
+## Configure OIDC in Change Tracker
+
+All OIDC settings live under the `security:oauth:oidc` section of the Hub's
+`appsettings.Production.json` configuration file.
 
 ### Configuration keys
 
 | Key | Required | Default | Description |
 |---|---|---|---|
-| `enabled` | Yes | `false` | Set to `true` to enable OIDC SSO. |
-| `authorizeUrl` | Yes | — | The IdP's authorization endpoint URL. |
-| `accessTokenUrl` | Yes | — | The IdP's token endpoint URL. |
-| `userProfileUrl` | Yes | — | The IdP's userinfo endpoint URL. |
-| `callbackUrl` | No | — | The Hub's OIDC callback URL. Defaults to `https://<hub-host>/auth/oidc`. Override this if the Hub is behind a reverse proxy or load balancer with a different external URL. |
+| `enabled` | Yes | `false` | Set to `true` to enable OIDC SSO and show the SSO button on the login page. |
 | `clientId` | Yes | — | The client (application) ID registered with the IdP. |
 | `clientSecret` | Yes | — | The client secret issued by the IdP. |
-| `scopes` | No | `openid profile email` | Space-separated list of OIDC scopes to request. |
-| `buttonLabel` | No | `Sign In with SSO` | The text displayed on the SSO button on the login page. |
-| `rolesClaimKey` | No | `roles` | The claim key in the userinfo response that contains role assignments. Use a namespaced URL for IdPs that require custom claim namespacing (e.g. `https://example.com/roles` for Auth0). |
+| `authorizeUrl` | Yes | — | The IdP's authorization endpoint URL. |
+| `accessTokenUrl` | Yes | — | The IdP's token endpoint URL. |
+| `userProfileUrl` | Yes | — | The IdP's UserInfo endpoint URL. |
+| `callbackUrl` | No | `https://<hub-host>/api/auth/oidc` | Override the callback URL registered with the IdP. Set this only if the Hub is behind a reverse proxy or load balancer with a different external URL. |
+| `scopes` | No | `openid profile email` | Space-separated list of OAuth2 scopes to request. |
+| `buttonLabel` | No | `Sign In with SSO` | The label on the SSO button. Set this to something meaningful to your users, such as `Sign In with Keycloak`. |
+| `rolesClaimKey` | No | `roles` | The claim key that contains role assignments. See [The rolesClaimKey setting](#the-rolesclaimkey-setting). |
 
-### Example configuration
+### Apply the configuration
 
-Add the following section to `appsettings.Production.json`:
+**Option 1 — Maintenance App (recommended)**
+
+Run the Maintenance App with `--updateAppSettings` and `--targetEnvironment Production` to write
+the values directly to `appsettings.Production.json`:
+
+```
+NNT.Hub.Service.Maintenance.App.exe --updateAppSettings --targetEnvironment Production ^
+  --oidc-enabled true ^
+  --oidc-client-id "<your-client-id>" ^
+  --oidc-client-secret "<your-client-secret>" ^
+  --oidc-authorize-url "https://idp.example.com/authorize" ^
+  --oidc-access-token-url "https://idp.example.com/token" ^
+  --oidc-user-profile-url "https://idp.example.com/userinfo" ^
+  --oidc-roles-claim-key "roles" ^
+  --oidc-button-label "Sign In with SSO"
+```
+
+Available flags:
+
+| Flag | Setting |
+|---|---|
+| `--oidc-enabled` | `enabled` |
+| `--oidc-client-id` | `clientId` |
+| `--oidc-client-secret` | `clientSecret` |
+| `--oidc-authorize-url` | `authorizeUrl` |
+| `--oidc-access-token-url` | `accessTokenUrl` |
+| `--oidc-user-profile-url` | `userProfileUrl` |
+| `--oidc-callback-url` | `callbackUrl` |
+| `--oidc-scopes` | `scopes` |
+| `--oidc-button-label` | `buttonLabel` |
+| `--oidc-roles-claim-key` | `rolesClaimKey` |
+
+After running the Maintenance App, restart the Hub service for the changes to take effect.
+
+**Option 2 — Edit appsettings.Production.json directly**
+
+Open `<Hub install directory>\Configs\appsettings.Production.json` and add or update the OIDC
+section:
 
 ```json
 {
@@ -71,13 +167,13 @@ Add the following section to `appsettings.Production.json`:
     "oauth": {
       "oidc": {
         "enabled": "true",
+        "clientId": "<your-client-id>",
+        "clientSecret": "<your-client-secret>",
         "authorizeUrl": "https://idp.example.com/authorize",
-        "accessTokenUrl": "https://idp.example.com/oauth/token",
+        "accessTokenUrl": "https://idp.example.com/token",
         "userProfileUrl": "https://idp.example.com/userinfo",
-        "clientId": "your-client-id",
-        "clientSecret": "your-client-secret",
         "scopes": "openid profile email",
-        "buttonLabel": "Sign In with Contoso",
+        "buttonLabel": "Sign In with SSO",
         "rolesClaimKey": "roles"
       }
     }
@@ -85,110 +181,258 @@ Add the following section to `appsettings.Production.json`:
 }
 ```
 
-### Applying the configuration
+All values — including booleans — are strings in the configuration file (note `"true"`, not
+`true`). Restart the Hub service after saving.
 
-After editing `appsettings.Production.json`, restart the Hub service for the changes to take
-effect.
+---
 
-Alternatively, use the Hub Maintenance App to configure OIDC from the command line:
+## The rolesClaimKey setting
 
-```powershell
-NNT.Hub.Service.Maintenance.App.exe `
-  --oidc-enabled true `
-  --oidc-authorize-url "https://idp.example.com/authorize" `
-  --oidc-access-token-url "https://idp.example.com/oauth/token" `
-  --oidc-user-profile-url "https://idp.example.com/userinfo" `
-  --oidc-client-id "your-client-id" `
-  --oidc-client-secret "your-client-secret" `
-  --oidc-scopes "openid profile email" `
-  --oidc-button-label "Sign In with Contoso" `
-  --oidc-roles-claim-key "roles"
+Role or group membership is not a standard OIDC claim — there is no single agreed-upon name for
+it, and different identity providers use different keys. The `rolesClaimKey` setting tells Change
+Tracker which claim key to read when resolving a user's role assignments.
+
+The default value is `roles`, which works when the IdP returns roles under that exact key.
+However:
+
+- Some IdPs use a different key entirely. For example, ADFS may publish group memberships under
+  `groups`, or a Keycloak mapper may use a custom name.
+- Some IdPs require custom claims to be namespaced with a URL prefix to prevent collisions. Auth0,
+  for example, requires the full namespaced string — such as `https://your-domain.com/roles` — as
+  the claim key.
+
+To find the correct value, inspect the raw token or UserInfo response from your IdP and locate the
+key that contains a list of role or group names. Use that exact string as `rolesClaimKey`.
+
+**Example — standard key:**
+
+```json
+{
+  "sub": "abc123",
+  "email": "alice@example.com",
+  "roles": ["CT-Administrators", "CT-Users"]
+}
 ```
 
-The Maintenance App writes the configuration directly to the Hub's settings and doesn't require
-a manual restart.
+`rolesClaimKey` should be `roles` (the default).
+
+**Example — namespaced key (Auth0):**
+
+```json
+{
+  "sub": "auth0|abc123",
+  "email": "alice@example.com",
+  "https://your-domain.com/roles": ["CT-Administrators"]
+}
+```
+
+`rolesClaimKey` must be set to `https://your-domain.com/roles` — the entire string including the
+URL prefix.
+
+---
 
 ## Role mapping
 
-When a user logs in through OIDC, the Hub reads the roles claim from the IdP's userinfo response
-and maps each role to a ChangeTracker role. The mapping follows this order:
+When a user logs in through OIDC, Change Tracker reads the roles claim from the IdP response and
+resolves each role to a Change Tracker role using this sequence:
 
-1. **Explicit mapping** — If a mapping exists in the Hub configuration database for the IdP role
-   name, the mapped ChangeTracker role is used.
-2. **Direct match** — If no explicit mapping exists but the IdP role name matches a known
-   ChangeTracker role exactly, it is used as-is.
-3. **Discarded** — If neither condition is met, the role is discarded with a warning in the Hub
-   log.
+1. If an explicit mapping is configured for the IdP role name, the mapped Change Tracker role is
+   used.
+2. If no mapping exists but the IdP role name exactly matches a known Change Tracker role name, it
+   is used directly.
+3. If neither condition is met, the role is discarded and a warning is written to the Hub log.
 
-If no valid roles remain after mapping, the user is assigned the default **User** role.
+If no valid roles remain after this process, the user is assigned the default `user` role.
 
-### ChangeTracker roles
+Role assignments are re-evaluated on every login. Role changes made in the IdP take effect the
+next time the user logs in to Change Tracker.
+
+### Change Tracker roles
 
 | Role | Description |
 |---|---|
-| `admin` | Full administrator access. |
-| `user` | Read-only access (default for unmapped users). |
-| `useradmin` | Can create and edit user accounts within their groups. |
-| `changeapprover` | Manages planned changes for their groups. |
-| `reportadmin` | Can view and edit reports across all users. |
-| `itsm` | ITSM synchronisation permissions. |
-| `licenseupdater` | Can update the product license. |
+| `admin` | Full administrative access. Can manage all devices, policies, users, and system settings. |
+| `user` | Standard read access (default for users with no valid roles). |
+| `useradmin` | Can create and manage user accounts within their groups. |
+| `changeapprover` | Can manage planned change windows for their groups. |
+| `reportadmin` | Can view and manage reports across all users. |
+| `itsm` | Provides permissions required for ITSM integration. |
+| `licenseupdater` | Can apply license updates. |
 
-### Configuring role mappings
-
-Role mappings are stored as key-value pairs in the Hub configuration database. Each mapping
-uses the key format `oidc:rolemap:<idp-role-name>` with the value set to the target
-ChangeTracker role.
-
-To add a role mapping, insert a record into the `HubConfigData` MongoDB collection:
-
-```javascript
-db.HubConfigData.insertOne({
-  _id: new ObjectId().toString(),
-  Key: "oidc:rolemap:Engineering",
-  Value: "user",
-  Encrypted: false
-})
-```
-
-This example maps the IdP role `Engineering` to the ChangeTracker `user` role.
-
-:::warning
-When writing to `HubConfigData` via `mongosh`, always set `_id` to `new ObjectId().toString()`.
-Using an auto-generated `ObjectId` causes the Hub to fail when deserialising the collection.
+:::note
+The `agent` role is reserved for device monitoring agents and can't be assigned via OIDC.
 :::
 
-## Multi-factor authentication detection
+### Configure role mappings
 
-If the IdP includes an `amr` (Authentication Methods References) claim in the ID token,
-Change Tracker detects whether multi-factor authentication (MFA) was used during the login.
-The user's session reflects the MFA status. No additional configuration is required.
+Role mapping is needed when your IdP uses role or group names that don't match Change Tracker role
+names. For example, if your Active Directory group is named `CT-Administrators` but you want those
+users to get the Change Tracker `admin` role, define a mapping.
+
+Mappings are stored as key-value pairs in **System Settings**. Each mapping uses the key format
+`oidc:rolemap:<IdP-role-name>` with the value set to the target Change Tracker role name.
+
+**Step 1 –** In Change Tracker, go to **Administration** > **System Settings**.
+
+**Step 2 –** Add a new entry for each mapping. For example:
+
+| Key | Value |
+|---|---|
+| `oidc:rolemap:CT-Administrators` | `admin` |
+| `oidc:rolemap:CT-Users` | `user` |
+| `oidc:rolemap:CT-ChangeApprovers` | `changeapprover` |
+| `oidc:rolemap:CT-UserAdmins` | `useradmin` |
+
+**Step 3 –** Save. Mappings take effect on the user's next login — no Hub restart is required.
+
+:::warning
+Key matching is case-sensitive. The IdP role name in the key must exactly match the value returned
+in the token. For example, `oidc:rolemap:CT-Administrators` matches only `CT-Administrators`, not
+`ct-administrators`.
+:::
+
+---
+
+## User provisioning
+
+### First login
+
+When an OIDC user logs in for the first time, Change Tracker automatically creates a local account
+for them. No pre-registration is required.
+
+The new account is created with:
+
+| Field | Source |
+|---|---|
+| **Username** | `preferred_username` claim; falls back to `email` if not present |
+| **Email** | `email` claim |
+| **Display name** | `name` claim; falls back to `given_name` |
+| **Roles** | Resolved from the IdP token via the role mapping process |
+
+### Subsequent logins
+
+On every login, Change Tracker re-reads the user's roles from the IdP and updates the local
+account if they have changed.
+
+---
+
+## Username conflicts
+
+Change Tracker checks for username conflicts at login time and rejects the login in the following
+situations.
+
+**Conflict with a system account**
+
+If the IdP returns a `preferred_username` that matches a reserved Change Tracker system account
+name (such as `admin` or `agent`), the login is rejected.
+
+To resolve: update the user's `preferred_username` in the IdP to a different value.
+
+**Conflict with an existing local account**
+
+If the IdP returns a `preferred_username` that matches an existing Change Tracker account that was
+created locally (not via OIDC), the login is rejected.
+
+To resolve, update the existing local account's email address to match the email returned by the
+IdP. Change Tracker will then recognise the account by email address on the next OIDC login and
+link the OIDC identity to it, rather than attempting to create a duplicate.
+
+**Step 1 –** Log in to Change Tracker as an administrator.
+
+**Step 2 –** Go to **Administration** > **Users**.
+
+**Step 3 –** Find the existing account and update its email address to match exactly what the IdP
+returns.
+
+The user can then log in via OIDC successfully.
+
+---
+
+## Login experience
+
+### SSO button
+
+When OIDC is enabled, a **Sign In with SSO** button (or the custom label configured via
+`buttonLabel`) appears on the Change Tracker login page alongside the standard username/password
+form. OIDC doesn't replace existing authentication methods.
+
+### Forced re-authentication
+
+Change Tracker always includes the `prompt=login` parameter in authorization requests to the IdP.
+This instructs the IdP to always prompt for credentials, even if the user already has an active
+IdP session in the browser.
+
+This is intentional behavior for a security monitoring product: Change Tracker is often deployed
+on shared workstations where multiple users may use the same browser. Without forced
+re-authentication, a second user could be silently authenticated as the previous user.
+
+### Multi-factor authentication
+
+Change Tracker respects MFA enforced by the IdP. If your IdP requires MFA as part of the
+authentication flow, users are prompted for their second factor before being redirected back to
+Change Tracker. MFA enforcement is the responsibility of the IdP — Change Tracker doesn't enforce
+its own MFA for OIDC-authenticated users.
+
+If the IdP includes an `amr` (Authentication Methods References) claim in the ID token, Change
+Tracker reflects the MFA status in the user's session. No additional configuration is required.
+
+---
+
+## Limitations
+
+The following items are not supported in the current release:
+
+- **Automatic OIDC endpoint discovery**: Endpoint URLs must be supplied individually. Automatic
+  discovery from a `.well-known/openid-configuration` URL is not supported.
+- **Multiple simultaneous OIDC providers**: Only one OIDC provider can be configured at a time.
+- **Group-to-device group mapping**: Role mapping assigns Change Tracker roles only. Mapping IdP
+  groups to Change Tracker device access groups is not supported.
+- **SAML**: SAML-based SSO is not supported.
+
+---
 
 ## Troubleshooting
 
 **SSO button doesn't appear on the login page**
 
-- Verify `enabled` is set to `true` under `security:oauth:oidc` in `appsettings.Production.json`.
-- Confirm the Hub has been restarted after the configuration change.
+- Verify `enabled` is set to `"true"` under `security:oauth:oidc` in
+  `appsettings.Production.json`.
+- Confirm the Hub service has been restarted after the configuration change.
 - OIDC SSO isn't available in SaaS deployments. Verify you're running an on-premises Hub.
 
 **Login redirects to the IdP but fails to return**
 
-- Verify the callback URL is correctly registered in the IdP as `https://<hub-host>:<port>/auth/oidc`.
-- If the Hub is behind a reverse proxy, set the `callbackUrl` configuration key to the external URL.
+- Verify the callback URL registered in your IdP exactly matches
+  `https://<hub-host>/api/auth/oidc`. A mismatch in protocol, hostname, port, or path causes the
+  IdP to reject the redirect.
+- If the Hub is behind a reverse proxy, set the `callbackUrl` configuration key to the external
+  URL and ensure the IdP's registered redirect URI matches it.
 - Check the IdP's logs for error details.
 
 **User logs in successfully but has incorrect permissions**
 
 - Check the Hub's `rolling-log.txt` for warnings from `OidcRoleMappingService`. The log shows
   which IdP roles were received and whether they were mapped, matched directly, or discarded.
-- Verify the `rolesClaimKey` matches the claim key the IdP actually uses. Some IdPs (e.g. Auth0)
-  namespace custom claims with a URL prefix.
-- Add explicit role mappings for IdP roles that don't match ChangeTracker role names directly.
+- Verify the `rolesClaimKey` value exactly matches the claim key the IdP uses, including any URL
+  namespace prefix.
+- Confirm that the IdP is actually including role claims in its response. Decode a sample token at
+  [jwt.io](https://jwt.io) and verify the roles claim is present.
+- If using role mappings, verify the keys in System Settings are spelled correctly and match the
+  IdP role names exactly (case-sensitive).
 
-**Error page shown after login attempt**
+**Login fails with "username is reserved for a system account"**
 
-- The error description is displayed in the URL. Check for common issues:
-  - `unauthorized` — the IdP returned valid credentials but the user's email conflicts with an
-    existing local account or a protected system account.
-  - IdP-side errors (invalid scope, expired client secret) appear with the IdP's error description.
+- The user's `preferred_username` in the IdP matches a reserved Change Tracker account name.
+  Update it in the IdP.
+
+**Login fails with "username already in use by an existing Change Tracker account"**
+
+- An existing local Change Tracker account has the same username. Update that account's email
+  address in Change Tracker to match what the IdP returns — see
+  [Username conflicts](#username-conflicts).
+
+**Roles are not updating after being changed in the IdP**
+
+- Roles are re-synced on every login. The user must log out and log back in via OIDC for role
+  changes to take effect.
+- Verify that the updated roles are present in the IdP's token or UserInfo response.


### PR DESCRIPTION
## Summary

- Reverts `devicediscoveryregistration.md` (8.2) to match 8.1 content; supported OS lists now link to the Support Matrix instead of inlining; ESXi / vCenter cross-reference retained
- Adds new child page `customgroupnameprefix.md` documenting the `CustomGroupNamePrefix` agent registration gate (configuration, validation logic, behavior table, audit events, troubleshooting)
- Expands `oidcsso.md` with IdP setup instructions (including Auth0 and Keycloak notes), corrected callback URL path (`/api/auth/oidc`), `rolesClaimKey` detail, System Settings–based role mapping (replacing the previous MongoDB approach), user provisioning, username conflict resolution, login experience, and limitations

## Test plan

- [ ] Verify `devicediscoveryregistration` (8.2) renders correctly and matches 8.1 structure
- [ ] Verify `customgroupnameprefix` child page appears in sidebar under Device Discovery and Registration
- [ ] Verify cross-links between parent and child pages resolve correctly
- [ ] Verify `oidcsso` page renders all new sections without broken anchors or links

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>