### PR TITLE
fix(ci): broaden kb/ label skip in codeowner notification step

### DIFF
--- a/.github/workflows/claude-issue-labeler.yml
+++ b/.github/workflows/claude-issue-labeler.yml
@@ -115,9 +115,9 @@ jobs:
             exit 0
           fi
 
-          # Skip codeowner notification for KB PR review tracking issues
-          if echo "$LABELS" | grep -q "kb/review"; then
-            echo "Issue has kb/review label — skipping codeowner notification"
+          # Skip codeowner notification for KB Operations tracking issues (any kb/ label)
+          if echo "$LABELS" | grep -q "^kb/"; then
+            echo "Issue has kb/ label — skipping codeowner notification"
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

- The Step 4 (Notify codeowners) block in `claude-issue-labeler.yml` previously skipped codeowner notifications only when the exact `kb/review` label was present.
- This caused unwanted codeowner pings on KB Operations tracking issues carrying other `kb/` labels (e.g., `kb/published`, `kb/draft`, `kb/blocked`).
- The fix broadens the skip condition to match any label with a `kb/` prefix.

## Change

In `.github/workflows/claude-issue-labeler.yml`, Step 4 — Notify codeowners:

```diff
-          # Skip codeowner notification for KB PR review tracking issues
-          if echo "$LABELS" | grep -q "kb/review"; then
-            echo "Issue has kb/review label — skipping codeowner notification"
+          # Skip codeowner notification for KB Operations tracking issues (any kb/ label)
+          if echo "$LABELS" | grep -q "^kb/"; then
+            echo "Issue has kb/ label — skipping codeowner notification"
             exit 0
           fi
```

The Admin Support title check (`^Admin: PR review`) is unchanged.

## Context

Issues like netwrix/docs #1055 (labeled `kb/published`) were still triggering codeowner notifications after the original `kb/review`-only guard was added. Same pattern observed in data-export-staging #49 and netwrix/docs #1036.

## Testing

Verified the `grep` pattern locally before pushing:

| Label | Expected | Result |
|---|---|---|
| `kb/published` | MATCH (skip) | ✅ MATCH |
| `kb/draft` | MATCH (skip) | ✅ MATCH |
| `kb/review` | MATCH (skip) | ✅ MATCH |
| `kb/blocked` | MATCH (skip) | ✅ MATCH |
| `bug` | NO MATCH (notify) | ✅ NO MATCH |
| `documentation` | NO MATCH (notify) | ✅ NO MATCH |