### PR TITLE
SaaS product version filter returns zero results — Algolia index mismatch 

### DIFF
--- a/src/components/ProductMetaTags/index.js
+++ b/src/components/ProductMetaTags/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from '@docusaurus/Head';
 import { useLocation } from '@docusaurus/router';
-import { createProductMap } from '@site/src/config/products.js';
+import { createProductMap, PRODUCTS } from '@site/src/config/products.js';
 
 const productMap = createProductMap();
 
@@ -34,14 +34,24 @@ export default function ProductMetaTags() {
       let versionFromUrl = pathParts[productIndex + 1];
       // Check if it looks like a version (e.g., "13_5", "2_0", "v2", "saas", etc.)
       // Regex now accepts underscores in version numbers
-      if (/^(v?\d+(_\d+)*|saas)$/i.test(versionFromUrl)) {
+      if (/^(v?\d+(_\d+)*|saas|current)$/i.test(versionFromUrl)) {
         versionFromUrl = versionFromUrl.replace(/^v/i, ''); // Remove 'v' prefix if present
         if (versionFromUrl.toLowerCase() === 'saas') {
           productVersion = 'saas';
+        } else if (versionFromUrl.toLowerCase() === 'current') {
+          productVersion = 'current';
         } else {
           // Convert underscores back to periods for the meta tag content
           productVersion = versionFromUrl.replace(/_/g, '.');
         }
+      }
+    }
+
+    // Fallback for single-version "current" products with no version segment in the URL
+    if (!productVersion) {
+      const product = PRODUCTS.find(p => productName === p.name);
+      if (product && product.versions.length === 1 && product.versions[0].version === 'current') {
+        productVersion = 'current';
       }
     }
   }

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -307,7 +307,7 @@ function getVersionsForProducts(selectedProducts) {
     selectedProducts.forEach(productName => {
         const product = PRODUCTS.find(p => p.name === productName);
         if (product && product.versions) {
-            product.versions.forEach(v => versionsSet.add(v.label));
+            product.versions.forEach(v => versionsSet.add(v.version));
         }
     });
     return Array.from(versionsSet).sort();

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -41,7 +41,7 @@ function getVersionsForProducts(selectedProducts) {
     const source = isAll ? PRODUCTS : selectedProducts.map(name => PRODUCTS.find(p => p.name === name)).filter(Boolean);
     source.forEach(product => {
         if (product.versions) {
-            product.versions.forEach(v => versionsSet.add(v.label));
+            product.versions.forEach(v => versionsSet.add(v.version));
         }
     });
     return Array.from(versionsSet).sort();


### PR DESCRIPTION
### Summary

  - **ProductMetaTags** (`src/components/ProductMetaTags/index.js`): Now emits `product-version: "current"` instead of an empty string for SaaS/single-version products
    - Added `current` to the URL path segment regex (handles products with `/current/` in URL like Identity Manager, Password Secure)
    - Added fallback for single-version products with no version segment in the URL (1Secure, Endpoint Protector, PolicyPak, etc.)
  - **SearchBar** (`src/theme/SearchBar/index.js`): `getVersionsForProducts` now uses `v.version` instead of `v.label` for filter values
  - **SearchPage** (`src/theme/SearchPage/index.js`): Same `v.version` fix as SearchBar

  ### Root Cause

  SaaS products use `version: 'current', label: 'Current'` in `src/config/products.js`. Two things were wrong:

  1. `ProductMetaTags` only recognized numeric versions and `saas` in its regex — `current` was not matched, so these pages were indexed with `product_version: ""` (empty string)
  2. The search version filter built facet values from `v.label` (`'Current'`), querying `product_version:Current` — which matched nothing in the index

  ### Testing

  1. **Local build** — `npm run build` completed successfully, no errors
  2. **Meta tag verification** — Confirmed via DevTools Elements panel:
     - `/docs/1secure/` → `<meta name="product-version" content="current">` (was `content=""`)
     - `/docs/auditor/10_8/` → `<meta name="product-version" content="10.8">` (no regression)
  3. **Version dropdown** — Confirmed correct version values appear:
     - Password Secure → `9.2`, `9.3`, `current`
     - 1Secure → `current`
     - Privilege Secure for Discovery → `2.22` (numeric unchanged)
  4. **Numeric version filter** — Privilege Secure for Discovery filtered to `2.22` returns results as expected (no regression)
  5. **Algolia request payload** — Confirmed via DevTools Network tab that the facet filter sends `product_version:current` (not `product_version:Current`)
  6. **Expected: "current" filter returns zero results until Algolia recrawl** — The live index still has `product_version: ""` for these pages; after deploy + scheduled Algolia crawl, `current` will be indexed and the filter will return results

  ### Post-Deploy
  
  After this merges and deploys, the Algolia crawler will re-index the site on its next scheduled run. If faster resolution is needed, a manual re-crawl can be triggered from the Algolia Crawler dashboard.

Closes #1046