### PR TITLE
fix: correct Activity Monitor integration page for CT 8.2

### DIFF
--- a/docs/changetracker/8.2/integration/netwrixproducts/activitymonitor.md
+++ b/docs/changetracker/8.2/integration/netwrixproducts/activitymonitor.md
@@ -7,18 +7,18 @@ sidebar_position: 20
 # Netwrix Activity Monitor Integration
 
 Netwrix Change Tracker can use the **Netwrix Activity Monitor** (via its `SBTService` Windows
-service, displayed as **Netwrix Windows File Monitoring Service** in `services.msc`) as an
+service, which appears as **Netwrix Windows File Monitoring Service** in `services.msc`) as an
 alternative data source for file change attribution on Windows. When you enable this integration,
 the Gen 7 Agent reads user and process information from log files that Activity Monitor produces
 instead of relying on the built-in kernel mini-filter driver (`NNTInfo.sys`).
 
-This is useful in environments where the system cannot load the kernel driver, for example systems
+This is useful in environments where the system can't load the kernel driver, for example systems
 with strict kernel security policies (Secure Boot / HVCI), certain hypervisor configurations, or
 where you already deploy Activity Monitor and want a single audit trail for file activity.
 
 :::note
 This feature applies to **Windows only** and to **file integrity monitoring (FIM) with live
-tracking**. This feature does not affect Linux devices.
+tracking**. This feature doesn't affect Linux devices.
 :::
 
 ## Prerequisites
@@ -46,7 +46,7 @@ When you enable the integration:
    data to the event before sending it to the Hub.
 
 The agent and the kernel driver are mutually exclusive as attribution sources. If you configure
-both, Activity Monitor takes precedence and the agent does not load the kernel driver.
+both, Activity Monitor takes precedence and the agent doesn't load the kernel driver.
 
 ## Configuration
 
@@ -80,7 +80,7 @@ can do so to make the configuration clearer.
 :::
 
 **Step 1 –** Open `Gen7Agent.App.NetCore.dll.config` in a text editor with administrator
-privileges and add the keys above with the appropriate values for your environment.
+privileges and add the preceding keys with the appropriate values for your environment.
 
 **Step 2 –** Restart the Gen 7 Agent service for the changes to take effect:
 
@@ -103,8 +103,8 @@ file. The agent discovers the correct directory by reading the registry key:
 HKLM\SYSTEM\CurrentControlSet\Services\SBTLogging\Parameters\ConfigPath
 ```
 
-The INI file instructs Activity Monitor to log file events to the directory specified by
-`activityMonitorChangeSourceDirectory`, using the path filters that the Hub's FIM policy
+The INI file instructs Activity Monitor to log file events to the directory that
+`activityMonitorChangeSourceDirectory` specifies, using the path filters that the Hub's FIM policy
 defines. You don't need to manually edit this file, as the agent regenerates it each
 time the FIM policy changes.
 
@@ -113,7 +113,7 @@ section in the INI file.
 
 :::note
 The `SBTFileMon.ChangeTracker.ini` file is separate from Activity Monitor's main
-`SBTFileMon.ini`. This file does not change other monitoring sections in the main INI.
+`SBTFileMon.ini`. This file doesn't change other monitoring sections in the main INI.
 :::
 
 ## Troubleshooting
@@ -125,7 +125,7 @@ The `SBTFileMon.ChangeTracker.ini` file is separate from Activity Monitor's main
 - Verify the `activityMonitorChangeSourceDirectory` path exists and contains files matching
   the pattern `*_CT_Log_{YYYYMMDD}.json`.
 - Check the agent's `rolling-log.txt` for warnings from `ActivityMonitorChangeSource`. Look
-  for messages indicating the directory or log file cannot be found.
+  for messages indicating the directory or log file can't be found.
 
 **INI file not generated**
 

--- a/docs/changetracker/8.2/integration/netwrixproducts/activitymonitor.md
+++ b/docs/changetracker/8.2/integration/netwrixproducts/activitymonitor.md
@@ -12,7 +12,7 @@ alternative data source for file change attribution on Windows. When you enable 
 the Gen 7 Agent reads user and process information from log files that Activity Monitor produces
 instead of relying on the built-in kernel mini-filter driver (`NNTInfo.sys`).
 
-This is useful in environments where the system can't load the kernel driver, for example systems
+This is useful in environments where the kernel driver can't load, for example systems
 with strict kernel security policies (Secure Boot / HVCI), certain hypervisor configurations, or
 where you already deploy Activity Monitor and want a single audit trail for file activity.
 
@@ -63,6 +63,7 @@ Add or update the following keys in the `<appSettings>` section:
 | `useActivityMonitorChangeSource` | `true` | Enables Activity Monitor as the attribution source. Set to `false` (or omit) to use the default kernel driver. |
 | `activityMonitorChangeSourceDirectory` | Path to log directory | The folder where Activity Monitor writes its log files. The default is `C:\ProgramData\Netwrix\Activity Monitor\Agent\ActivityLogs`. Must match the `LOG_FILE` directory in the [auto-generated INI file](#auto-generated-ini-file). |
 | `changeSourceFileFormat` | `json` (default) or `tsv` | Log file format that Activity Monitor writes. Leave as `json` unless you explicitly configure Activity Monitor for TSV output. |
+| `loaddriver` | `true` (default) or `false` | Controls whether the agent loads the kernel mini-filter driver (`NNTInfo.sys`) for file change attribution. Mutually exclusive with `useActivityMonitorChangeSource`. When both are `true`, Activity Monitor takes precedence and the agent doesn't load the driver. |
 
 Example `<appSettings>` entries:
 
@@ -88,7 +89,7 @@ privileges and add the preceding keys with the appropriate values for your envir
 Restart-Service Gen7AgentCore
 ```
 
-**Step 3 –** Confirm that the Hub applies a FIM live-tracking policy to the device. The
+**Step 3 –** Confirm that the device has a FIM live-tracking policy assigned from the Hub. The
 agent generates the Activity Monitor INI file the next time it receives a device configuration
 update. To trigger this immediately, navigate to **Settings > Agents and Devices**, select the
 device, and click **Refresh Configuration**.
@@ -113,7 +114,7 @@ section in the INI file.
 
 :::note
 The `SBTFileMon.ChangeTracker.ini` file is separate from Activity Monitor's main
-`SBTFileMon.ini`. This file doesn't change other monitoring sections in the main INI.
+`SBTFileMon.ini`. The agent doesn't modify other monitoring sections in `SBTFileMon.ini`.
 :::
 
 ## Troubleshooting
@@ -138,7 +139,7 @@ The `SBTFileMon.ChangeTracker.ini` file is separate from Activity Monitor's main
 
 **Both driver and Activity Monitor appear active**
 
-- If you set both `loaddriver` and `useActivityMonitorChangeSource` to `true` in
-  `Gen7Agent.App.NetCore.dll.config`, the agent automatically uses Activity Monitor and
-  disables the kernel driver. You can optionally set `loaddriver` to `false` to make the
-  configuration explicit.
+- If you set both `loaddriver` and `useActivityMonitorChangeSource` to `true` in the
+  `<appSettings>` section of `Gen7Agent.App.NetCore.dll.config` (see [Configuration](#configuration)),
+  the agent automatically uses Activity Monitor and disables the kernel driver. You can
+  optionally set `loaddriver` to `false` to make the configuration explicit.

--- a/docs/changetracker/8.2/integration/netwrixproducts/activitymonitor.md
+++ b/docs/changetracker/8.2/integration/netwrixproducts/activitymonitor.md
@@ -7,17 +7,18 @@ sidebar_position: 20
 # Netwrix Activity Monitor Integration
 
 Netwrix Change Tracker can use the **Netwrix Activity Monitor** (via its `SBTService` Windows
-service) as an alternative data source for file change attribution on Windows. When this
-integration is enabled, the Gen 7 Agent reads user and process information from log files written
-by Activity Monitor instead of relying on the built-in kernel mini-filter driver (`NNTInfo.sys`).
+service, displayed as **Netwrix Windows File Monitoring Service** in `services.msc`) as an
+alternative data source for file change attribution on Windows. When you enable this integration,
+the Gen 7 Agent reads user and process information from log files that Activity Monitor produces
+instead of relying on the built-in kernel mini-filter driver (`NNTInfo.sys`).
 
-This is useful in environments where the kernel driver cannot be loaded, for example systems
+This is useful in environments where the system cannot load the kernel driver, for example systems
 with strict kernel security policies (Secure Boot / HVCI), certain hypervisor configurations, or
-where Activity Monitor is already deployed and you want a single audit trail for file activity.
+where you already deploy Activity Monitor and want a single audit trail for file activity.
 
 :::note
 This feature applies to **Windows only** and to **file integrity monitoring (FIM) with live
-tracking**. Linux devices are unaffected.
+tracking**. This feature does not affect Linux devices.
 :::
 
 ## Prerequisites
@@ -31,28 +32,28 @@ tracking**. Linux devices are unaffected.
 
 ## How it works
 
-When the integration is enabled:
+When you enable the integration:
 
 1. The Gen 7 Agent automatically generates a configuration file (`SBTFileMon.ChangeTracker.ini`)
    in the Activity Monitor configuration directory whenever it receives a FIM policy from the Hub.
    This file instructs Activity Monitor which paths to monitor and in what format to log events.
 2. Activity Monitor's `SBTService` writes file change events, including the user account and
-   process name responsible, to a daily JSON log file on the local disk. Files are named
-   `{hostname}_CT_Log_{YYYYMMDD}.json`.
+   process name responsible, to a daily JSON log file on the local disk. The service names these
+   files `{hostname}_CT_Log_{YYYYMMDD}.json`.
 3. The Gen 7 Agent continuously reads these log files and caches attribution data keyed by file
    path.
-4. When a file change is detected by the agent's file system watcher, the cached attribution data
-   is attached to the event before it is sent to the Hub.
+4. When the agent's file system watcher detects a file change, it attaches the cached attribution
+   data to the event before sending it to the Hub.
 
-The agent and the kernel driver are mutually exclusive as attribution sources. If both are
-configured, Activity Monitor takes precedence and the kernel driver is not loaded.
+The agent and the kernel driver are mutually exclusive as attribution sources. If you configure
+both, Activity Monitor takes precedence and the agent does not load the kernel driver.
 
 ## Configuration
 
-Activity Monitor integration is configured in the Gen 7 Agent's `app.config` file, located at:
+Configure Activity Monitor integration in the Gen 7 Agent's configuration file, located at:
 
 ```
-%PROGRAMDATA%\NNT\gen7agent.service\app.config
+C:\Program Files\NNT Change Tracker Suite\Gen7Agent (NetCore)\Gen7Agent.App.NetCore.dll.config
 ```
 
 Add or update the following keys in the `<appSettings>` section:
@@ -60,34 +61,34 @@ Add or update the following keys in the `<appSettings>` section:
 | Key | Value | Description |
 |---|---|---|
 | `useActivityMonitorChangeSource` | `true` | Enables Activity Monitor as the attribution source. Set to `false` (or omit) to use the default kernel driver. |
-| `activityMonitorChangeSourceDirectory` | Path to log directory | The folder where Activity Monitor writes its `_CT_Log_` JSON files. Must match the `LOG_FILE` directory in the generated INI (see below). |
-| `changeSourceFileFormat` | `json` (default) or `tsv` | Log file format written by Activity Monitor. Leave as `json` unless Activity Monitor is explicitly configured for TSV output. |
+| `activityMonitorChangeSourceDirectory` | Path to log directory | The folder where Activity Monitor writes its log files. The default is `C:\ProgramData\Netwrix\Activity Monitor\Agent\ActivityLogs`. Must match the `LOG_FILE` directory in the [auto-generated INI file](#auto-generated-ini-file). |
+| `changeSourceFileFormat` | `json` (default) or `tsv` | Log file format that Activity Monitor writes. Leave as `json` unless you explicitly configure Activity Monitor for TSV output. |
 
 Example `<appSettings>` entries:
 
 ```xml
 <add key="useActivityMonitorChangeSource" value="true" />
-<add key="activityMonitorChangeSourceDirectory" value="C:\ProgramData\Netwrix\ActivityMonitor\CTLogs" />
+<add key="activityMonitorChangeSourceDirectory" value="C:\ProgramData\Netwrix\Activity Monitor\Agent\ActivityLogs" />
 <add key="changeSourceFileFormat" value="json" />
 ```
 
-:::warning
-Do not set both `useActivityMonitorChangeSource=true` and `loaddriver=true`. These are mutually
-exclusive. If both are present, Activity Monitor will be used and the kernel driver will be
-disabled automatically, but it is best practice to explicitly set `loaddriver=false` to avoid
-ambiguity.
+:::note
+The `useActivityMonitorChangeSource` and `loaddriver` settings are mutually exclusive as
+attribution sources. If you set both to `true`, the agent automatically uses Activity Monitor
+and disables the kernel driver. You don't need to explicitly set `loaddriver=false`, but you
+can do so to make the configuration clearer.
 :::
 
-**Step 1 –** Open `app.config` in a text editor with administrator privileges and add the keys
-above with the appropriate values for your environment.
+**Step 1 –** Open `Gen7Agent.App.NetCore.dll.config` in a text editor with administrator
+privileges and add the keys above with the appropriate values for your environment.
 
 **Step 2 –** Restart the Gen 7 Agent service for the changes to take effect:
 
 ```powershell
-Restart-Service gen7agent.service
+Restart-Service Gen7AgentCore
 ```
 
-**Step 3 –** Confirm that a FIM live-tracking policy is applied to the device from the Hub. The
+**Step 3 –** Confirm that the Hub applies a FIM live-tracking policy to the device. The
 agent generates the Activity Monitor INI file the next time it receives a device configuration
 update. To trigger this immediately, navigate to **Settings > Agents and Devices**, select the
 device, and click **Refresh Configuration**.
@@ -103,23 +104,24 @@ HKLM\SYSTEM\CurrentControlSet\Services\SBTLogging\Parameters\ConfigPath
 ```
 
 The INI file instructs Activity Monitor to log file events to the directory specified by
-`activityMonitorChangeSourceDirectory`, using the path filters derived from the FIM policy
-configured in the Hub. You do not need to edit this file manually, as it is regenerated each
+`activityMonitorChangeSourceDirectory`, using the path filters that the Hub's FIM policy
+defines. You don't need to manually edit this file, as the agent regenerates it each
 time the FIM policy changes.
 
-If the FIM policy is removed from a device, the agent disables the corresponding section in
-the INI file automatically.
+If you remove the FIM policy from a device, the agent automatically disables the corresponding
+section in the INI file.
 
 :::note
 The `SBTFileMon.ChangeTracker.ini` file is separate from Activity Monitor's main
-`SBTFileMon.ini`. Other monitoring sections in the main INI are not affected.
+`SBTFileMon.ini`. This file does not change other monitoring sections in the main INI.
 :::
 
 ## Troubleshooting
 
 **No user attribution in events**
 
-- Confirm `SBTService` is running: `Get-Service SBTService`.
+- Confirm `SBTService` is running: `Get-Service SBTService`. This service appears as
+  **Netwrix Windows File Monitoring Service** in `services.msc`.
 - Verify the `activityMonitorChangeSourceDirectory` path exists and contains files matching
   the pattern `*_CT_Log_{YYYYMMDD}.json`.
 - Check the agent's `rolling-log.txt` for warnings from `ActivityMonitorChangeSource`. Look
@@ -129,12 +131,14 @@ The `SBTFileMon.ChangeTracker.ini` file is separate from Activity Monitor's main
 
 - Check that the registry key
   `HKLM\SYSTEM\CurrentControlSet\Services\SBTLogging\Parameters\ConfigPath` exists and
-  contains a valid path. This key is created by the Activity Monitor installer; if it is
+  contains a valid path. The Activity Monitor installer creates this key; if it is
   missing, Activity Monitor may not be installed correctly.
-- Confirm the FIM policy is assigned to the device in the Hub and that live tracking is
-  enabled in the policy template.
+- Confirm that the Hub assigns the FIM policy to the device and that the policy template
+  enables live tracking.
 
 **Both driver and Activity Monitor appear active**
 
-- Review `app.config` and ensure `loaddriver` is set to `false` or removed. The agent logs a
-  warning to `rolling-log.txt` if both settings are enabled simultaneously.
+- If you set both `loaddriver` and `useActivityMonitorChangeSource` to `true` in
+  `Gen7Agent.App.NetCore.dll.config`, the agent automatically uses Activity Monitor and
+  disables the kernel driver. You can optionally set `loaddriver` to `false` to make the
+  configuration explicit.


### PR DESCRIPTION
## Summary

- **Config file path**: corrected from `%PROGRAMDATA%\NNT\gen7agent.service\app.config` to `C:\Program Files\NNT Change Tracker Suite\Gen7Agent (NetCore)\Gen7Agent.App.NetCore.dll.config`
- **Service name**: corrected from `gen7agent.service` to `Gen7AgentCore`
- **Default log directory**: corrected from `C:\ProgramData\Netwrix\ActivityMonitor\CTLogs` to `C:\ProgramData\Netwrix\Activity Monitor\Agent\ActivityLogs`
- **Mutual exclusion behavior**: downgraded warning admonition — both `loaddriver` and `useActivityMonitorChangeSource` can be `true`; the agent handles it gracefully (Activity Monitor wins, driver disabled). Removed incorrect claim about a warning in `rolling-log.txt`
- **SBTService display name**: added that SBTService appears as "Netwrix Windows File Monitoring Service" in `services.msc` (intro + troubleshooting)
- **Writing quality**: converted passive voice to active voice throughout, replaced positional reference with named anchor, fixed misplaced modifier

## Test plan

- [ ] Verify the page renders correctly on the dev server
- [ ] Confirm the `#auto-generated-ini-file` anchor link works from the config table
- [ ] Cross-check config path, service name, and log directory against a live Change Tracker 8.2 installation

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>