### PR TITLE
docs(auditor): add KB crosslink and estimation tool to Access Reviews

### DIFF
--- a/docs/auditor/10.8/accessreviews/accessreviews.md
+++ b/docs/auditor/10.8/accessreviews/accessreviews.md
@@ -24,15 +24,15 @@ the following data sources:
 This workflow assumes you already have Netwrix Auditor installed with configured monitoring plans
 for a supported data source.
 
-**NOTE:** Access Reviews is a separately licensed product and is not included with Netwrix Auditor.
-Make sure that you have the Access Reviews license enabled in Auditor.
+**NOTE:** Access Reviews is a separately licensed product and isn't included with Netwrix Auditor.
+ensure that you have the Access Reviews license enabled in Auditor.
 
 See the [Licenses](/docs/auditor/10.8/admin/settings/licenses.md) topic for additional information.
 
 _Remember,_ there is one single Access Review license for all data sources that can send data to the
 application.
 
-Follow the steps to use Netwrix Auditor Access Reviews in conjunction with Auditor.
+To use Netwrix Auditor Access Reviews with Auditor, complete the following steps.
 
 **Step 1 –** Install Access Reviews on the same computer where Netwrix Auditor is installed. See the
 [Installation Overview](/docs/auditor/10.8/accessreviews/installation/overview.md) topic for prerequisites and
@@ -42,7 +42,7 @@ additional information.
 the Administrator role. See the [Administrator Overview](/docs/auditor/10.8/accessreviews/admin/overview.md) topic
 for configuration settings and enabling user access.
 
-**Step 3 –** Use the Access reviews configuration tool to setup the data flow from the Auditor
+**Step 3 –** Use the Access reviews configuration tool to set up the data flow from the Auditor
 database to the Access Reviews database. See the
 [Select Data Sources](/docs/auditor/10.8/accessreviews/installation/accessreviewsconfiguration.md) topic for additional information.
 
@@ -70,21 +70,21 @@ Netwrix Auditor Access Reviews is now configured and ready to use.
 
 Review the following considerations:
 
-1. Enabling State-in-Time data collection for your monitoring plans option is not required for the
+1. Enabling State-in-Time data collection for your monitoring plans option isn't required for the
    integration works properly.
-2. The data collected by Auditor is updated at least once a day.
-3. If a monitoring plan or a data source with enabled integration is deleted, all collected data
-   will be removed from the Access Reviews database.
-4. If there are errors in upload of data to the Access Reviews database, these errors are reflected
-   in the Netwrix Auditor Health Log and text log files; status of items and data sources in Auditor
-   is not affected by these errors.
+2. Auditor updates the collected data at least once a day.
+3. If you delete a monitoring plan or a data source with enabled integration, Auditor removes all
+   collected data from the Access Reviews database.
+4. If errors occur during the upload of data to the Access Reviews database, Auditor logs these
+   errors in the Netwrix Auditor Health Log and text log files; these errors don't affect the
+   status of items and data sources in Auditor.
 5. Permissions-related considerations:
 
     - For Windows File Servers, permission data for all items in this data source is sent to the
       Access Reviews application;
     - Only effective top-level permissions are sent (share+NTFS);
     - Permission data is sent per file server (entirely for each server);
-    - Transfer of permission data to the Access Reviews application is started when you enable the
+    - Transfer of permission data to the Access Reviews application starts when you enable the
       integration for a data source.
 
 6. For File Server Auditing (FSA) data sources, the default permission upload limit is **200,000**
@@ -116,7 +116,7 @@ Review the following considerations:
 
     ## Enable Console Users
 
-    Access Reviews Console users granted one of the available roles should be notified.
+    Notify Access Reviews Console users granted one of the available roles.
 
     **_RECOMMENDED:_** The notification should include:
 
@@ -139,7 +139,7 @@ Review the following considerations:
 
     ## Resource Ownership Configuration
 
-    Ownership of resources must be assigned in order to use the Access Reviews workflow:
+    You must assign ownership of resources to use the Access Reviews workflow:
 
     - Resource Ownership — Assign ownership for resources to be managed through the application. See
       the [Resource Owners Interface](/docs/auditor/10.8/accessreviews/resourceowners/interface/interface.md) topic for

--- a/docs/auditor/10.8/accessreviews/accessreviews.md
+++ b/docs/auditor/10.8/accessreviews/accessreviews.md
@@ -87,6 +87,15 @@ Review the following considerations:
     - Transfer of permission data to the Access Reviews application is started when you enable the
       integration for a data source.
 
+6. For File Server Auditing (FSA) data sources, the default permission upload limit is **200,000**
+   per data collection cycle, with a configurable maximum of **800,000**. Exceeding these limits
+   causes upload failures. Before enabling the integration for FSA plans, verify your permission
+   count using the
+   [AIC Resource Estimation Tool](https://releases.netwrix.com/products/auditor/10.8/auditor-aic-estimation-tool-tool-1.0.1.zip)
+   and ensure sufficient system resources. For details on FSA-specific limits, memory requirements,
+   and the estimation tool usage, see
+   [Managing Access Reviews Integration Limits for File Servers](/docs/kb/auditor/configuration-and-setup/file-server-auditing/managing-access-reviews-integration-limits-for-file-servers).
+
     ## Initial Configuration
 
     Next, configure the Access Reviews for your environment:


### PR DESCRIPTION
## Summary

- Added permission upload limits (200K default / 800K max) for FSA data sources to the **Considerations & Limitations** section of the Access Reviews page
- Added link to the KB article [Managing Access Reviews Integration Limits for File Servers](/docs/kb/auditor/configuration-and-setup/file-server-auditing/managing-access-reviews-integration-limits-for-file-servers)
- Added direct download link to the [AIC Resource Estimation Tool](https://releases.netwrix.com/products/auditor/10.8/auditor-aic-estimation-tool-tool-1.0.1.zip)

## Test plan

- [ ] Verify the KB crosslink resolves correctly on the dev build
- [ ] Verify the AIC Resource Estimation Tool download link works
- [ ] Confirm the new bullet renders properly in the numbered list

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>