### PR TITLE
docs(auditor): add Group.Read.All API permission to AFA Azure Files 10.9 [US 439213]

### DIFF
--- a/docs/auditor/10.9/configuration/azurefiles/overview.md
+++ b/docs/auditor/10.9/configuration/azurefiles/overview.md
@@ -12,7 +12,7 @@ It supports two types of monitored items for Azure Files:
  - **Azure Subscription**: monitoring [actions](https://docs.netwrix.com/docs/auditor/10_8/configuration/azurefiles/monitoredobjects) on all shares of all **storage accounts** of the specified **Azure Files subscription**
 
 
-**Note:** For all **"data storage accounts"** used in the points above, you must configure [Diaggnostic settings](https://docs.netwrix.com/docs/auditor/10_8/configuration/azurefiles/overview#diagnostic-settings)
+**Note:** For all **"data storage accounts"**, you must configure [Diaggnostic settings](https://docs.netwrix.com/docs/auditor/10_8/configuration/azurefiles/overview#diagnostic-settings)
 to save audit events on **"log storage account(s)"**. Ensure you have the necessary access ([API permissions](https://docs.netwrix.com/docs/auditor/10_8/configuration/azurefiles/overview#configure-api-permissions), [IAM Roles](https://docs.netwrix.com/docs/auditor/10_8/configuration/azurefiles/overview#assign-iam-roles-to-the-app)) for [application](https://docs.netwrix.com/docs/auditor/10_8/configuration/azurefiles/overview#azure-application-registration) to read these events and access storage accounts metadata.
 
 ## Prerequisites
@@ -26,7 +26,7 @@ to save audit events on **"log storage account(s)"**. Ensure you have the necess
 
    - One for audit logs — Create a storage account [Create a storage account (Microsoft Learn)](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?utm_source=chatgpt.com&tabs=azure-portal)
 
-- [Azure Files identity-based access](https://learn.microsoft.com/en-us/azure/storage/files/storage-files-active-directory-overview) is configured for data storage account in Azure Files
+- [Azure Files identity-based access](https://learn.microsoft.com/en-us/azure/storage/files/storage-files-active-directory-overview) configured for the data storage account in Azure Files
 
   Supported options:
    - Active Directory Domain Services (AD DS)
@@ -46,7 +46,7 @@ to save audit events on **"log storage account(s)"**. Ensure you have the necess
 
 ## Azure Application Registration
 
-You should register an application so Netwrix Auditor can authenticate to Azure and read audit logs
+Register an application so Netwrix Auditor can authenticate to Azure and read audit logs.
 
 ### Step 1: Create the App Registration
 
@@ -157,7 +157,7 @@ You should assign Azure IAM roles so that Netwrix Auditor can:
    - "View everything, but not make any changes"
 5. Click **Next**
 6. Under **Members**, click **+ Select members**
-7. In the search window, find and select the **App you registered earlier**
+7. In the search window, select the **App you registered earlier**
 8. Click **Select → Review + assign**
 
 

--- a/docs/auditor/10.9/configuration/azurefiles/overview.md
+++ b/docs/auditor/10.9/configuration/azurefiles/overview.md
@@ -95,10 +95,13 @@ Netwrix Auditor uses the **App ID** + **Client Secret** for authentication
 
 ### Step 1: Add Permissions
 
+The Purpose column references Microsoft Graph API endpoints that Netwrix Auditor calls to perform each resolution task.
+
 | Permission | Purpose |
 |------------|---------|
 | `User.Read` | Basic user information. Sign in and read user profile. *(default)* |
-| `User.Read.All` | Read all users' profiles. Required to resolve SIDs into usernames in reports |
+| `User.Read.All` | Read all users' full profiles. Required to resolve user security identifiers (SIDs) into display names and User Principal Names (UPNs), and to map access control entries (ACEs) from group membership via the Microsoft Graph endpoint `/users/{id}/transitiveMemberOf` |
+| `Group.Read.All` | Resolve groups and search by SID from discretionary access control lists (DACLs). Required to expand group membership via the Microsoft Graph endpoint `/groups/{id}/transitiveMembers` and filter groups by `securityIdentifier` |
 
 
 1. In your app in EntraID, go to **Manage > API permissions > + Add a permission**.
@@ -106,9 +109,11 @@ Netwrix Auditor uses the **App ID** + **Client Secret** for authentication
 3. Add:
    - **User.Read (default)**
    - **User.Read.All**
+   - **Group.Read.All**
 
 - *User.Read* – "Sign in and read user profile." *(default)*
 - *User.Read.All* – "Read all users' full profiles"
+- *Group.Read.All* – "Read all groups"
 
 
 ### Step 2: Grant Admin Consent
@@ -117,9 +122,10 @@ Click **Grant admin consent for TenantName**
 
 **Why this is required:**
 - By default, applications cannot query Microsoft Graph for directory-wide information
-- Admin consent allows the app to use **User.Read.All**
-- This lets Netwrix Auditor query Azure AD and resolve **user SIDs → user accounts → display names**
-- Without admin consent, audit logs will only show unresolved SIDs instead of usernames, making reports incomplete and less useful
+- Admin consent allows the app to use **User.Read.All** and **Group.Read.All**
+- **User.Read.All** lets Netwrix Auditor query Microsoft Entra ID and resolve **user SIDs → user accounts → display names**
+- **Group.Read.All** lets Netwrix Auditor resolve groups from DACLs and expand group membership so reports show which users inherit access through group ACEs
+- Without admin consent, audit logs will only show unresolved SIDs and object IDs instead of usernames and group names, making reports incomplete and less useful
 
 **At the end of this step, your app has granted Microsoft Graph API permissions**
 
@@ -236,7 +242,7 @@ Azure Files audit logs will now be archived into your **Log Storage Account**
 ## Checklist
 
 - [Azure Application registered](#azure-application-registration) with App ID + Secret
-- [API permissions](#configure-api-permissions) (User.Read, User.Read.All) granted
+- [API permissions](#configure-api-permissions) (User.Read, User.Read.All, Group.Read.All) granted
 - [IAM roles assigned](#assign-iam-roles-to-the-app) (Reader, Storage File Data Privileged Reader, Storage Blob Data Reader)
 - [Diagnostic Settings configured](#diagnostic-settings) to log to a Log Storage Account
 


### PR DESCRIPTION
## Summary

- Port `Group.Read.All` Microsoft Graph API permission requirement from Auditor 10.8 (PR #1047) to Auditor 10.9 documentation
- Updated permissions table with detailed Purpose descriptions for `User.Read.All` and new `Group.Read.All` entry
- Added `Group.Read.All` to Step 1 Add Permissions checklist and bullet list
- Updated "Why this is required" section to explain both `User.Read.All` and `Group.Read.All`
- Updated Checklist at the bottom of the page

## Changes

**File:** `docs/auditor/10.9/configuration/azurefiles/overview.md`

- Added note that Purpose column references Microsoft Graph API endpoints
- `User.Read.All`: expanded description with SID resolution details and `/users/{id}/transitiveMemberOf` endpoint
- `Group.Read.All`: new entry — resolves groups from DACLs, uses `/groups/{id}/transitiveMembers` and `securityIdentifier` filter
- Checklist updated: `(User.Read, User.Read.All, Group.Read.All) granted`

## Test plan

- [ ] Verify page renders correctly in docs preview
- [ ] Confirm all three permissions (User.Read, User.Read.All, Group.Read.All) appear in table and checklist
- [ ] Check links and anchors are valid

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>