### PR TITLE
fix(ci): skip code review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   code-review:
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     concurrency:
       group: code-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true


### PR DESCRIPTION
Dependabot is a bot actor, and claude-code-action blocks non-human actors by default, causing the job to fail on automated dependency bump PRs. Skipping the job for dependabot[bot] is the right fix — Claude code review isn't useful for automated version bumps.

Generated with AI