### PR TITLE
fix(ci): bump remaining actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -25,7 +25,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Create tracking issue, link PR, add to project board
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.KB_OPS_PAT }}
           script: |
@@ -131,7 +131,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Create tracking issue, link PR, add to project board
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.KB_OPS_PAT }}
           script: |

--- a/.github/workflows/claude-code-followup.yml
+++ b/.github/workflows/claude-code-followup.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Checkout base repository
         if: steps.pr-info.outputs.is_fork == 'false' && steps.pr-info.outputs.targets_dev == 'true'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ secrets.VALE_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1

--- a/.github/workflows/update-project-board-on-pr-merge.yml
+++ b/.github/workflows/update-project-board-on-pr-merge.yml
@@ -18,7 +18,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Parse closing keywords and update project board
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # KB_OPS_PAT requires repo + project scopes. SSO-authorized for netwrix and netwrix-corp orgs.
           github-token: ${{ secrets.KB_OPS_PAT }}


### PR DESCRIPTION
Updates actions/checkout (v4→v6.0.2) in claude-code-followup and claude-code-review, and replaces unpinned actions/github-script@v7 (node20) with SHA-pinned v9.0.0 (node24) in auto-create-pr-tracking-issues and update-project-board-on-pr-merge. Resolves #1052.

Generated with AI