### PR TITLE
docs(policypak): add USA datacenter and data residency info to Cloud …

### DIFF
--- a/docs/policypak/deliverymethods/cloud/knowledgebase/cloudportalsecurity/datasafety.md
+++ b/docs/policypak/deliverymethods/cloud/knowledgebase/cloudportalsecurity/datasafety.md
@@ -56,6 +56,8 @@ endpoint data
 All communication to and from the client machines with PolicyPak Cloud is always
 encrypted.
 
+PolicyPak Cloud customer data is stored exclusively in USA datacenters. Data is redundant and split between East and West coast USA datacenters to ensure availability in the event of an outage. There is no option to select an alternative data residency region — locations such as Ireland or Germany are not available at this time.
+
 At rest, we store all the data in SQL Azure, and have Transparent Data Encryption option enabled.
 
 See Microsoft's

--- a/docs/policypak/deliverymethods/cloud/knowledgebase/cloudportalsecurity/datasafety.md
+++ b/docs/policypak/deliverymethods/cloud/knowledgebase/cloudportalsecurity/datasafety.md
@@ -4,34 +4,31 @@ description: "What data is stored in PolicyPak Cloud, and how is that data safel
 sidebar_position: 10
 ---
 
-# What data is stored in PolicyPak Cloud, and how is that data safely communicated and stored ?
+# Data stored in PolicyPak Cloud and how it's safely communicated and stored
 
 ## What is stored:
 
-As expected, a small amount ofdata from your organization is stored within Netwrix PolicyPak Cloud after a computer joins PolicyPak cloud.
+Netwrix PolicyPak Cloud stores a small amount of data from your organization after a computer joins PolicyPak Cloud.
 
 :::note
-times At no times are any usernames, passwords, OUs, domain names, or anything else
-utilized or stored within PolicyPak Cloud.
+PolicyPak Cloud never uses or stores usernames, passwords, OUs, domain names, or anything else.
 :::
 
 
-Below is a detailed list of what is stored within PolicyPak Cloud with terms of
-endpoint data
-
-:
+The following list details what PolicyPak Cloud stores in terms of endpoint data:
 
 - PolicyPak UUID: This is random, unique ID generated in the cloud at "join time." It
-  doesn't contain any computer-specific data, but it helps us to identify the computer when it
+  doesn't contain any computer-specific data, but it helps identify the computer when it
   checks in.
-- Fingerprint: This is a SHA256 hash of hardware UUID and OS IDs. This is used as a unique computer
-  ID in order to generate a unique license.
-- MAC address: All physical network adapters MAC addresses are stored in PPCloud.
+- Fingerprint: This is a SHA256 hash of hardware UUID and OS IDs. PolicyPak Cloud uses this as a unique computer
+  ID to generate a unique license.
+- MAC address: PolicyPak Cloud stores MAC addresses for all physical network adapters.
 - BIOS UUID: This is a unique hardware ID assigned to every physical and virtual machine by the
-  manufacturer. (For more information on BIOS UUID, see
-  [http://searchsoa.techtarget.com/definition/UUID](http://searchsoa.techtarget.com/definition/UUID))
-- Last known public IP address: This is stored only for reporting and search on the website.
-- OS version and build: This is stored only for reporting. (e.g. Microsoft Windows NT 6.2.9200.0 or
+  manufacturer. See the
+  [TechTarget UUID definition](http://searchsoa.techtarget.com/definition/UUID) for background on
+  BIOS UUID.
+- Last known public IP address: PolicyPak Cloud stores this only for reporting and search on the website.
+- OS version and build: PolicyPak Cloud stores this only for reporting. (e.g. Microsoft Windows NT 6.2.9200.0 or
   Microsoft Windows NT 6.1.7601 Service Pack 1)
 - Computer name: The FQDN computer name it has been assigned.
 - Check in times: First check in date and time and Last check in date and time.
@@ -43,22 +40,20 @@ endpoint data
 - Reports that you create.
 - Names and email addresses of other administrators you have granted rights to use PolicyPak cloud
 - Current licensing status and number of computers licensed.
-- Events (if the PolicyPak Cloud Event Log Collector is turned on for your tenant.)
-  For example PolicyPak Least Privilege Manager events which can be stored for a time
-  in PolicyPak Cloud Service (not enabled for all customers.) Details of this feature
-  can be seen
-  at[PolicyPak Cloud + PPLPM + Events: Collect Events in the Cloud](/docs/policypak/components/leastprivilegemanager/videolearningcenter/eventing/cloudevents.md)
-  and details about specific event types (for example) can be found here:
+- Events (if you turn on the PolicyPak Cloud Event Log Collector for your tenant.)
+  For example, PolicyPak Cloud Service can store PolicyPak Least Privilege Manager events for a time (not enabled for all customers.) See
+  [PolicyPak Cloud + PPLPM + Events: Collect Events in the Cloud](/docs/policypak/components/leastprivilegemanager/videolearningcenter/eventing/cloudevents.md)
+  for details of this feature, and see
   [List of PolicyPak Event Categories and IDs](/docs/policypak/misc/knowledgebase/tipstricksandfaqs/eventcategories.md)
+  for details about specific event types.
 
 #### How is data is stored at rest with PolicyPak Cloud:
 
-All communication to and from the client machines with PolicyPak Cloud is always
-encrypted.
+PolicyPak Cloud always encrypts all communication to and from the client machines.
 
-PolicyPak Cloud customer data is stored exclusively in USA datacenters. Data is redundant and split between East and West coast USA datacenters to ensure availability in the event of an outage. There is no option to select an alternative data residency region — locations such as Ireland or Germany are not available at this time.
+PolicyPak Cloud stores customer data exclusively in USA datacenters. To ensure availability if there is an outage, PolicyPak Cloud distributes redundant copies of data between East and West coast USA datacenters. You can't select an alternative data residency region — locations such as Ireland or Germany aren't available at this time.
 
-At rest, we store all the data in SQL Azure, and have Transparent Data Encryption option enabled.
+PolicyPak Cloud stores all data at rest in SQL Azure with the Transparent Data Encryption option enabled.
 
 See Microsoft's
 article[TDE Azure option information](https://msdn.microsoft.com/library/dn948096?f=255&MSPPError=-2147217396)
@@ -66,13 +61,12 @@ for additional information about TDE Azure.
 
 See Microsoft's article More about TDE (in
 general):[https://msdn.microsoft.com/en-us/library/bb934049](https://msdn.microsoft.com/en-us/library/bb934049):
-"_Transparent Data Encryption (TDE) encrypts SQL Server and Azure SQL Database data files, known as
+"_Transparent Data Encryption (TDE) encrypts SQL Server and Azure SQL Database data files, known as
 encrypting data at rest_. "
 
 #### How is data communicated to and from PolicyPak Cloud:
 
-All communication to and from the client machines with PolicyPak Cloud is always
-encrypted. Here is how the client attempts to communicate with PolicyPak Cloud:
+PolicyPak Cloud always encrypts all communication to and from the client machines. Here is how the client attempts to communicate with PolicyPak Cloud:
 
 - PolicyPak Cloud client tries HTTPS (secure HTTP) using port 443 first using an
   encrypted PolicyPak Cloud certificate the client received at "join" time.


### PR DESCRIPTION
…data safety article

Adds that customer data is stored exclusively in USA (East and West coast) datacenters with redundancy, and that no alternative data residency regions are available.

Generated with AI