### PR TITLE
fix(changetracker): collapse multiline image alt text to restore broken images

### DIFF
--- a/docs/changetracker/8.0/cloud/policytab/setupwizard.md
+++ b/docs/changetracker/8.0/cloud/policytab/setupwizard.md
@@ -8,7 +8,7 @@ sidebar_position: 10
 
 **Step 1 –** New Policy: Use the Actions button to start a new Cloud Tracker system set-up.
 
-**Step 2 –** Cloud Report Template: The templates shown here include all Cloud reports available in
+**Step 2 –** Cloud Report Template: The following templates include all Cloud reports available in
 your system.
 
 ![cloudsystemsetup](/images/changetracker/8.0/cloud/cloudsystemsetup.webp)
@@ -75,8 +75,8 @@ file was found in any module directory".
 In this case, run the following PowerShell setup on the host running the
 Gen7Agent NETCore used for Cloud Tracker work:
 
-**Step 1 –** Install PowerShell NETCore version 7.x (NB this isn't the old PowerShell that ships
-with Windows, but a new cross-platform version based on NETCore). See the Microsoft
+**Step 1 –** Install PowerShell NETCore version 7.x (this is the new cross-platform version of
+PowerShell based on NETCore, separate from the PowerShell that ships with Windows). See the Microsoft
 [Installing the MIS package](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows#installing-the-mis-package)
 article for additional information.
 
@@ -112,8 +112,8 @@ file was found".
 In this case, run the following PowerShell setup on the host running the
 Gen7Agent NETCore used for Cloud Tracker work:
 
-**Step 1 –** Install PowerShell NETCore version 7.x (NB this isn't the old PowerShell that ships
-with Windows, but a new cross-platform version based on NETCore). See the Microsoft
+**Step 1 –** Install PowerShell NETCore version 7.x (this is the new cross-platform version of
+PowerShell based on NETCore, separate from the PowerShell that ships with Windows). See the Microsoft
 [Installing the MIS package](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows#installing-the-mis-package)
 article for additional information.
 

--- a/docs/changetracker/8.0/cloud/policytab/setupwizard.md
+++ b/docs/changetracker/8.0/cloud/policytab/setupwizard.md
@@ -19,10 +19,7 @@ presented with next.
 
 Google Cloud Platform Credentials example:
 
-![Graphical user interface, text, application, email
-
-Description automatically
-generated](/images/changetracker/8.0/cloud/cloudgoogleplatformcredentials.webp)
+![Graphical user interface, text, application, email Description automatically generated](/images/changetracker/8.0/cloud/cloudgoogleplatformcredentials.webp)
 
 :::note
 Just click the Query icon to get a quick tip on what the Credential field requires.
@@ -97,10 +94,7 @@ PowerShell NETCore command prompt (PowerShell 7(x64) Start menu item, Run As Adm
 
 Azure Platform Credentials Example:
 
-![Graphical user interface, text, application
-
-Description automatically
-generated](/images/changetracker/8.0/cloud/cloudazure-credentials.webp)
+![Graphical user interface, text, application Description automatically generated](/images/changetracker/8.0/cloud/cloudazure-credentials.webp)
 
 - Credential Name – Enter a name to uniquely identify these credentials
 - Cloud Platform – Select from the drop-down options presented

--- a/docs/changetracker/8.0/cloud/policytab/setupwizard.md
+++ b/docs/changetracker/8.0/cloud/policytab/setupwizard.md
@@ -8,31 +8,30 @@ sidebar_position: 10
 
 **Step 1 –** New Policy: Use the Actions button to start a new Cloud Tracker system set-up.
 
-**Step 2 –** Cloud Report Template: Templates presented here will be filtered to show all Cloud
-reports available in your system.
+**Step 2 –** Cloud Report Template: The templates shown here include all Cloud reports available in
+your system.
 
 ![cloudsystemsetup](/images/changetracker/8.0/cloud/cloudsystemsetup.webp)
 
-**Step 3 –** Create a new Cloud System and Credentials: The Cloud Set-Up Wizard is context-sensitive
-so depending on which Cloud Platform you select will determine the Credentials dialogue you will be
-presented with next.
+**Step 3 –** Create a new Cloud System and Credentials: The Cloud Set-Up Wizard is context-sensitive,
+so the Cloud Platform you select determines the Credentials dialogue that appears next.
 
 Google Cloud Platform Credentials example:
 
 ![Graphical user interface, text, application, email Description automatically generated](/images/changetracker/8.0/cloud/cloudgoogleplatformcredentials.webp)
 
 :::note
-Just click the Query icon to get a quick tip on what the Credential field requires.
+Click the Query icon to get a quick tip on what the Credential field requires.
 :::
 
 
 - Credential Name – Enter a name to uniquely identify these credentials
-- Cloud Platform – Select from the drop-down options presented
+- Cloud Platform – Select from the dropdown options presented
 - Description – Optionally provide a credential description
 
-Once Credentials have been entered, Change Tracker will automatically select an Agent to run the
-Cloud Compliance Report from and then run a test of the Credentials. By default, the Agent selected
-will be the local Agent on the Hub Server.
+After you enter the Credentials, Change Tracker automatically selects an Agent to run the
+Cloud Compliance Report from and then tests the Credentials. By default, Change Tracker uses
+the local Agent on the Hub Server.
 
 :::note
 This must always be the latest Net Core Gen 7 Agent. See the
@@ -40,26 +39,25 @@ This must always be the latest Net Core Gen 7 Agent. See the
 :::
 
 
-This can be changed using the links displayed once the Credentials test has completed, and in the
-event that the Credentials are not working for any reason, you will now have the opportunity to edit
-them and verify they have been entered correctly.
+You can change this using the links displayed after the Credentials test completes. If the
+Credentials aren't working, you can edit them and verify you entered them correctly.
 
 Cloud security is higher and more complex than standard access credentials for regular servers and
-hypervisors so please ask for help if needed!
+hypervisors, so ask for help if needed.
 
 ![cloudcompletedsetup](/images/changetracker/8.0/cloud/cloudcompletedsetup.webp)
 
-At this point you are ready to run your first Cloud Compliance Report – just hit the Run Report
-button!
+You're now ready to run your first Cloud Compliance Report – click the Run Report
+button.
 
 AWS Platform Credentials Example:
 
 ![cloudaws-credentials](/images/changetracker/8.0/cloud/cloudaws-credentials.webp)
 
 - Credential Name – Enter a name to uniquely identify these credentials Cloud
-- Platform – Select from the drop-down options presented
+- Platform – Select from the dropdown options presented
 - Description – Optionally provide a credential description
-- ARN – AWS Resource Name of a role that can be assumed by a user when establishing a trust
+- ARN – AWS Resource Name of a role a user can assume when establishing a trust
   relationship.
 - ExternalId – An Id used in establishing the trust relationship
 - Root AccessKeyId – The Access Key Id of the AWS user the trust relationship is established for
@@ -68,23 +66,23 @@ AWS Platform Credentials Example:
 
 ### Special Instructions for AWS Cloud Reporting
 
-The NNT Cloud Tracker feature set utilizes the Microsoft PowerShell cmdlets for AWS.
+The NNT Cloud Tracker feature set uses the Microsoft PowerShell cmdlets for AWS.
 
-You may experience a failure message after the Credentials Test has run: "Cannot execute AWS
-commands, error: The specified module 'AWSPowerShell. NETCore was not loaded because no valid module
+You may experience a failure message after the Credentials Test has run: "Can't execute AWS
+commands, error: The specified module 'AWSPowerShell. NETCore wasn't loaded because no valid module
 file was found in any module directory".
 
-In this case it will be necessary to run the following PowerShell setup on the host running the
-Gen7Agent NETCore being used for Cloud Tracker work:
+In this case, run the following PowerShell setup on the host running the
+Gen7Agent NETCore used for Cloud Tracker work:
 
-**Step 1 –** Install PowerShell NETCore version 7.x (NB this is not the old PowerShell that is
-packaged with Windows, but a new cross-platform version based on NETCore). See the Microsoft
+**Step 1 –** Install PowerShell NETCore version 7.x (NB this isn't the old PowerShell that ships
+with Windows, but a new cross-platform version based on NETCore). See the Microsoft
 [Installing the MIS package](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows#installing-the-mis-package)
 article for additional information.
 
-Although the agent provides its own PowerShell scripting, this NETCore version of PowerShell must be
-installed in order that the various AWS/Azure etc. PowerShell core support libraries can be
-installed. These are used by some Change Tracker reports to collect data from the cloud
+Although the agent provides its own PowerShell scripting, you must install this NETCore version of
+PowerShell so that you can install the various AWS/Azure PowerShell core support libraries.
+Some Change Tracker reports use these libraries to collect data from the cloud
 environments.
 
 **Step 2 –** Install AWS Cmdlets for use in AWS compliance reports, run the following in the
@@ -97,7 +95,7 @@ Azure Platform Credentials Example:
 ![Graphical user interface, text, application Description automatically generated](/images/changetracker/8.0/cloud/cloudazure-credentials.webp)
 
 - Credential Name – Enter a name to uniquely identify these credentials
-- Cloud Platform – Select from the drop-down options presented
+- Cloud Platform – Select from the dropdown options presented
 - Description – Optionally provide a credential description
 - Tenant ID – From the Azure portal, click properties and copy the Tenant Id
 - Application ID – The Azure application (client) ID
@@ -105,23 +103,23 @@ Azure Platform Credentials Example:
 
 ### Special Instructions for Azure Cloud Reporting
 
-The NNT Cloud Tracker feature set utilizes the Microsoft PowerShell cmdlets for AWS.
+The NNT Cloud Tracker feature set uses the Microsoft PowerShell cmdlets for AWS.
 
-You may experience a failure message after the Credentials Test has run: "Cannot execute Az
-commands, error on Import-Module: The specified module 'Az' was not loaded because no valid module
+You may experience a failure message after the Credentials Test has run: "Can't execute Az
+commands, error on Import-Module: The specified module 'Az' wasn't loaded because no valid module
 file was found".
 
-In this case it will be necessary to run the following PowerShell setup on the host running the
-Gen7Agent NETCore being used for Cloud Tracker work:
+In this case, run the following PowerShell setup on the host running the
+Gen7Agent NETCore used for Cloud Tracker work:
 
-**Step 1 –** Install PowerShell NETCore version 7.x (NB this is not the old PowerShell that is
-packaged with windows, but a new cross-platform version based on netcore). See the Microsoft
+**Step 1 –** Install PowerShell NETCore version 7.x (NB this isn't the old PowerShell that ships
+with Windows, but a new cross-platform version based on NETCore). See the Microsoft
 [Installing the MIS package](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows#installing-the-mis-package)
 article for additional information.
 
-Although the agent provides its own PowerShell scripting, this NETCore version of PowerShell must be
-installed in order that the various AWS/Azure etc. PowerShell core support libraries can be
-installed. These are used by some Change Tracker reports to collect data from the cloud
+Although the agent provides its own PowerShell scripting, you must install this NETCore version of
+PowerShell so that you can install the various AWS/Azure PowerShell core support libraries.
+Some Change Tracker reports use these libraries to collect data from the cloud
 environments.
 
 **Step 2 –** Install Azure Cmdlets for use in Azure compliance reports, run the following in the

--- a/docs/changetracker/8.0/cloud/policytab/setupwizard.md
+++ b/docs/changetracker/8.0/cloud/policytab/setupwizard.md
@@ -18,7 +18,7 @@ so the Cloud Platform you select determines the Credentials dialogue that appear
 
 Google Cloud Platform Credentials example:
 
-![Graphical user interface, text, application, email Description automatically generated](/images/changetracker/8.0/cloud/cloudgoogleplatformcredentials.webp)
+![Google Cloud Platform credentials dialog showing Credential Name, Cloud Platform, and Description fields](/images/changetracker/8.0/cloud/cloudgoogleplatformcredentials.webp)
 
 :::note
 Click the Query icon to get a quick tip on what the Credential field requires.
@@ -92,7 +92,7 @@ PowerShell NETCore command prompt (PowerShell 7(x64) Start menu item, Run As Adm
 
 Azure Platform Credentials Example:
 
-![Graphical user interface, text, application Description automatically generated](/images/changetracker/8.0/cloud/cloudazure-credentials.webp)
+![Azure Platform credentials dialog showing Credential Name, Cloud Platform, Tenant ID, Application ID, and Client Secret fields](/images/changetracker/8.0/cloud/cloudazure-credentials.webp)
 
 - Credential Name – Enter a name to uniquely identify these credentials
 - Cloud Platform – Select from the dropdown options presented


### PR DESCRIPTION
## Summary

Two images in `changetracker/8.0/cloud/policytab/setupwizard.md` had multiline alt text, causing Docusaurus to not render them on the live site. Collapsed to single lines.

## Affected file

- `docs/changetracker/8.0/cloud/policytab/setupwizard.md` (2 images fixed)

## Test plan

- [ ] Verify the Google Cloud Platform and Azure credential screenshot images render on the [Cloud Policy Setup Wizard](https://docs.netwrix.com/docs/changetracker/8_0/cloud/policytab/setupwizard) page

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>