### PR TITLE
fix(kb/threatmanager): Update Ransomware Extension List with No Internet

### DIFF
--- a/docs/kb/threatmanager/threat-management-and-operations/update-ransomware-extension-list-with-no-internet.md
+++ b/docs/kb/threatmanager/threat-management-and-operations/update-ransomware-extension-list-with-no-internet.md
@@ -11,7 +11,10 @@ keywords:
 - Netwrix Threat Manager
 - KnownExtensions
 products:
-- threat-manager
+- threatmanager
+sidebar_label: 'Update Ransomware Extension List with No Internet'
+tags:
+- kb
 title: 'Update Ransomware Extension List with No Internet'
 knowledge_article_id: kA04u0000000HuTCAU
 ---
@@ -20,7 +23,7 @@ knowledge_article_id: kA04u0000000HuTCAU
 
 ## Question
 
-How to update the ransomware extension list without internet connection in Netwrix Threat Manager?
+How can I update the ransomware extension list when Netwrix Threat Manager has no internet access?
 
 ## Answer
 
@@ -34,8 +37,4 @@ How to update the ransomware extension list without internet connection in Netwr
 C:\Program Files\STEALTHbits\StealthDEFEND\JobService\Python\pydefend\pydefend\data
 ```
 
-3. Increment the version number in the `filters.metadata` file in `pydefend\data` for old files to be reprocessed.
-
-## Related links
-
-- https://raw.githubusercontent.com/DFFspace/CryptoBlocker/master/KnownExtensions.txt (CryptoBlocker − Known Extensions · GitHub)
+3. Increment the version number in the `filters.metadata` file in `pydefend\data` to trigger reprocessing of existing files.


### PR DESCRIPTION
## Summary

Lint and style fixes for the KB article on updating the Threat Manager ransomware extension list on air-gapped appliances.

## Changes

- Added missing `sidebar_label` and `tags: [kb]` frontmatter fields
- Fixed product ID from `threat-manager` to `threatmanager`
- Rewrote the Question from an incomplete sentence to a complete question
- Rewrote step 3 to active voice
- Removed `Related Links` section (article has fewer than 3 inline links per style guide)
- Added trailing newline

## Testing
- Local build passed (`npm run start`).
---

   _Created via the in-development `kb-pr-open` Claude Code skill. Refs #1077._

Closes #1130