### PR TITLE
fix(kb): lint and style fixes for five KB articles

### DIFF
--- a/docs/kb/dataclassification/system-administration/how-to-back-up-the-ndc-index.md
+++ b/docs/kb/dataclassification/system-administration/how-to-back-up-the-ndc-index.md
@@ -26,24 +26,24 @@ knowledge_article_id: kA04u000000PcvZCAS
 
 # Backing Up the Netwrix Data Classification Index
 
-This article details steps to back up the Netwrix Data Classification (NDC) index. You should back up the index to provide a safety net in case of index corruption. Maintaining a proper NDC index reduces the time lost if an index becomes corrupted.
+This article details steps to back up the Netwrix Data Classification (NDC) index. You should back up the index to create a recovery point in case of index corruption. Maintaining a proper NDC index reduces the time lost if an index becomes corrupted.
 
 ## What Causes Index Corruption?
 
 Corruption within the index occurs when one of two situations happens:
 
-1. The Indexer process is terminated without being allowed to stop gracefully, for example by a power interruption or by using the **End Task** option in Task Manager.
+1. The Indexer process terminates abruptly without shutting down gracefully — for example, due to a power interruption or because a user selects **End Task** in Task Manager.
 2. The Indexer is prevented from editing the files by another utility (ransomware protection, anti-virus, etc.) during that same window, or the utility modifies those files itself.
 
 ## How Do You Prevent Index Corruption?
 
 You can reduce the risk of index corruption by doing the following:
 
-1. Ensure that automatic restarts are disabled on the server.
-2. Ensure that the CSE files are excluded from any running anti-virus. (Default CSE location: `C:\Program Files\ConceptSearching\ConceptDB\`)
+1. Disable automatic restarts on the server.
+2. Exclude the CSE files from any running anti-virus. (Default CSE location: `C:\Program Files\ConceptSearching\ConceptDB\`)
 3. Educate users of the Netwrix Data Classification product to avoid manually stopping the Indexer process.
 
-## My Index Has Corrupted — Can I Perform a Root Cause Analysis?
+## How Do You Perform a Root Cause Analysis on a Corrupted Index?
 
 Yes. Logs are generally the best method for root cause analysis, though it may be difficult if considerable time has passed. One option is to review the following SQL data:
 
@@ -51,7 +51,7 @@ Yes. Logs are generally the best method for root cause analysis, though it may b
 SELECT * FROM ApplicationLog WHERE Operation = 1 AND ModuleID = 2 ORDER BY LogDateTime DESC
 ```
 
-If the service was improperly shut down, you would expect to see a **Started** entry without a corresponding **Shutdown** entry.
+If the service shut down improperly, you would expect to see a **Started** entry without a corresponding **Shutdown** entry.
 
 ## How Do You Back Up the Index?
 
@@ -59,7 +59,7 @@ Follow these steps to back up the index:
 
 1. Stop all services: **Collector**, **Indexer**, **Classifier**. If you are using a Distributed Query Server (DQS), stop all three services on each server in the cluster.
 2. Take a backup of the CSE file folder on each server. (Default CSE location: `C:\Program Files\ConceptSearching\ConceptDB\`)
-3. Take a backup of the SQL database. It is very important that the SQL database is in sync with the CSE files — stop the services first to ensure consistency.
+3. Take a backup of the SQL database. The SQL database must be in sync with the CSE files — stop the services first to ensure consistency.
 4. Start all services.
 
 For best results, perform these steps weekly to ensure minimal data loss in the event of index corruption.

--- a/docs/kb/dataclassification/system-administration/how-to-back-up-the-ndc-index.md
+++ b/docs/kb/dataclassification/system-administration/how-to-back-up-the-ndc-index.md
@@ -15,26 +15,27 @@ keywords:
   - SQL
   - index corruption
 products:
-  - data-classification
-sidebar_label: How to back up the Netwrix Data Classification index
+  - dataclassification
+sidebar_label: Backing Up the Netwrix Data Classification Index
 tags:
+  - kb
   - system-administration
-title: "How to back up the Netwrix Data Classification index"
+title: "Backing Up the Netwrix Data Classification Index"
 knowledge_article_id: kA04u000000PcvZCAS
 ---
 
-# How to back up the Netwrix Data Classification index
+# Backing Up the Netwrix Data Classification Index
 
 This article details steps to back up the Netwrix Data Classification (NDC) index. You should back up the index to provide a safety net in case of index corruption. Maintaining a proper NDC index reduces the time lost if an index becomes corrupted.
 
-## What causes index corruption?
+## What Causes Index Corruption?
 
 Corruption within the index occurs when one of two situations happens:
 
-1. The Indexer process is terminated without being allowed to stop gracefully, for example by a power interruption or by using the “End Task” option in Task Manager.
+1. The Indexer process is terminated without being allowed to stop gracefully, for example by a power interruption or by using the **End Task** option in Task Manager.
 2. The Indexer is prevented from editing the files by another utility (ransomware protection, anti-virus, etc.) during that same window, or the utility modifies those files itself.
 
-## How to prevent the index from corrupting?
+## How Do You Prevent Index Corruption?
 
 You can reduce the risk of index corruption by doing the following:
 
@@ -42,7 +43,7 @@ You can reduce the risk of index corruption by doing the following:
 2. Ensure that the CSE files are excluded from any running anti-virus. (Default CSE location: `C:\Program Files\ConceptSearching\ConceptDB\`)
 3. Educate users of the Netwrix Data Classification product to avoid manually stopping the Indexer process.
 
-## My index has corrupted — can I perform a root cause analysis?
+## My Index Has Corrupted — Can I Perform a Root Cause Analysis?
 
 Yes. Logs are generally the best method for root cause analysis, though it may be difficult if considerable time has passed. One option is to review the following SQL data:
 
@@ -52,11 +53,11 @@ SELECT * FROM ApplicationLog WHERE Operation = 1 AND ModuleID = 2 ORDER BY LogDa
 
 If the service was improperly shut down, you would expect to see a **Started** entry without a corresponding **Shutdown** entry.
 
-## How to back up the index?
+## How Do You Back Up the Index?
 
 Follow these steps to back up the index:
 
-1. Stop all services: **Collector**, **Indexer**, **Classifier**. If you are using a DQS (clustered NDC), stop all three services on each server in the cluster.
+1. Stop all services: **Collector**, **Indexer**, **Classifier**. If you are using a Distributed Query Server (DQS), stop all three services on each server in the cluster.
 2. Take a backup of the CSE file folder on each server. (Default CSE location: `C:\Program Files\ConceptSearching\ConceptDB\`)
 3. Take a backup of the SQL database. It is very important that the SQL database is in sync with the CSE files — stop the services first to ensure consistency.
 4. Start all services.

--- a/docs/kb/dataclassification/system-administration/how-to-change-the-default-iis-port-for-netwrix-data-classification-web-console.md
+++ b/docs/kb/dataclassification/system-administration/how-to-change-the-default-iis-port-for-netwrix-data-classification-web-console.md
@@ -13,29 +13,28 @@ keywords:
   - port 80
   - change port
 products:
-  - data-classification
-sidebar_label: How to Change the Default IIS Port for Netwrix Dat
+  - dataclassification
+sidebar_label: How to Change the Default IIS Port
 tags:
+  - kb
   - system-administration
-title: >-
-  How to Change the Default IIS Port for Netwrix Data Classification Web
-  Console?
+title: "How to Change the Default IIS Port"
 knowledge_article_id: kA0Qk0000000MzpKAE
 ---
 
-# How to Change the Default IIS Port for Netwrix Data Classification Web Console?
+# How to Change the Default IIS Port
 
 ## Question
 
-How to change the port 80 that comes with a default Netwrix Data Classification installation?
+How do you change the default port 80 in a Netwrix Data Classification installation?
 
 ## Answer
 
-The default IIS configuration of the Netwrix Data Classification is typically performed on the **Administration Web Application** step of the installation procedure. Learn more in Deployment — Install Netwrix Data Classification — v5.7
+By default, IIS is configured during the **Administration Web Application** step of the installation procedure. See [Install Netwrix Data Classification](pathname:///docs/dataclassification/5_7/introduction/install/overview) for details.
 
 Follow the steps below to change the default IIS port for the web console:
 
-1. Start the **IIS Manager**: navigate to **Control Panel** **Administrative Tools** > **Internet Information Services (IIS) Manager**.
+1. Start the **IIS Manager**: navigate to **Control Panel** > **Administrative Tools** > **Internet Information Services (IIS) Manager**.
 2. In the **Connections** menu on the left, expand **Sites** > **Default Website**.
 3. Click the **Bindings** link under **Actions**.
 4. In the **Site Binding** window, click **Edit**.

--- a/docs/kb/dataclassification/system-administration/how-to-export-event-logs.md
+++ b/docs/kb/dataclassification/system-administration/how-to-export-event-logs.md
@@ -26,7 +26,7 @@ knowledge_article_id: kA00g000000H9eECAS
 
 ## Question
 
-How do I export the Netwrix Data Classification event logs?
+How do you export the Netwrix Data Classification event logs?
 
 ## Answer
 

--- a/docs/kb/directorymanager/troubleshooting-and-errors/unable-to-sort-groups-by-displayname.md
+++ b/docs/kb/directorymanager/troubleshooting-and-errors/unable-to-sort-groups-by-displayname.md
@@ -15,9 +15,10 @@ keywords:
   - attribute
   - bulk update
 products:
-  - directory-manager
+  - directorymanager
 sidebar_label: Unable to Sort Groups by DisplayName
 tags:
+  - kb
   - troubleshooting-and-errors
 title: "Unable to Sort Groups by DisplayName"
 knowledge_article_id: kA0Qk0000002IC9KAM
@@ -33,12 +34,12 @@ When you attempt to sort the **My Groups** listing in Netwrix Directory Manager 
 
 ![Group listing in Directory Manager portal with Display Name column sorted in ascending order](./../0-images/ka0Qk000000EZ2j_0EMQk00000BoBWe.png)
 
-## Causes
+## Cause
 - The **Display Name** attribute is not mandatory for groups created directly in Active Directory, so some groups may not have this attribute populated.
 - When you sort by **Display Name** in Netwrix Directory Manager, the portal treats missing display names as null values and uses the **Common Name** instead. This can result in incorrect or failed sorting.
 - Groups created using Netwrix Directory Manager always have a **Display Name** because it is a required attribute.
 
-## Resolutions
+## Resolution
 1. Verify which groups are missing the **Display Name** attribute by checking the attribute editor in Active Directory.
 2. Populate the **Display Name** attribute for all groups that are missing it.
 3. After all groups have a **Display Name**, the Netwrix Directory Manager portal will sort group listings correctly by this attribute.

--- a/docs/kb/threatmanager/threat-management-and-operations/update-ransomware-extension-list-with-no-internet.md
+++ b/docs/kb/threatmanager/threat-management-and-operations/update-ransomware-extension-list-with-no-internet.md
@@ -23,7 +23,7 @@ knowledge_article_id: kA04u0000000HuTCAU
 
 ## Question
 
-How can I update the ransomware extension list when Netwrix Threat Manager has no internet access?
+How can you update the ransomware extension list when Netwrix Threat Manager has no internet access?
 
 ## Answer
 


### PR DESCRIPTION
## Summary

Applies Vale, Dale, and Derek lint and style fixes to five KB articles
across Netwrix Threat Manager, Netwrix Data Classification, and Netwrix
Directory Manager.

## Changes

- **update-ransomware-extension-list-with-no-internet.md** (Threat Manager):
  rewritten Q&A question to second person
- **how-to-export-event-logs.md** (Data Classification):
  rewritten Q&A question to second person
- **how-to-back-up-the-ndc-index.md** (Data Classification):
  corrected `products` ID to `dataclassification`, added `kb` tag,
  updated title/H1/sidebar_label to title case and gerund form, rewrote
  sub-question headings to title case and second-person interrogative form,
  defined DQS on first use, fixed **End Task** formatting, resolved passive
  voice and wordiness issues, replaced idiom ("safety net" → "recovery point")
- **unable-to-sort-groups-by-displayname.md** (Directory Manager):
  corrected `products` ID to `directorymanager`, added `kb` tag, changed
  `## Causes` → `## Cause` and `## Resolutions` → `## Resolution`
- **how-to-change-the-default-iis-port-for-netwrix-data-classification-web-console.md**
  (Data Classification): corrected `products` ID to `dataclassification`,
  added `kb` tag, updated title/H1/sidebar_label, fixed Q&A question to
  second-person interrogative form, converted bare "Learn more" link to a
  proper reference, added missing `>` separator in IIS Manager navigation step

## Testing

Reviewed in local dev server. All five articles render correctly and
hyperlinks redirect as expected.

---

_Created via the in-development `kb-pr-open` Claude Code skill. Refs #1077._

Closes #1143