### PR TITLE
Re-apply: Add note about on-premises AD limitations for Azure Files SiT reports [Doc Task 439319]

### DIFF
--- a/docs/auditor/10.9/admin/reports/types/stateintime/azurefiles.md
+++ b/docs/auditor/10.9/admin/reports/types/stateintime/azurefiles.md
@@ -48,7 +48,7 @@ Before you can use Azure Files State-in-Time reports, you must:
 2. Enable the **Collect data for state-in-time reports** option in the monitoring plan settings.
 3. (Optional but recommended) Configure **Azure diagnostic settings** to send logs to a blob storage account. The "Times Accessed" data in the Excessive Access Permissions report requires this configuration.
 
-For configuration details, see [Configuring State-in-Time Data Collection for Azure Files](/docs/auditor/10_8//configuration/azurefiles/stateintime).
+For configuration details, see [Configuring State-in-Time Data Collection for Azure Files](/docs/auditor/10_9/configuration/azurefiles/stateintime).
 
 ## Snapshot dates and historical analysis
 
@@ -77,5 +77,5 @@ If you are familiar with File Server State-in-Time reports, note the following d
 
 ## Related topics
 
-- [Configuring State-in-Time Data Collection for Azure Files](/docs/auditor/10_9//configuration/azurefiles/stateintime)
+- [Configuring State-in-Time Data Collection for Azure Files](/docs/auditor/10_9/configuration/azurefiles/stateintime)
 - [Azure Files Configuration Overview](/docs/auditor/10_9/configuration/azurefiles/overview)

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -2,6 +2,13 @@
 
 This topic describes how to enable State-in-Time data collection for an Azure Files monitoring plan in Netwrix Auditor, configure the monitoring scope using omit lists, and set up optional Azure diagnostic settings for activity-based reports.
 
+> **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
+>
+> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group name appears in the report. The report does not list individual group members.
+> - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
+>
+> These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.
+
 ## Prerequisites
 
 - An Azure Files monitoring plan must already exist in Netwrix Auditor [Azure Files Configuration Overview](/docs/auditor/10_8/configuration/azurefiles/overview)

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -4,7 +4,7 @@ This topic describes how to enable State-in-Time data collection for an Azure Fi
 
 > **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
 >
-> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
+> - **Group expansion is not supported for on-premises AD groups that are not synced to Microsoft Entra ID.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
 > - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
 >
 > These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -4,8 +4,8 @@ This topic describes how to enable State-in-Time data collection for an Azure Fi
 
 > **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
 >
-> - **Group expansion is not supported for on-premises AD groups that are not synced to Microsoft Entra ID.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
-> - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
+> - **Group expansion is unavailable for on-premises AD groups that are not synced to Microsoft Entra ID.** If access to a file or folder is granted through such a group, the report does not list individual group members.
+> - **SID resolution is unavailable for on-premises AD groups and accounts that are not synced to Microsoft Entra ID.** These objects appear as unresolved SIDs instead of display names in permission reports.
 >
 > These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.
 

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -4,7 +4,7 @@ This topic describes how to enable State-in-Time data collection for an Azure Fi
 
 > **Note:** When Azure file shares use on-premises Active Directory (AD DS) authentication, the following limitations apply to State-in-Time permission reports:
 >
-> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group name appears in the report. The report does not list individual group members.
+> - **Group expansion is not supported for on-premises AD groups.** If access to a file or folder is granted through an on-premises AD security group, only the group SID appears in the report. The report does not list individual group members.
 > - **On-premises AD accounts that are not synced to Microsoft Entra ID appear as unresolved SIDs.** Netwrix Auditor cannot retrieve display names for accounts that exist only in on-premises Active Directory.
 >
 > These limitations do not affect environments that use Microsoft Entra ID-only identities or fully synced hybrid identities.

--- a/docs/auditor/10.9/configuration/azurefiles/stateintime.md
+++ b/docs/auditor/10.9/configuration/azurefiles/stateintime.md
@@ -58,7 +58,7 @@ You can also define omit lists using plain text files:
 
 ## Configuring Azure diagnostic settings (optional)
 
-The **Times Accessed** column in the **Excessive Access Permissions in Azure Files** report requires Azure diagnostic settings. Without diagnostic settings, "Times Accessed" defaults to 0 for all objects. [Configuring Diagnostic Settings](docs/auditor/10_8/configuration/azurefiles/overview#diagnostic-settings)
+The **Times Accessed** column in the **Excessive Access Permissions in Azure Files** report requires Azure diagnostic settings. Without diagnostic settings, "Times Accessed" defaults to 0 for all objects. [Configuring Diagnostic Settings](/docs/auditor/10_8/configuration/azurefiles/overview#diagnostic-settings)
 
 > **Note:** The current version supports only **blob storage** as the destination, not Event Hub or Log Analytics Workspace.
 
@@ -91,4 +91,4 @@ Historical snapshots allow generating reports for past dates. A Global administr
 
 - [Azure Files State-in-Time Reports Overview](/docs/auditor/10_9/admin/reports/types/stateintime/azurefiles)
 - [Azure Files Configuration Overview](/docs/auditor/10_9/configuration/azurefiles/overview)
-- [Configuring Diagnostic Settings](docs/auditor/10_9/configuration/azurefiles/overview#diagnostic-settings)
+- [Configuring Diagnostic Settings](/docs/auditor/10_9/configuration/azurefiles/overview#diagnostic-settings)


### PR DESCRIPTION
## Summary

Re-applies changes from PR #1032 that were lost when the `release/auditor_10.9` branch was reset after the merge.

The original PR (merged 2026-05-29) added a note to the Azure Files State-in-Time configuration page explaining limitations when using on-premises AD DS authentication:

- Group expansion is unavailable for on-premises AD groups not synced to Microsoft Entra ID
- SID resolution is unavailable for on-premises AD groups/accounts not synced to Microsoft Entra ID

**Root cause:** After PR #1032 was merged, the release branch was force-reset, which discarded the merge commit. The fix was applied by cherry-picking the 4 original commits from the PR.

## Test plan
- [x] Cherry-pick applied cleanly with no conflicts
- [ ] Verify note renders correctly on the docs site
- [ ] Confirm note text accurately reflects current limitations

Closes (re-applies) #1032

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>

Closes #1172