### PR TITLE
ci: suppress CODEOWNERS auto-tagging on release-branch PRs

### DIFF
--- a/.github/workflows/suppress-codeowners-on-release.yml
+++ b/.github/workflows/suppress-codeowners-on-release.yml
@@ -1,0 +1,48 @@
+name: Suppress CODEOWNERS on release branches
+
+# Release branches are cut from `dev` and inherit its full CODEOWNERS map.
+# GitHub resolves code owners from a pull request's BASE branch, so any large
+# or cross-wired PR targeting a release branch auto-requests every doc team.
+# Emptying CODEOWNERS once, at branch creation, scopes code-owner auto-requests
+# to PRs targeting `dev` (where the full ownership map lives).
+on:
+  create:
+
+permissions:
+  contents: write
+
+jobs:
+  empty-codeowners:
+    # The `create` event can't be ref-filtered in `on:`, so gate the job here.
+    if: github.event.ref_type == 'branch' && startsWith(github.event.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.ref }}
+
+      - name: Empty the CODEOWNERS file
+        run: |
+          mkdir -p .github
+          printf '%s\n' \
+            '# Intentionally empty on release branches.' \
+            '# GitHub resolves code owners from the PR base branch, so an empty' \
+            '# file here suppresses doc-team auto-tagging for PRs targeting this' \
+            '# release branch. The full ownership map lives on dev.' \
+            > .github/CODEOWNERS
+
+      - name: Commit and push if changed
+        env:
+          # Pass the ref through the environment rather than interpolating it
+          # into the shell (GitHub script-injection hardening).
+          TARGET_REF: ${{ github.event.ref }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if git diff --quiet -- .github/CODEOWNERS; then
+            echo 'CODEOWNERS already empty; nothing to do.'
+          else
+            git add .github/CODEOWNERS
+            git commit -m 'chore: empty CODEOWNERS on release branch (suppress doc-team auto-tagging)'
+            git push origin "HEAD:$TARGET_REF"
+          fi


### PR DESCRIPTION
## What

Adds `.github/workflows/suppress-codeowners-on-release.yml`, which empties `.github/CODEOWNERS` once on any newly created `release/*` branch.

## Why

GitHub resolves code owners from the **base branch** of a pull request. Release branches are cut from `dev` and inherit its full ownership map, so any large or cross-wired PR targeting a release branch auto-requests **every** doc team.

This recently happened on PR #1171 (`reapply-pr-1032-stateintime-note` → `release/auditor_10.9`): the branch fell ~243 commits behind, a sync temporarily ballooned its diff to 200+ files spanning every product, and all doc teams were tagged — even though the final merged diff was only 2 files.

Emptying CODEOWNERS on release branches scopes code-owner auto-requests to PRs targeting `dev`, where the full ownership map lives. (Code-owner auto-requests fire regardless of branch protection, so this per-branch CODEOWNERS file is the only native lever.)

## How

- Triggers on the `create` event, gated to `release/*` branches. The workflow must live on the default branch (`dev`) for `create` to fire it.
- Feature branches and `main` are untouched.
- The ref is passed via an env var (not interpolated into the shell) per GitHub's script-injection hardening guidance.
- Pushes use `GITHUB_TOKEN`, so they don't retrigger CI or loop.

## Follow-up (not in this PR)

The already-existing `release/auditor_10.9` needs a one-time empty-CODEOWNERS commit pushed directly to it — the Action only covers branches created from now on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)