### PR TITLE
NPS-D: update landing page to reflect 2.22 EOL

### DIFF
--- a/docs/privilegesecurediscovery/2.22/index.md
+++ b/docs/privilegesecurediscovery/2.22/index.md
@@ -17,18 +17,20 @@ lateral movement attacks, and significantly reducing an organization’s attack 
 
 NPS-D is available in two release lines:
 
-- **2.22** — Legacy release line, approaching end of support.
 - **26.03 and later** — Current release line, actively developed with new features delivered
   quarterly (26.03, 26.06, 26.09, and so on). This is the recommended line for all new and
   existing deployments.
+- **2.22** — Legacy release line. Version 2.22.13 is the final release in this line. The 2.22.x
+  line receives no further feature work, security updates, or dependency upgrades.
 
 This documentation covers both release lines. Where a feature or procedure applies only to a
 specific release, an inline note calls this out.
 
 :::note
-Netwrix recommends upgrading from 2.22 to the latest release to take advantage of new
-capabilities, including native Microsoft Entra ID integration, container-based deployment on
-standard Ubuntu machines, and continued active development. Contact your Netwrix account
-representative for upgrade guidance.
+The 2.22.x release line has reached end of life. Netwrix recommends upgrading to the latest
+release of NPS-D (26.06 or later) to receive security updates and new capabilities, including
+native Microsoft Entra ID integration, container-based deployment on standard Ubuntu machines,
+and continued active development. Customers requiring bug fixes or security updates must upgrade
+to the latest supported release. Contact your Netwrix account representative for upgrade guidance.
 :::
 

--- a/docs/privilegesecurediscovery/2.22/index.md
+++ b/docs/privilegesecurediscovery/2.22/index.md
@@ -6,9 +6,9 @@ sidebar_position: 1
 
 # Netwrix Privilege Secure for Discovery Documentation
 
-Netwrix Privilege Secure for Discovery (formerly Remediant SecureONE) enables IT administrators
-and security analysts to have dynamic and continuous visibility into their organization’s privileged
-accounts and manage them from a single interface. Users then self-administer privilege access,
+Netwrix Privilege Secure for Discovery (formerly Remediant SecureONE) gives IT administrators
+and security analysts dynamic and continuous visibility into their organization’s privileged
+accounts and lets them manage those accounts from a single interface. Users then self-administer privilege access,
 getting access to only the right resource, at the right moment and for as long as they
 need to complete their job. This approach eliminates standing privileges, effectively preventing
 lateral movement attacks, and significantly reducing an organization’s attack surface.
@@ -17,8 +17,8 @@ lateral movement attacks, and significantly reducing an organization’s attack 
 
 NPS-D is available in two release lines:
 
-- **26.03 and later** — Current release line, actively developed with new features delivered
-  quarterly (26.03, 26.06, 26.09, and so on). This is the recommended line for all new and
+- **26.03 and later** — Current release line that Netwrix actively develops, delivering new
+  features quarterly (26.03, 26.06, 26.09, and so on). This is the recommended line for all new and
   existing deployments.
 - **2.22** — Legacy release line. Version 2.22.13 is the final release in this line. The 2.22.x
   line receives no further feature work, security updates, or dependency upgrades.


### PR DESCRIPTION
## Summary

- Updated NPS-D landing page (index.md) to reflect 2.22.x end of life
- Reordered release lines: current line (26.03+) now listed first
- 2.22 entry updated: version 2.22.13 is the final release, no further feature work, security updates, or dependency upgrades
- Upgrade note changed from `:::note` to `:::note` with updated wording confirming EOL status

## Test plan

- [ ] Verify landing page renders correctly
- [ ] Confirm build passes

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>