### PR TITLE
Removed Drain nodes instructions and enhance clarity in update OS doc…

### DIFF
--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -12,7 +12,7 @@ Update Privilege Secure OS on Appliances
 
 The best practice for installing Privilege Secure OS updates is to do so during a scheduled
 maintenance window. For a 3-node clustered NPSD deployment a failover is optional. During that change window, 
-the below high level steps are to be completed. This prevents a potential issue should an
+complete the following high-level steps. This prevents a potential issue should an
 update require a reboot of the server or Docker service.
 
 There are different options to fit your environment or downtime tolerance.
@@ -55,15 +55,15 @@ SSH to the node being updated
 docker --version
 ```
 
-**NOTE: Ensure it is not at/above the 29.x.x versions.**
+**NOTE: Ensure it isn't at/above the 29.x.x versions.**
 
-**Step 2 –** On each node, confirm that below 3 Docker packages have a hold placed on them.
+**Step 2 –** On each node, confirm that the following 3 Docker packages have a hold on them.
 ```
 sudo apt-mark showhold
 ```
 If the command doesn't return any results, then go to Step 3.
 
-**Step 3 –** Run the command below to add the packages to the holds list.
+**Step 3 –** Run the following command to add the packages to the holds list.
 ```
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 ```
@@ -134,21 +134,21 @@ s1 status; s1 node
 s1 status; s1 nodes
 ```
 
-**Step 2 –** Confirm the Docker version on each node, with the below command.
+**Step 2 –** Confirm the Docker version on each node, with the following command.
 ```
 docker --version
 ```
 
-**Note: Make sure it is not at/above the 29.x.x versions.**
+**Note: ensure it isn't at/above the 29.x.x versions.**
 
-**Step 3 –** On each node, confirm that below 3 Docker packages have a hold placed on them via the command.
+**Step 3 –** On each node, confirm that the following 3 Docker packages have a hold on them via the command.
 ```
 sudo apt-mark showhold
 ```
 
 If the command doesn't return any results, then go to Step 3.
 
-**Step 4 –** Run the command below to add the packages to the holds list.
+**Step 4 –** Run the following command to add the packages to the holds list.
 ```
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 ```

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -59,7 +59,7 @@ proceed with the update; contact Netwrix support before continuing.
 ```
 sudo apt-mark showhold
 ```
-If the command doesn't return any results, then go to Step 3.
+If the command doesn't return any results, go to Step 3.
 
 **Step 3 –** Run the following command to add the packages to the holds list.
 ```
@@ -147,7 +147,7 @@ proceed with the update; contact Netwrix support before continuing.
 sudo apt-mark showhold
 ```
 
-If the command doesn't return any results, then go to Step 4.
+If the command doesn't return any results, go to Step 4.
 
 **Step 4 –** Run the following command to add the packages to the holds list.
 ```

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -6,7 +6,7 @@ sidebar_position: 40
 
 # Update Privilege Secure OS on Appliances
 
-The best practice for installing Privilege Secure OS updates is to do so during a scheduled
+As a best practice, install Privilege Secure OS updates during a scheduled
 maintenance window. This prevents a potential issue should an
 update require a reboot of the server or Docker service.
 
@@ -118,7 +118,7 @@ sudo cat /var/run/reboot-required
 s1 status; s1 nodes
 ```
 
-**Step 9 –** Move on to the next node.
+**Step 9 –** Proceed to the next node.
 
 **Step 10 –** After all nodes completed, check Privilege Secure services and nodes status:
 

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -6,10 +6,6 @@ sidebar_position: 40
 
 # Update Privilege Secure OS on Appliances
 
-Update Privilege Secure OS on Appliances
-
-# Update Privilege Secure OS on Appliances
-
 The best practice for installing Privilege Secure OS updates is to do so during a scheduled
 maintenance window. This prevents a potential issue should an
 update require a reboot of the server or Docker service.
@@ -27,7 +23,7 @@ Privilege Secure will be offline for 30-60 minutes.
 - 30-60 minute scheduled maintenance window with expected downtime
 - [Install the S1 CLI Helper Utility ](../../installation/s1clihelperutility.md)
 
-## Use Case: Cluster In-Place (1 node at a Time, No Downtime)
+## Use Case: Cluster In-Place (1 Node at a Time, No Downtime)
 
 For a 3-node clustered Netwrix Privilege Secure Discovery (NPSD) deployment, a failover is optional.
 Complete the following high-level steps during the change window.
@@ -36,10 +32,7 @@ Check DB replication status, "stateStr" should be "PRIMARY" or "SECONDARY"; and 
 difference, a few seconds is acceptable:
 
 ```
-mEvl="sudo docker exec -it $(sudo docker ps | grep mongo | cut -d' ' -f1) mongo SecureONESecureONE --quiet --eval"; $mEvl 'rs.status()' | grep "name\|stateStr\|lastHeartbeatRecv\|
-\|lastHeartbeatMessage" | column -t; echo; $mEvl 'rs.printSlaveReplicationInfo()'; unset
-mEvl
-
+mEvl="sudo docker exec -it $(sudo docker ps | grep mongo | cut -d' ' -f1) mongo SecureONE --quiet --eval"; $mEvl 'rs.status()' | grep "name\|stateStr\|lastHeartbeatRecv\|lastHeartbeatMessage" | column -t; echo; $mEvl 'rs.printSlaveReplicationInfo()'; unset mEvl
 ```
 
 **NOTE:** If the database replication isn't in a healthy state, resolve that before continuing.
@@ -50,7 +43,7 @@ Primary node only: Check Privilege Secure services and nodes status:
 s1 status; s1 nodes
 ```
 
-SSH to the node being updated
+SSH to the node being updated.
 
 **Step 1 –** Confirm the Docker version on each node.
 ```
@@ -62,7 +55,7 @@ Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or 
 proceed with the update; contact Netwrix support before continuing.
 :::
 
-**Step 2 –** On each node, confirm that the following 3 Docker packages have a hold on them.
+**Step 2 –** On each node, confirm that the following three Docker packages have a hold on them.
 ```
 sudo apt-mark showhold
 ```
@@ -72,8 +65,8 @@ If the command doesn't return any results, then go to Step 3.
 ```
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 ```
-  
-**Step 4 –** Download Update Package Information.
+
+**Step 4 –** Download update package information.
 ```
 sudo apt update; sudo apt list --upgradable
 ```
@@ -122,7 +115,7 @@ sudo cat /var/run/reboot-required
 **Step 8 –** Check Privilege Secure services and nodes status.
 
 ```
-s1 status; s1 node
+s1 status; s1 nodes
 ```
 
 **Step 9 –** Move on to the next node.
@@ -133,13 +126,13 @@ s1 status; s1 node
 
 ## Use Case: Single-Node (Downtime During Reboot)
 
-**Step 1 –** Check Privilege Secure services and nodes' status.
+**Step 1 –** Check Privilege Secure services and nodes status.
 
 ```
 s1 status; s1 nodes
 ```
 
-**Step 2 –** Confirm the Docker version on the node, with the following command.
+**Step 2 –** Confirm the Docker version on the node.
 ```
 docker --version
 ```
@@ -149,7 +142,7 @@ Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or 
 proceed with the update; contact Netwrix support before continuing.
 :::
 
-**Step 3 –** On the node, confirm that the following 3 Docker packages have a hold on them via the command.
+**Step 3 –** On the node, confirm that the following three Docker packages have a hold on them.
 ```
 sudo apt-mark showhold
 ```
@@ -160,8 +153,8 @@ If the command doesn't return any results, then go to Step 4.
 ```
 sudo apt-mark hold docker-ce docker-ce-cli containerd.io
 ```
-  
-**Step 5 –** Download Update Package Information.
+
+**Step 5 –** Download update package information.
 ```
 sudo apt update; sudo apt list --upgradable
 ```
@@ -170,8 +163,8 @@ sudo apt update; sudo apt list --upgradable
 ```
 sudo apt -y upgrade
 ```
-- If prompted to replace a configuration file or setting, always use the option to keep the existing
-  configurations, setting, or file.
+**NOTE:** If prompted to replace a configuration file or setting, always use the option to keep the
+existing configurations, settings, or files.
 
 **Step 7 –** Reboot if required.
 
@@ -182,7 +175,7 @@ sudo cat /var/run/reboot-required
 - Result if reboot is required:  "\*\*\* System restart required \*\*\*"
 - Result if reboot not required:  "cat: /var/run/reboot-required: No such file or directory"
 - If required, reboot node.
-    
+
 ```
 sudo reboot
 ```

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -11,8 +11,7 @@ Update Privilege Secure OS on Appliances
 # Update Privilege Secure OS on Appliances
 
 The best practice for installing Privilege Secure OS updates is to do so during a scheduled
-maintenance window. For a 3-node clustered NPSD deployment a failover is optional. During that change window, 
-complete the following high-level steps. This prevents a potential issue should an
+maintenance window. This prevents a potential issue should an
 update require a reboot of the server or Docker service.
 
 There are different options to fit your environment or downtime tolerance.
@@ -29,6 +28,9 @@ Privilege Secure will be offline for 30-60 minutes.
 - [Install the S1 CLI Helper Utility ](../../installation/s1clihelperutility.md)
 
 ## Use Case: Cluster In-Place (1 node at a Time, No Downtime)
+
+For a 3-node clustered Netwrix Privilege Secure Discovery (NPSD) deployment, a failover is optional.
+Complete the high-level steps below during the change window.
 
 Check DB replication status, "stateStr" should be "PRIMARY" or "SECONDARY"; and replication time
 difference, a few seconds is acceptable:
@@ -55,7 +57,10 @@ SSH to the node being updated
 docker --version
 ```
 
-**NOTE: Ensure it isn't at/above the 29.x.x versions.**
+:::note
+Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or higher, do not
+proceed with the update; contact Netwrix support before continuing.
+:::
 
 **Step 2 –** On each node, confirm that the following 3 Docker packages have a hold on them.
 ```
@@ -70,10 +75,10 @@ sudo apt-mark hold docker-ce docker-ce-cli containerd.io
   
 **Step 4 –** Download Update Package Information.
 ```
-sudo apt update; sudp apt list --upgradable
+sudo apt update; sudo apt list --upgradable
 ```
 
-**Step 5 –** Install Package Updates.
+**Step 5 –** Install package updates.
 
 ```
 sudo apt -y upgrade
@@ -134,19 +139,22 @@ s1 status; s1 node
 s1 status; s1 nodes
 ```
 
-**Step 2 –** Confirm the Docker version on each node, with the following command.
+**Step 2 –** Confirm the Docker version on the node, with the following command.
 ```
 docker --version
 ```
 
-**Note: ensure it isn't at/above the 29.x.x versions.**
+:::note
+Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or higher, do not
+proceed with the update; contact Netwrix support before continuing.
+:::
 
-**Step 3 –** On each node, confirm that the following 3 Docker packages have a hold on them via the command.
+**Step 3 –** On the node, confirm that the following 3 Docker packages have a hold on them via the command.
 ```
 sudo apt-mark showhold
 ```
 
-If the command doesn't return any results, then go to Step 3.
+If the command doesn't return any results, then go to Step 4.
 
 **Step 4 –** Run the following command to add the packages to the holds list.
 ```
@@ -155,7 +163,7 @@ sudo apt-mark hold docker-ce docker-ce-cli containerd.io
   
 **Step 5 –** Download Update Package Information.
 ```
-sudo apt update; sudp apt list --upgradable
+sudo apt update; sudo apt list --upgradable
 ```
 
 **Step 6 –** Install package updates.

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -11,7 +11,8 @@ Update Privilege Secure OS on Appliances
 # Update Privilege Secure OS on Appliances
 
 The best practice for installing Privilege Secure OS updates is to do so during a scheduled
-maintenance window, and with all services scaled down. This prevents potential issue should an
+maintenance window. For a 3-node clustered NPSD deployment a failover is optional. During that change window, 
+the below high level steps are to be completed. This prevents a potential issue should an
 update require a reboot of the server or Docker service.
 
 There are different options to fit your environment or downtime tolerance.
@@ -24,7 +25,7 @@ Privilege Secure will be offline for 30-60 minutes.
 
 ## Requirements
 
-- 30-60 minute scheduled maintenance window with expected downtim
+- 30-60 minute scheduled maintenance window with expected downtime
 - [Install the S1 CLI Helper Utility ](../../installation/s1clihelperutility.md)
 
 ## Use Case: Cluster In-Place (1 node at a Time, No Downtime)
@@ -39,7 +40,7 @@ mEvl
 
 ```
 
-**NOTE:** If the database replication isn't in healthy state, resolve that before continuing.
+**NOTE:** If the database replication isn't in a healthy state, resolve that before continuing.
 
 Primary node only: Check Privilege Secure services and nodes status:
 
@@ -47,120 +48,138 @@ Primary node only: Check Privilege Secure services and nodes status:
 s1 status; s1 nodes
 ```
 
-Check for the swarm leader:
-
-```
-s1 nodes | grep Leader
-```
-
-Only if the node being updated has a MANAGER STATUS of leader, run the following command on a
-different node to change the swarm Leader, replacing `<hostname>` with the hostname of the node
-being upgraded:
-
-```
-HNupg=`<hostname>` ;  sudo docker node demote $HNupg; sleep 10; sudo docker node promote $HNupg
-```
-
-Verify swarm leader is no longer the node being updated:
-
-```
-s1 nodes | grep Leader
-
-```
-
-Process one node completely before moving on to another node:
-
-List nodes with:
-
-- s1 nodes
-
-Drain node to be updated:
-
-- sudo docker node update --availability drain `<hostname>`
-
-Verify "Availability" is set to "Drain" with:
-
-- s1 nodes
-
 SSH to the node being updated
 
-**Step 1 –** Download Update Package Information.
+**Step 1 –** Confirm the Docker version on each node.
+```
+docker --version
+```
 
-- sudo apt update
+**NOTE: Ensure it is not at/above the 29.x.x versions.**
 
-**Step 2 –** Install package updates.
+**Step 2 –** On each node, confirm that below 3 Docker packages have a hold placed on them.
+```
+sudo apt-mark showhold
+```
+If the command doesn't return any results, then go to Step 3.
 
-- sudo apt -y upgrade
+**Step 3 –** Run the command below to add the packages to the holds list.
+```
+sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+```
+  
+**Step 4 –** Download Update Package Information.
+```
+sudo apt update; sudp apt list --upgradable
+```
+
+**Step 5 –** Install Package Updates.
+
+```
+sudo apt -y upgrade
+```
 
 **NOTE:** If prompted to replace a configuration file or setting, always use the option to keep the
-existing configurations, setting, or file.
+existing configurations, settings, or files.
 
-**Step 3 –** Reboot if required.
+**Step 6 –** Reboot if required.
 
-- sudo cat /var/run/reboot-required
+```
+sudo cat /var/run/reboot-required
+```
+
 - Result if reboot is required:  "\*\*\* System restart required \*\*\*"
 - Result if reboot not required:  "cat: /var/run/reboot-required: No such file or directory"
-- If required, reboot node:
+- If required, reboot node.
 
-    - sudo reboot
 
-**Step 4 –** Once reboot has started, return to the other node. S
+  ```
+  sudo reboot
+  ```
 
-- Set drained node to active from a different node:
+**Step 7 –** Once reboot has started, return to the other node.
 
-    - sudo docker node update --availability active `<hostname>`
+- Monitor for the node to complete rebooting with.
 
-- Monitor for the node to complete rebooting with:
+  ```
+  watch s1 nodes
+  ```
 
-    - watch s1 nodes
-
-        - Verify "Availability" is set to "Active" on updated node.
+  - Verify "Availability" is set to "Active" on updated node.
 
 - After the updated node is reachable, press Ctrl+C to stop the watch command
 - Check DB replication status, "stateStr" should be "PRIMARY" or "SECONDARY"; and replication time
   difference, a few seconds is acceptable:
-- ```
+  ```
   mEvl="sudo docker exec -it $(sudo docker ps | grep mongo | cut -d' ' -f1) mongo SecureONE --quiet --eval"; $mEvl 'rs.status()' | grep "name\|stateStr\|lastHeartbeatRecv\|lastHeartbeatMessage" | column -t; echo; $mEvl 'rs.printSlaveReplicationInfo()'; unset mEvl
   ```
 
-**Step 5 –** Check Privilege Secure services and nodes status:
+**Step 8 –** Check Privilege Secure services and nodes status.
 
-- s1 status; s1 node
+```
+s1 status; s1 node
+```
 
-**Step 6 –** Move on to next node.
+**Step 9 –** Move on to the next node.
 
-**Step 7 –** After all nodes completed, check Privilege Secure services and nodes status:
+**Step 10 –** After all nodes completed, check Privilege Secure services and nodes status:
 
 - s1 status; s1 nodes
 
 ## Use Case: Single-Node (Downtime During Reboot)
 
-**Step 1 –** Check Privilege Secure services and nodes status.
+**Step 1 –** Check Privilege Secure services and nodes' status.
 
-- s1 status; s1 nodes
+```
+s1 status; s1 nodes
+```
 
-**Step 2 –** Download Update Package Information.
+**Step 2 –** Confirm the Docker version on each node, with the below command.
+```
+docker --version
+```
 
-- sudo apt update
+**Note: Make sure it is not at/above the 29.x.x versions.**
 
-**Step 3 –** Install package updates.
+**Step 3 –** On each node, confirm that below 3 Docker packages have a hold placed on them via the command.
+```
+sudo apt-mark showhold
+```
 
-- sudo apt -y upgrade
+If the command doesn't return any results, then go to Step 3.
 
+**Step 4 –** Run the command below to add the packages to the holds list.
+```
+sudo apt-mark hold docker-ce docker-ce-cli containerd.io
+```
+  
+**Step 5 –** Download Update Package Information.
+```
+sudo apt update; sudp apt list --upgradable
+```
+
+**Step 6 –** Install package updates.
+```
+sudo apt -y upgrade
+```
 - If prompted to replace a configuration file or setting, always use the option to keep the existing
   configurations, setting, or file.
 
-**Step 4 –** Reboot if required.
+**Step 7 –** Reboot if required.
 
-- sudo cat /var/run/reboot-required
+```
+sudo cat /var/run/reboot-required
+```
 
-    - Result if reboot is required:  "\*\*\* System restart required \*\*\*"
-    - Result if reboot not required:  "cat: /var/run/reboot-required: No such file or directory"
-    - If required, reboot node:
+- Result if reboot is required:  "\*\*\* System restart required \*\*\*"
+- Result if reboot not required:  "cat: /var/run/reboot-required: No such file or directory"
+- If required, reboot node.
+    
+```
+sudo reboot
+```
 
-        - sudo reboot
-
-**Step 5 –** After reboot complete, log in and check Privilege Secure services and nodes status:
+**Step 8 –** After reboot complete, log in and check Privilege Secure services and nodes status:
 
 - s1 status; s1 nodes
 

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -30,7 +30,7 @@ Privilege Secure will be offline for 30-60 minutes.
 ## Use Case: Cluster In-Place (1 node at a Time, No Downtime)
 
 For a 3-node clustered Netwrix Privilege Secure Discovery (NPSD) deployment, a failover is optional.
-Complete the high-level steps below during the change window.
+Complete the following high-level steps during the change window.
 
 Check DB replication status, "stateStr" should be "PRIMARY" or "SECONDARY"; and replication time
 difference, a few seconds is acceptable:
@@ -58,7 +58,7 @@ docker --version
 ```
 
 :::note
-Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or higher, do not
+Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or higher, don't
 proceed with the update; contact Netwrix support before continuing.
 :::
 
@@ -145,7 +145,7 @@ docker --version
 ```
 
 :::note
-Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or higher, do not
+Ensure the Docker version isn't at or above 29.x.x. If the version is 29.x.x or higher, don't
 proceed with the update; contact Netwrix support before continuing.
 :::
 

--- a/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
+++ b/docs/privilegesecurediscovery/2.22/administration/onpremmaintenance/updateosonappliances.md
@@ -15,7 +15,7 @@ There are different options to fit your environment or downtime tolerance.
 - Cluster:  No downtime
 - Single-Node:  Downtime during reboot
 
-This is a guide to updating the OS on Privilege Secure node with that best practice in mind.
+This guide explains how to update the OS on a Privilege Secure node using this best practice.
 Privilege Secure will be offline for 30-60 minutes.
 
 ## Requirements
@@ -43,7 +43,7 @@ Primary node only: Check Privilege Secure services and nodes status:
 s1 status; s1 nodes
 ```
 
-SSH to the node being updated.
+SSH to the node you're updating.
 
 **Step 1 –** Confirm the Docker version on each node.
 ```
@@ -103,7 +103,7 @@ sudo cat /var/run/reboot-required
   watch s1 nodes
   ```
 
-  - Verify "Availability" is set to "Active" on updated node.
+  - Verify that "Availability" shows "Active" on the updated node.
 
 - After the updated node is reachable, press Ctrl+C to stop the watch command
 - Check DB replication status, "stateStr" should be "PRIMARY" or "SECONDARY"; and replication time


### PR DESCRIPTION
…umentation

Removed Drain nodes instructions as node drain and changing of manager node is not required to apply OS updates. This can cause instability in environment and result in P1 issue. 

Also improved clarity in the update OS documentation for appliances.