### PR TITLE
docs(activitymonitor): document Dell permission-change reporting limitation

### DIFF
--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellcelerravnx.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellcelerravnx.md
@@ -74,7 +74,7 @@ Operations** to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellcelerravnx.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellcelerravnx.md
@@ -73,6 +73,12 @@ can be monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerscale.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerscale.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/10.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Isilon/PowerScale host to the Activity Monitor, the prerequisites for the
+Before adding a Dell Isilon/PowerScale host to the Activity Monitor, the prerequisites for the
 target environment must be met. See the
 [Dell Isilon/PowerScale Activity Auditing Configuration](/docs/activitymonitor/10.0/requirements/activityagent/nas-device-configuration/isilon-powerscale-aac/isilon-activity.md)
 topic for additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell Isilon/PowerScale Host
 
-Follow the steps to add a Dell Isilon/PowerScale host to be monitored.
+To add a Dell Isilon/PowerScale host to be monitored, complete the following steps:
 
 **Step 1 –** Navigate to the Monitored Hosts & Services tab and click Add. The Add New Host window opens.
 
@@ -59,7 +59,7 @@ left blank to collect activity from the Isilon cluster. If desired, add a **Comm
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/10.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -68,11 +68,11 @@ machine, manual configuration is required. See the
 
 ![Isilon Options page](/images/activitymonitor/9.0/admin/monitoredhosts/add/isilonoptions.webp)
 
-**Step 4 –** On the Isilon Options page, choose whether or not to automatically enable and configure
-auditing on the Isilon cluster. If a manual configuration has been completed, do not enable these
+**Step 4 –** On the Isilon Options page, choose whether to automatically enable and configure
+auditing on the Isilon cluster. If a manual configuration has been completed, don't enable these
 options.
 
-Follow these steps to use this automated option:
+To use this automated option:
 
 - Check the **Enable Protocol Access Auditing in OneFS if it is disabled** box.
 - Enter the User name and User password to connect to the OneFS Platform API.
@@ -90,8 +90,8 @@ Follow these steps to use this automated option:
       All activity for the host is collected and placed in a single activity log file per day.
     - If access zones are selected, only those access zones are monitored and the activity is placed
       in a single activity log file per day.
-        - Use the arrow buttons to move the desired access zones to the **Monitored** box.
-    - (_Optional_) Activity log files can be generated for each access zone. In order to generate
+        - Use the arrow buttons to move the access zones you want to the **Monitored** box.
+    - (_Optional_) Activity log files can be generated for each access zone. To generate
       one activity log file for each access zone, add only one access zone to this configuration of
       the monitored host. Then, add the host again for each access zone to be monitored. When adding
       an Isilon host for each access zone, the Dell device name will be the same for each
@@ -100,7 +100,7 @@ Follow these steps to use this automated option:
         :::note
         Although the Isilon Options page allows multiple access zones to be placed in the
         Monitored box for a single Isilon host, when generating separate activity log files for each
-        access zones, Access Analyzer does not support this configuration. Access Analyzer
+        access zones, Access Analyzer doesn't support this configuration. Access Analyzer
         integration requires all access zones to be monitored from a single configuration.
         :::
 
@@ -119,7 +119,7 @@ Operations** options to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -136,7 +136,7 @@ Click **Next**.
 ![Configure Basic Options](/images/activitymonitor/9.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 7 –** On the Configure Basic Options page, choose which settings to enable. The “Log files”
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -155,7 +155,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -198,19 +198,19 @@ Click **Next**.
 **Step 10 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/10.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -227,7 +227,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -246,13 +246,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -263,7 +263,7 @@ Click **Finish**.
 ![Activity Monitor with Dell Isilon added](/images/activitymonitor/9.0/admin/monitoredhosts/add/activitymonitoremcisilon.webp)
 
 The added Dell Isilon/PowerScale host is displayed in the monitored hosts/services table. Once a host has
-been added for monitoring, configure the desired outputs. See the
+been added for monitoring, configure the outputs you want. See the
 [Output for Monitored Hosts](/docs/activitymonitor/10.0/admin/monitoredhosts/output/output.md) topic for additional information.
 
 ## Host Properties for Dell Isilon/PowerScale

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerscale.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerscale.md
@@ -118,6 +118,12 @@ be monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** options to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerstore.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerstore.md
@@ -77,6 +77,12 @@ to be monitored.
 - Suppress reporting of File Explorer's excessive directory traversal activity – Filters out events
   of excessive directory traversal in File Explorer.
 
+:::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
 Click **Next**.
 
 ![powerstoreaddhost04](/images/activitymonitor/9.0/admin/monitoredhosts/add/powerstoreaddhost04.webp)

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerstore.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellpowerstore.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,12 +22,12 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/10.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell PowerStore host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell PowerStore host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell PowerStore Activity Auditing Configuration](/docs/activitymonitor/10.0/requirements/activityagent/nas-device-configuration/powerstore-aac/powerstore-activity.md)
 topic for additional information.
@@ -40,7 +40,7 @@ monitoring the target environment.
 
 ## Add Dell PowerStore Host
 
-Follow the steps to add a Dell PowerStore host to be monitored.
+To add a Dell PowerStore host to be monitored, complete the following steps:
 
 **Step 1 –** In Activity Monitor, go to the Monitored Hosts & Services tab and click **Add**. The Add New Host
 window opens.
@@ -57,7 +57,7 @@ name. Click **Next**.
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/10.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -79,7 +79,7 @@ to be monitored.
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -149,7 +149,7 @@ be configured.
 - Add header to Log files – Adds headers to TSV files. This is used to feed data into Splunk.
 
     :::note
-    Access Analyzer does not support log files with the header.
+    Access Analyzer doesn't support log files with the header.
     :::
 
 
@@ -160,25 +160,25 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the Where To Log The Activity page, the Syslog Output
 page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the textbox.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the **Message framing** drop-down menu. See the
+    The TCP and TLS protocols add the **Message framing** dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/10.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - The Test button sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -189,7 +189,7 @@ Click **Finish**.
 ![powerstoreaddhost08](/images/activitymonitor/9.0/admin/monitoredhosts/add/powerstoreaddhost08.webp)
 
 The added Dell PowerStore host is displayed in the monitored hosts/services table. Once a host has been added
-for monitoring, configure the desired outputs. See the [Output for Monitored Hosts](/docs/activitymonitor/10.0/admin/monitoredhosts/output/output.md)
+for monitoring, configure the outputs you want. See the [Output for Monitored Hosts](/docs/activitymonitor/10.0/admin/monitoredhosts/output/output.md)
 topic for additional information.
 
 ## Host Properties for Dell PowerStore

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellunity.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellunity.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/10.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Unity host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell Unity host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell Unity Activity Auditing Configuration](/docs/activitymonitor/10.0/requirements/activityagent/nas-device-configuration/unity-aac/unity-activity.md) topic for
 additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell VNX/Celerra Host
 
-Follow the steps to add a Dell Unity host to be monitored.
+To add a Dell Unity host to be monitored, complete the following steps:
 
 **Step 1 –** In Activity Monitor, go to the Monitored Hosts & Services tab and click Add. The Add New Host
 window opens.
@@ -57,7 +57,7 @@ Name** for the device. If desired, add a **Comment**. Click **Next**.
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/10.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -76,7 +76,7 @@ Operations** to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -93,7 +93,7 @@ Click **Next**.
 ![Configure Basic Options Page](/images/activitymonitor/9.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 6 –** On the Configure Basic Options page, choose which settings to enable. The “Log files”
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -112,7 +112,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -155,19 +155,19 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/10.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -184,7 +184,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -203,13 +203,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -220,7 +220,7 @@ Click **Finish**.
 ![Activity Monitor with Dell Unity host added](/images/activitymonitor/9.0/admin/monitoredhosts/add/activitymonitoremcunity.webp)
 
 The added Dell Unity host is displayed in the monitored hosts/service table. Once a host has been added for
-monitoring, configure the desired outputs. See the [Output for Monitored Hosts](/docs/activitymonitor/10.0/admin/monitoredhosts/output/output.md) topic
+monitoring, configure the outputs you want. See the [Output for Monitored Hosts](/docs/activitymonitor/10.0/admin/monitoredhosts/output/output.md) topic
 for additional information.
 
 ## Host Properties for Dell Unity

--- a/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellunity.md
+++ b/docs/activitymonitor/10.0/admin/monitoredhosts/add/dellunity.md
@@ -75,6 +75,12 @@ monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/10.0/admin/outputs/operations/operations.md
+++ b/docs/activitymonitor/10.0/admin/outputs/operations/operations.md
@@ -46,6 +46,37 @@ The table lists operations being monitored, displaying columns for Service, Cate
 Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
 Properties window closes.
 
+## For Dell Hosts
+
+The tab contains the following settings and features:
+
+- File Operations – Scope by file operation events: Add, Delete, Rename, Permission change, Read,
+  Update
+- Directory Operations – Scope by directory operation events: Add, Delete, Rename, Permission
+  change, Read / List
+- Suppress reporting of File Explorer's excessive directory traversal activity – When you open a
+  folder, Windows File Explorer tends to read all sub-folders to display proper icons and meta-data.
+  This activity occurs without the explicit intent of the user. This option tries to suppress such
+  automatic activity. It is only available when the Read / List option for Directory Operations is
+  selected.
+- Suppress reporting of File Explorer's excessive file read activity – When you open a folder,
+  Windows File Explorer tends to read files in the folder to display proper icons and meta-data.
+  This activity occurs without the explicit intent of the user. This option tries to suppress such
+  automatic activity. It is only available when the Read option for File Operations is selected.
+- Suppress Microsoft Office operations on temporary files – Filters out events for Microsoft Office
+  temporary files. When Microsoft Office files are saved or edited, many temporary files are
+  created. With this option enabled, events for these temporary files are ignored.
+- Suppress duplicate operations for [VALUE] seconds
+
+:::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
+Properties window closes.
+
 ## For Nasuni Hosts
 
 The tab contains the following settings and features:

--- a/docs/activitymonitor/10.0/admin/outputs/operations/operations.md
+++ b/docs/activitymonitor/10.0/admin/outputs/operations/operations.md
@@ -37,8 +37,8 @@ The tab contains the following settings and features:
 
 - Monitor Sign-Ins activity – Indicates if user sign-ins activity is monitored
 - Monitor Audit activity – Indicates if audit for all operations is monitored
-- Service – Filter the table by Service using the drop-down menu
-- Category – Filter the table by Category using the drop-down menu
+- Service – Filter the table by Service using the dropdown menu
+- Category – Filter the table by Category using the dropdown menu
 - Operation – Filter the table by Operation using the textbox
 
 The table lists operations being monitored, displaying columns for Service, Category, and Operation.
@@ -70,7 +70,7 @@ The tab contains the following settings and features:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -155,7 +155,7 @@ Properties window closes.
 
 ## For SharePoint Online Host
 
-The tab contains a subset of tabs. Each tab has a **Select All** check box to include all events for
+The tab contains a subset of tabs. Each tab has a **Select All** checkbox to include all events for
 that tab.
 
 ![Operations Tab for SharePoint Online Properties](/images/activitymonitor/9.0/admin/outputs/operationstab.webp)
@@ -372,4 +372,4 @@ The tab contains the following settings and features:
 Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
 Properties window closes.
 
-See[Suppress Windows Explorer Activity](/docs/activitymonitor/10.0/admin/outputs/operations/suppress.md) topic for more information.
+See the [Suppress Windows Explorer Activity](/docs/activitymonitor/10.0/admin/outputs/operations/suppress.md) topic for additional information.

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellcelerravnx.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellcelerravnx.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/8.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer (formerly Enterprise Auditor)
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Celerra or VNX host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell Celerra or VNX host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell Celerra & Dell VNX Activity Auditing Configuration](/docs/activitymonitor/8.0/requirements/activityagent/nas-device-configuration/celerra-vnx-aac/celerra-vnx-activity.md)
 topic for additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell VNX/Celerra Host
 
-Follow the steps to add a Dell Celerra or VNX host to be monitored.
+To add a Dell Celerra or VNX host to be monitored, complete the following steps:
 
 **Step 1 –** Navigate to the Monitored Hosts tab and click Add. The Add New Host window opens.
 
@@ -57,7 +57,7 @@ Server NetBIOS Name** for the device. If desired, add a **Comment**. Click **Nex
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/8.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -76,7 +76,7 @@ Operations** to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -93,7 +93,7 @@ Click **Next**.
 ![Configure Basic Options Page](/images/activitymonitor/8.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 6 –** On the Configure Basic Options page, choose which settings to enable. The "Log files"
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds 'C:\" to file paths to be displayed
@@ -112,7 +112,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -156,19 +156,19 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization's environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/8.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -185,7 +185,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds 'C:\" to file paths to be displayed
@@ -204,13 +204,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -221,7 +221,7 @@ Click **Finish**.
 ![activitymonitoremcvnxcelerra](/images/activitymonitor/8.0/admin/monitoredhosts/add/activitymonitoremcvnxcelerra.webp)
 
 The added Dell Celerra or VNX host is displayed in the Monitored Hosts table. Once a host has been
-added for monitoring, configure the desired ouptuts. See the
+added for monitoring, configure the outputs you want. See the
 [Output for Monitored Hosts](/docs/activitymonitor/8.0/admin/monitoredhosts/output/output.md) topic for additional information.
 
 ## Host Properties for Dell Celerra or VNX

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellcelerravnx.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellcelerravnx.md
@@ -75,6 +75,12 @@ can be monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerscale.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerscale.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/8.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer (formerly Enterprise Auditor)
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Isilon/PowerScale host to the Activity Monitor, the prerequisites for the
+Before adding a Dell Isilon/PowerScale host to the Activity Monitor, the prerequisites for the
 target environment must be met. See the
 [Dell Isilon/PowerScale Activity Auditing Configuration](/docs/activitymonitor/8.0/requirements/activityagent/nas-device-configuration/isilon-powerscale-aac/isilon-activity.md)
 topic for additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell Isilon/PowerScale Host
 
-Follow the steps to add a Dell Isilon/PowerScale host to be monitored.
+To add a Dell Isilon/PowerScale host to be monitored, complete the following steps:
 
 **Step 1 –** Navigate to the Monitored Hosts tab and click Add. The Add New Host window opens.
 
@@ -59,7 +59,7 @@ left blank to collect activity from the Isilon cluster. If desired, add a **Comm
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/8.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -68,11 +68,11 @@ machine, manual configuration is required. See the
 
 ![Isilon Options page](/images/activitymonitor/8.0/admin/monitoredhosts/add/isilonoptions.webp)
 
-**Step 4 –** On the Isilon Options page, choose whether or not to automatically enable and configure
-auditing on the Isilon cluster. If a manual configuration has been completed, do not enable these
+**Step 4 –** On the Isilon Options page, choose whether to automatically enable and configure
+auditing on the Isilon cluster. If a manual configuration has been completed, don't enable these
 options.
 
-Follow these steps to use this automated option:
+To use this automated option:
 
 - Check the **Enable Protocol Access Auditing in OneFS if it is disabled** box.
 - Enter the User name and User password to connect to the OneFS Platform API.
@@ -90,8 +90,8 @@ Follow these steps to use this automated option:
       All activity for the host is collected and placed in a single activity log file per day.
     - If access zones are selected, only those access zones are monitored and the activity is placed
       in a single activity log file per day.
-        - Use the arrow buttons to move the desired access zones to the **Monitored** box.
-    - (_Optional_) Activity log files can be generated for each access zone. In order to generate
+        - Use the arrow buttons to move the access zones you want to the **Monitored** box.
+    - (_Optional_) Activity log files can be generated for each access zone. To generate
       one activity log file for each access zone, add only one access zone to this configuration of
       the monitored host. Then, add the host again for each access zone to be monitored. When adding
       an Isilon host for each access zone, the Dell device name will be the same for each
@@ -100,7 +100,7 @@ Follow these steps to use this automated option:
         :::note
         Although the Isilon Options page allows multiple access zones to be placed in the
         Monitored box for a single Isilon host, when generating separate activity log files for each
-        access zones, Access Analyzer does not support this configuration. Access Analyzer
+        access zones, Access Analyzer doesn't support this configuration. Access Analyzer
         integration requires all access zones to be monitored from a single configuration.
         :::
 
@@ -119,7 +119,7 @@ Operations** options to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -136,7 +136,7 @@ Click **Next**.
 ![Configure Basic Options](/images/activitymonitor/8.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 7 –** On the Configure Basic Options page, choose which settings to enable. The “Log files”
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -155,7 +155,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -199,19 +199,19 @@ Click **Next**.
 **Step 10 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/8.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -228,7 +228,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -247,13 +247,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -264,7 +264,7 @@ Click **Finish**.
 ![Activity Monitor with Dell Isilon added](/images/activitymonitor/8.0/admin/monitoredhosts/add/activitymonitoremcisilon.webp)
 
 The added Dell Isilon/PowerScale host is displayed in the monitored hosts table. Once a host has
-been added for monitoring, configure the desired ouptuts. See the
+been added for monitoring, configure the outputs you want. See the
 [Output for Monitored Hosts](/docs/activitymonitor/8.0/admin/monitoredhosts/output/output.md) topic for additional information.
 
 ## Host Properties for Dell Isilon/PowerScale

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerscale.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerscale.md
@@ -118,6 +118,12 @@ be monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** options to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerstore.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerstore.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,12 +22,12 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/8.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell PowerStore host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell PowerStore host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell PowerStore Activity Auditing Configuration](/docs/activitymonitor/8.0/requirements/activityagent/nas-device-configuration/powerstore-aac/powerstore-activity.md)
 topic for additional information.
@@ -40,7 +40,7 @@ monitoring the target environment.
 
 ## Add Dell PowerStore Host
 
-Follow the steps to add a Dell PowerStore host to be monitored.
+To add a Dell PowerStore host to be monitored, complete the following steps:
 
 **Step 1 –** In Activity Monitor, go to the Monitored Hosts tab and click **Add**. The Add New Host
 window opens.
@@ -57,7 +57,7 @@ name. Click **Next**.
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/8.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -79,7 +79,7 @@ to be monitored.
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -149,7 +149,7 @@ be configured.
 - Add header to Log files – Adds headers to TSV files. This is used to feed data into Splunk.
 
     :::note
-    Access Analyzer does not support log files with the header.
+    Access Analyzer doesn't support log files with the header.
     :::
 
 
@@ -160,25 +160,25 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the Where To Log The Activity page, the Syslog Output
 page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the textbox.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the **Message framing** drop-down menu. See the
+    The TCP and TLS protocols add the **Message framing** dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/8.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - The Test button sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -189,7 +189,7 @@ Click **Finish**.
 ![powerstoreaddhost08](/images/activitymonitor/8.0/admin/monitoredhosts/add/powerstoreaddhost08.webp)
 
 The added Dell PowerStore host is displayed in the monitored hosts table. Once a host has been added
-for monitoring, configure the desired ouptuts. See the [Output for Monitored Hosts](/docs/activitymonitor/8.0/admin/monitoredhosts/output/output.md)
+for monitoring, configure the outputs you want. See the [Output for Monitored Hosts](/docs/activitymonitor/8.0/admin/monitoredhosts/output/output.md)
 topic for additional information.
 
 ## Host Properties for Dell PowerStore

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerstore.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellpowerstore.md
@@ -77,6 +77,12 @@ to be monitored.
 - Suppress reporting of File Explorer's excessive directory traversal activity – Filters out events
   of excessive directory traversal in File Explorer.
 
+:::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
 Click **Next**.
 
 ![powerstoreaddhost04](/images/activitymonitor/8.0/admin/monitoredhosts/add/powerstoreaddhost04.webp)

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellunity.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellunity.md
@@ -75,6 +75,12 @@ monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellunity.md
+++ b/docs/activitymonitor/8.0/admin/monitoredhosts/add/dellunity.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/8.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer (formerly Enterprise Auditor)
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Unity host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell Unity host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell Unity Activity Auditing Configuration](/docs/activitymonitor/8.0/requirements/activityagent/nas-device-configuration/unity-aac/unity-activity.md) topic for
 additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell VNX/Celerra Host
 
-Follow the steps to add a Dell Unity host to be monitored.
+To add a Dell Unity host to be monitored, complete the following steps:
 
 **Step 1 –** In Activity Monitor, go to the Monitored Hosts tab and click Add. The Add New Host
 window opens.
@@ -57,7 +57,7 @@ Name** for the device. If desired, add a **Comment**. Click **Next**.
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/8.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -76,7 +76,7 @@ Operations** to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -93,7 +93,7 @@ Click **Next**.
 ![Configure Basic Options Page](/images/activitymonitor/8.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 6 –** On the Configure Basic Options page, choose which settings to enable. The “Log files”
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -112,7 +112,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -156,19 +156,19 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/8.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -185,7 +185,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -204,13 +204,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -221,7 +221,7 @@ Click **Finish**.
 ![Activity Monitor with Dell Unity host added](/images/activitymonitor/8.0/admin/monitoredhosts/add/activitymonitoremcunity.webp)
 
 The added Dell Unity host is displayed in the monitored hosts table. Once a host has been added for
-monitoring, configure the desired ouptuts. See the [Output for Monitored Hosts](/docs/activitymonitor/8.0/admin/monitoredhosts/output/output.md) topic
+monitoring, configure the outputs you want. See the [Output for Monitored Hosts](/docs/activitymonitor/8.0/admin/monitoredhosts/output/output.md) topic
 for additional information.
 
 ## Host Properties for Dell Unity

--- a/docs/activitymonitor/8.0/admin/outputs/operations/operations.md
+++ b/docs/activitymonitor/8.0/admin/outputs/operations/operations.md
@@ -37,8 +37,8 @@ The tab contains the following settings and features:
 
 - Monitor Sign-Ins activity – Indicates if user sign-ins activity is monitored
 - Monitor Audit activity – Indicates if audit for all operations is monitored
-- Service – Filter the table by Service using the drop-down menu
-- Category – Filter the table by Category using the drop-down menu
+- Service – Filter the table by Service using the dropdown menu
+- Category – Filter the table by Category using the dropdown menu
 - Operation – Filter the table by Operation using the textbox
 
 The table lists operations being monitored, displaying columns for Service, Category, and Operation.
@@ -70,7 +70,7 @@ The tab contains the following settings and features:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -155,7 +155,7 @@ Properties window closes.
 
 ## For SharePoint Online Host
 
-The tab contains a subset of tabs. Each tab has a **Select All** check box to include all events for
+The tab contains a subset of tabs. Each tab has a **Select All** checkbox to include all events for
 that tab.
 
 ![Operations Tab for SharePoint Online Properties](/images/activitymonitor/8.0/admin/outputs/operationstab.webp)
@@ -372,4 +372,4 @@ The tab contains the following settings and features:
 Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
 Properties window closes.
 
-See[Suppress Windows Explorer Activity](/docs/activitymonitor/8.0/admin/outputs/operations/suppress.md) topic for more information.
+See the [Suppress Windows Explorer Activity](/docs/activitymonitor/8.0/admin/outputs/operations/suppress.md) topic for additional information.

--- a/docs/activitymonitor/8.0/admin/outputs/operations/operations.md
+++ b/docs/activitymonitor/8.0/admin/outputs/operations/operations.md
@@ -46,6 +46,37 @@ The table lists operations being monitored, displaying columns for Service, Cate
 Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
 Properties window closes.
 
+## For Dell Hosts
+
+The tab contains the following settings and features:
+
+- File Operations – Scope by file operation events: Add, Delete, Rename, Permission change, Read,
+  Update
+- Directory Operations – Scope by directory operation events: Add, Delete, Rename, Permission
+  change, Read / List
+- Suppress reporting of File Explorer's excessive directory traversal activity – When you open a
+  folder, Windows File Explorer tends to read all sub-folders to display proper icons and meta-data.
+  This activity occurs without the explicit intent of the user. This option tries to suppress such
+  automatic activity. It is only available when the Read / List option for Directory Operations is
+  selected.
+- Suppress reporting of File Explorer's excessive file read activity – When you open a folder,
+  Windows File Explorer tends to read files in the folder to display proper icons and meta-data.
+  This activity occurs without the explicit intent of the user. This option tries to suppress such
+  automatic activity. It is only available when the Read option for File Operations is selected.
+- Suppress Microsoft Office operations on temporary files – Filters out events for Microsoft Office
+  temporary files. When Microsoft Office files are saved or edited, many temporary files are
+  created. With this option enabled, events for these temporary files are ignored.
+- Suppress duplicate operations for [VALUE] seconds
+
+:::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
+Properties window closes.
+
 ## For Nasuni Hosts
 
 The tab contains the following settings and features:

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellcelerravnx.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellcelerravnx.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/9.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Celerra or VNX host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell Celerra or VNX host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell Celerra & Dell VNX Activity Auditing Configuration](/docs/activitymonitor/9.0/requirements/activityagent/nas-device-configuration/celerra-vnx-aac/celerra-vnx-activity.md)
 topic for additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell VNX/Celerra Host
 
-Follow the steps to add a Dell Celerra or VNX host to be monitored.
+To add a Dell Celerra or VNX host to be monitored, complete the following steps:
 
 **Step 1 –** Navigate to the Monitored Hosts & Services tab and click Add. The Add New Host window opens.
 
@@ -57,7 +57,7 @@ Server NetBIOS Name** for the device. If desired, add a **Comment**. Click **Nex
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/9.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -76,7 +76,7 @@ Operations** to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -93,7 +93,7 @@ Click **Next**.
 ![Configure Basic Options Page](/images/activitymonitor/9.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 6 –** On the Configure Basic Options page, choose which settings to enable. The "Log files"
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds 'C:\" to file paths to be displayed
@@ -112,7 +112,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -155,19 +155,19 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization's environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/9.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -184,7 +184,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds 'C:\" to file paths to be displayed
@@ -203,13 +203,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -220,7 +220,7 @@ Click **Finish**.
 ![activitymonitoremcvnxcelerra](/images/activitymonitor/9.0/admin/monitoredhosts/add/activitymonitoremcvnxcelerra.webp)
 
 The added Dell Celerra or VNX host is displayed in the Monitored Hosts & Services table. Once a host has been
-added for monitoring, configure the desired outputs. See the
+added for monitoring, configure the outputs you want. See the
 [Output for Monitored Hosts](/docs/activitymonitor/9.0/admin/monitoredhosts/output/output.md) topic for additional information.
 
 ## Host Properties for Dell Celerra or VNX

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellcelerravnx.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellcelerravnx.md
@@ -75,6 +75,12 @@ can be monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerscale.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerscale.md
@@ -118,6 +118,12 @@ be monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** options to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerscale.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerscale.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/9.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Isilon/PowerScale host to the Activity Monitor, the prerequisites for the
+Before adding a Dell Isilon/PowerScale host to the Activity Monitor, the prerequisites for the
 target environment must be met. See the
 [Dell Isilon/PowerScale Activity Auditing Configuration](/docs/activitymonitor/9.0/requirements/activityagent/nas-device-configuration/isilon-powerscale-aac/isilon-activity.md)
 topic for additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell Isilon/PowerScale Host
 
-Follow the steps to add a Dell Isilon/PowerScale host to be monitored.
+To add a Dell Isilon/PowerScale host to be monitored, complete the following steps:
 
 **Step 1 –** Navigate to the Monitored Hosts & Services tab and click Add. The Add New Host window opens.
 
@@ -59,7 +59,7 @@ left blank to collect activity from the Isilon cluster. If desired, add a **Comm
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/9.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -68,11 +68,11 @@ machine, manual configuration is required. See the
 
 ![Isilon Options page](/images/activitymonitor/9.0/admin/monitoredhosts/add/isilonoptions.webp)
 
-**Step 4 –** On the Isilon Options page, choose whether or not to automatically enable and configure
-auditing on the Isilon cluster. If a manual configuration has been completed, do not enable these
+**Step 4 –** On the Isilon Options page, choose whether to automatically enable and configure
+auditing on the Isilon cluster. If a manual configuration has been completed, don't enable these
 options.
 
-Follow these steps to use this automated option:
+To use this automated option:
 
 - Check the **Enable Protocol Access Auditing in OneFS if it is disabled** box.
 - Enter the User name and User password to connect to the OneFS Platform API.
@@ -90,8 +90,8 @@ Follow these steps to use this automated option:
       All activity for the host is collected and placed in a single activity log file per day.
     - If access zones are selected, only those access zones are monitored and the activity is placed
       in a single activity log file per day.
-        - Use the arrow buttons to move the desired access zones to the **Monitored** box.
-    - (_Optional_) Activity log files can be generated for each access zone. In order to generate
+        - Use the arrow buttons to move the access zones you want to the **Monitored** box.
+    - (_Optional_) Activity log files can be generated for each access zone. To generate
       one activity log file for each access zone, add only one access zone to this configuration of
       the monitored host. Then, add the host again for each access zone to be monitored. When adding
       an Isilon host for each access zone, the Dell device name will be the same for each
@@ -100,7 +100,7 @@ Follow these steps to use this automated option:
         :::note
         Although the Isilon Options page allows multiple access zones to be placed in the
         Monitored box for a single Isilon host, when generating separate activity log files for each
-        access zones, Access Analyzer does not support this configuration. Access Analyzer
+        access zones, Access Analyzer doesn't support this configuration. Access Analyzer
         integration requires all access zones to be monitored from a single configuration.
         :::
 
@@ -119,7 +119,7 @@ Operations** options to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -136,7 +136,7 @@ Click **Next**.
 ![Configure Basic Options](/images/activitymonitor/9.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 7 –** On the Configure Basic Options page, choose which settings to enable. The “Log files”
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -155,7 +155,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -198,19 +198,19 @@ Click **Next**.
 **Step 10 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/9.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -227,7 +227,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -246,13 +246,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -263,7 +263,7 @@ Click **Finish**.
 ![Activity Monitor with Dell Isilon added](/images/activitymonitor/9.0/admin/monitoredhosts/add/activitymonitoremcisilon.webp)
 
 The added Dell Isilon/PowerScale host is displayed in the monitored hosts/services table. Once a host has
-been added for monitoring, configure the desired outputs. See the
+been added for monitoring, configure the outputs you want. See the
 [Output for Monitored Hosts](/docs/activitymonitor/9.0/admin/monitoredhosts/output/output.md) topic for additional information.
 
 ## Host Properties for Dell Isilon/PowerScale

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerstore.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerstore.md
@@ -77,6 +77,12 @@ to be monitored.
 - Suppress reporting of File Explorer's excessive directory traversal activity – Filters out events
   of excessive directory traversal in File Explorer.
 
+:::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
 Click **Next**.
 
 ![powerstoreaddhost04](/images/activitymonitor/9.0/admin/monitoredhosts/add/powerstoreaddhost04.webp)

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerstore.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellpowerstore.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,12 +22,12 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/9.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell PowerStore host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell PowerStore host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell PowerStore Activity Auditing Configuration](/docs/activitymonitor/9.0/requirements/activityagent/nas-device-configuration/powerstore-aac/powerstore-activity.md)
 topic for additional information.
@@ -40,7 +40,7 @@ monitoring the target environment.
 
 ## Add Dell PowerStore Host
 
-Follow the steps to add a Dell PowerStore host to be monitored.
+To add a Dell PowerStore host to be monitored, complete the following steps:
 
 **Step 1 –** In Activity Monitor, go to the Monitored Hosts & Services tab and click **Add**. The Add New Host
 window opens.
@@ -57,7 +57,7 @@ name. Click **Next**.
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/9.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -79,7 +79,7 @@ to be monitored.
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -149,7 +149,7 @@ be configured.
 - Add header to Log files – Adds headers to TSV files. This is used to feed data into Splunk.
 
     :::note
-    Access Analyzer does not support log files with the header.
+    Access Analyzer doesn't support log files with the header.
     :::
 
 
@@ -160,25 +160,25 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the Where To Log The Activity page, the Syslog Output
 page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the textbox.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the **Message framing** drop-down menu. See the
+    The TCP and TLS protocols add the **Message framing** dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/9.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - The Test button sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -189,7 +189,7 @@ Click **Finish**.
 ![powerstoreaddhost08](/images/activitymonitor/9.0/admin/monitoredhosts/add/powerstoreaddhost08.webp)
 
 The added Dell PowerStore host is displayed in the monitored hosts/services table. Once a host has been added
-for monitoring, configure the desired outputs. See the [Output for Monitored Hosts](/docs/activitymonitor/9.0/admin/monitoredhosts/output/output.md)
+for monitoring, configure the outputs you want. See the [Output for Monitored Hosts](/docs/activitymonitor/9.0/admin/monitoredhosts/output/output.md)
 topic for additional information.
 
 ## Host Properties for Dell PowerStore

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellunity.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellunity.md
@@ -75,6 +75,12 @@ monitored are All, CIFS, or NIFS. Click **Next**.
 Operations** to be monitored. Additional options include:
 
 :::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+:::warning
 Suppress Microsoft Office operations on temporary files – Filters out events for
 Microsoft Office temporary files. When Microsoft Office files are saved or edited, many temporary
 files are created. With this option enabled, events for these temporary files are ignored. This

--- a/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellunity.md
+++ b/docs/activitymonitor/9.0/admin/monitoredhosts/add/dellunity.md
@@ -13,7 +13,7 @@ The Activity Monitor can be configured to monitor the following:
 - Ability to collect all or specific file activity for specific values or specific combinations of
   values
 
-It provides the ability to feed activity data to SIEM products. The following dashboards have been
+It lets you feed activity data to SIEM products. The following dashboards have been
 specifically created for Activity Monitor event data:
 
 - For IBM® QRadar®, see the
@@ -22,13 +22,13 @@ specifically created for Activity Monitor event data:
 - For Splunk®, see the [File Activity Monitor App for Splunk](/docs/activitymonitor/9.0/siem/splunk/overview.md) for
   additional information.
 
-It also provides the ability to feed activity data to other Netwrix products:
+It also lets you feed activity data to other Netwrix products:
 
 - Netwrix Access Analyzer
 - Netwrix Threat Prevention
 - Netwrix Threat Manager
 
-Prior to adding a Dell Unity host to the Activity Monitor, the prerequisites for the target
+Before adding a Dell Unity host to the Activity Monitor, the prerequisites for the target
 environment must be met. See the
 [Dell Unity Activity Auditing Configuration](/docs/activitymonitor/9.0/requirements/activityagent/nas-device-configuration/unity-aac/unity-activity.md) topic for
 additional information.
@@ -41,7 +41,7 @@ monitoring the target environment.
 
 ## Add Dell VNX/Celerra Host
 
-Follow the steps to add a Dell Unity host to be monitored.
+To add a Dell Unity host to be monitored, complete the following steps:
 
 **Step 1 –** In Activity Monitor, go to the Monitored Hosts & Services tab and click Add. The Add New Host
 window opens.
@@ -57,7 +57,7 @@ Name** for the device. If desired, add a **Comment**. Click **Next**.
 
 :::note
 All Dell event source types must have the CEE Monitor Service installed on the agent in
-order to collect events. Activity Monitor will detect if the CEE Monitor is not installed and
+order to collect events. Activity Monitor will detect if the CEE Monitor isn't installed and
 display a warning to install the service. If the CEE Monitor service is installed on a remote
 machine, manual configuration is required. See the
 [Dell CEE Options Tab](/docs/activitymonitor/9.0/admin/agents/properties/dellceeoptions.md) topic for additional information.
@@ -76,7 +76,7 @@ Operations** to be monitored. Additional options include:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -93,7 +93,7 @@ Click **Next**.
 ![Configure Basic Options Page](/images/activitymonitor/9.0/admin/monitoredhosts/add/configurebasicoptions.webp)
 
 **Step 6 –** On the Configure Basic Options page, choose which settings to enable. The “Log files”
-are the activity logs created by the activity agent on the proxy host. Select the desired options:
+are the activity logs created by the activity agent on the proxy host. Select the options you want:
 
 - Report account names – Adds an **Account Name** column in the generated TSV files
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -112,7 +112,7 @@ are the activity logs created by the activity agent on the proxy host. Select th
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - Report operations with millisecond precision – Changes the timestamps of events being recorded in
   the TSV log file for better ordering of events if multiple events occur within the same second
@@ -155,19 +155,19 @@ Click **Next**.
 **Step 9 –** If Syslog Server is selected on the **Where To Log The Activity** page, the Syslog
 Output page can be configured.
 
-- Syslog server in SERVER[:PORT] format – Type the **Syslog server name** with a SERVER:Port format
+- Syslog server in SERVER[:PORT] format – Enter the **Syslog server name** with a SERVER:Port format
   in the text box.
     - The server name can be short name, fully qualified name (FQDN), or IP Address, as long as the
       organization’s environment can resolve the name format used. The Event stream is the activity
       being monitored according to this configuration for the monitored host.
-- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The drop-down
+- Syslog Protocol – Identify the **Syslog protocol** to be used for the Event stream. The dropdown
   menu includes:
 
     - UDP
     - TCP
     - TLS
 
-    The TCP and TLS protocols add the Message framing drop-down menu. See the
+    The TCP and TLS protocols add the Message framing dropdown menu. See the
     [Syslog Tab](/docs/activitymonitor/9.0/admin/outputs/syslog/syslog.md) topic for additional information.
 
 - Syslog message template – Click the ellipsis (…) to open the Syslog Message Template window. The
@@ -184,7 +184,7 @@ Output page can be configured.
       template for Threat Manager. See the
       [Netwrix Threat Manager Documentation](https://helpcenter.netwrix.com/category/stealthdefend)
       for additional information.
-    - Custom templates can be created. Select the desired template or create a new template by
+    - Custom templates can be created. Select the template you want or create a new template by
       modifying an existing template within the Syslog Message Template window. The new message
       template will be named Custom.
 - Add C:\ to the beginning of the reported file paths – Adds ‘C:\” to file paths to be displayed
@@ -203,13 +203,13 @@ Output page can be configured.
       through the UNC Path. If a file is accessed locally, these columns are empty. These columns
       have also been added as Syslog macros.
     - When this option is selected, the user needs to provide credentials in the Auditing tab. If
-      credentials are not provided, the following warning message is displayed:
+      credentials aren't provided, the following warning message is displayed:
         - Credentials are required for this feature. Provide the credentials in the Auditing tab.
 - The Test button – Sends a test message to the Syslog server to check the connection. A green check
   mark or red will determine whether the test message has been sent or failed to send. Messages vary
   by Syslog protocol:
 
-    - UDP – Sends a test message and does not verify connection
+    - UDP – Sends a test message and doesn't verify connection
     - TCP/TLS – Sends test message and verifies connection
     - TLS – Shows error if TLS handshake fails
 
@@ -220,7 +220,7 @@ Click **Finish**.
 ![Activity Monitor with Dell Unity host added](/images/activitymonitor/9.0/admin/monitoredhosts/add/activitymonitoremcunity.webp)
 
 The added Dell Unity host is displayed in the monitored hosts/service table. Once a host has been added for
-monitoring, configure the desired outputs. See the [Output for Monitored Hosts](/docs/activitymonitor/9.0/admin/monitoredhosts/output/output.md) topic
+monitoring, configure the outputs you want. See the [Output for Monitored Hosts](/docs/activitymonitor/9.0/admin/monitoredhosts/output/output.md) topic
 for additional information.
 
 ## Host Properties for Dell Unity

--- a/docs/activitymonitor/9.0/admin/outputs/operations/operations.md
+++ b/docs/activitymonitor/9.0/admin/outputs/operations/operations.md
@@ -37,8 +37,8 @@ The tab contains the following settings and features:
 
 - Monitor Sign-Ins activity – Indicates if user sign-ins activity is monitored
 - Monitor Audit activity – Indicates if audit for all operations is monitored
-- Service – Filter the table by Service using the drop-down menu
-- Category – Filter the table by Category using the drop-down menu
+- Service – Filter the table by Service using the dropdown menu
+- Category – Filter the table by Category using the dropdown menu
 - Operation – Filter the table by Operation using the textbox
 
 The table lists operations being monitored, displaying columns for Service, Category, and Operation.
@@ -70,7 +70,7 @@ The tab contains the following settings and features:
 
 :::warning
 **Limitation: Permission Change details not available for Dell devices**
-For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+For Dell devices, Activity Monitor reports that a permission change occurred, but can't report the specifics of the change
 (e.g., which permissions were added or removed, owner changes, or inheritance changes).
 :::
 
@@ -155,7 +155,7 @@ Properties window closes.
 
 ## For SharePoint Online Host
 
-The tab contains a subset of tabs. Each tab has a **Select All** check box to include all events for
+The tab contains a subset of tabs. Each tab has a **Select All** checkbox to include all events for
 that tab.
 
 ![Operations Tab for SharePoint Online Properties](/images/activitymonitor/9.0/admin/outputs/operationstab.webp)
@@ -372,4 +372,4 @@ The tab contains the following settings and features:
 Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
 Properties window closes.
 
-See[Suppress Windows Explorer Activity](/docs/activitymonitor/9.0/admin/outputs/operations/suppress.md) topic for more information.
+See the [Suppress Windows Explorer Activity](/docs/activitymonitor/9.0/admin/outputs/operations/suppress.md) topic for additional information.

--- a/docs/activitymonitor/9.0/admin/outputs/operations/operations.md
+++ b/docs/activitymonitor/9.0/admin/outputs/operations/operations.md
@@ -46,6 +46,37 @@ The table lists operations being monitored, displaying columns for Service, Cate
 Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
 Properties window closes.
 
+## For Dell Hosts
+
+The tab contains the following settings and features:
+
+- File Operations – Scope by file operation events: Add, Delete, Rename, Permission change, Read,
+  Update
+- Directory Operations – Scope by directory operation events: Add, Delete, Rename, Permission
+  change, Read / List
+- Suppress reporting of File Explorer's excessive directory traversal activity – When you open a
+  folder, Windows File Explorer tends to read all sub-folders to display proper icons and meta-data.
+  This activity occurs without the explicit intent of the user. This option tries to suppress such
+  automatic activity. It is only available when the Read / List option for Directory Operations is
+  selected.
+- Suppress reporting of File Explorer's excessive file read activity – When you open a folder,
+  Windows File Explorer tends to read files in the folder to display proper icons and meta-data.
+  This activity occurs without the explicit intent of the user. This option tries to suppress such
+  automatic activity. It is only available when the Read option for File Operations is selected.
+- Suppress Microsoft Office operations on temporary files – Filters out events for Microsoft Office
+  temporary files. When Microsoft Office files are saved or edited, many temporary files are
+  created. With this option enabled, events for these temporary files are ignored.
+- Suppress duplicate operations for [VALUE] seconds
+
+:::warning
+**Limitation: Permission Change details not available for Dell devices**
+For Dell devices, Activity Monitor reports that a permission change occurred, but cannot report the specifics of the change
+(e.g., which permissions were added or removed, owner changes, or inheritance changes).
+:::
+
+Click **OK** to commit the modifications. Click **Cancel** to discard the modifications. The output
+Properties window closes.
+
 ## For Nasuni Hosts
 
 The tab contains the following settings and features:


### PR DESCRIPTION
Add a warning to the Dell host-add pages and Operations tab docs (8.0, 9.0, 10.0) noting that Activity Monitor can't report permission-change specifics (added/removed permissions, owner changes, inheritance) for Dell devices.
