### PR TITLE
fix(kb/changetracker): Batch 1 style fixes and 8.1→8.2 link cleanup

### DIFF
--- a/docs/kb/changetracker/audit-and-logging/corrupt-errorevent-in-event-reports.md
+++ b/docs/kb/changetracker/audit-and-logging/corrupt-errorevent-in-event-reports.md
@@ -29,7 +29,7 @@ knowledge_article_id: kA0Qk0000000ahpKAA
 ## Symptom
 
 - The events report in Netwrix Change Tracker contains one or more `ErrorEvent` events. Their description states `Corrupt`.
-- Agent logs (see [Rolling-Log File Location](/docs/changetracker/8_1/install/agent/rollinglogfile)) contain the following line:
+- Agent logs (see [Rolling-Log File Location](/docs/changetracker/8_2/install/agent/rollinglogfile)) contain the following line:
   - **Windows:** `C:\ProgramData\NNT\gen7agent.app.netcore\rolling-log.txt`
   - **Linux:** `/var/nnt/gen7agent.app.netcore/rolling-log.txt`
 
@@ -51,7 +51,7 @@ Perform an agent reset to reconfigure affected agents:
 
 1. Stop the Netwrix Change Tracker Agent Service.
 
-2. Navigate to the agent directory (see [Rolling-Log File Location](/docs/changetracker/8_1/install/agent/rollinglogfile)): `C:\ProgramData\NNT\gen7agent.app.netcore\`
+2. Navigate to the agent directory (see [Rolling-Log File Location](/docs/changetracker/8_2/install/agent/rollinglogfile)): `C:\ProgramData\NNT\gen7agent.app.netcore\`
 
 3. Right-click the `Hubdetails.xml` file and select **Edit**.
 
@@ -67,7 +67,7 @@ Perform an agent reset to reconfigure affected agents:
 service nntgen7agentcore stop
 ```
 
-2. Navigate to the agent directory (see [Rolling-Log File Location](/docs/changetracker/8_1/install/agent/rollinglogfile)): `/var/nnt/gen7agent.app.netcore/`
+2. Navigate to the agent directory (see [Rolling-Log File Location](/docs/changetracker/8_2/install/agent/rollinglogfile)): `/var/nnt/gen7agent.app.netcore/`
 
 3. Edit the `Hubdetails.xml` file.
 

--- a/docs/kb/changetracker/database-and-diagnostics/disk_space_occupied_by_core._files_in_gen_7_agent_servers.md
+++ b/docs/kb/changetracker/database-and-diagnostics/disk_space_occupied_by_core._files_in_gen_7_agent_servers.md
@@ -27,7 +27,7 @@ products:
 
 ## Question
 
-The `/opt/nnt/gen7agentcore/bin/` directory (see [Linux Agent Installation](/docs/changetracker/8_1/install/agent/linuxos)) in Gen 7 Agent servers (Linux) contains multiple `core.*` files.
+The `/opt/nnt/gen7agentcore/bin/` directory (see [Linux Agent Installation](/docs/changetracker/8_2/install/agent/linuxos)) in Gen 7 Agent servers (Linux) contains multiple `core.*` files.
 
 1. What are these files?
 2. Is it safe to delete these files?

--- a/docs/kb/changetracker/index.md
+++ b/docs/kb/changetracker/index.md
@@ -14,5 +14,5 @@ Use the search function above to find specific articles or browse through all Ch
 
 If you cannot find what you are looking for:
 1. Use the search function above
-2. Check the main [Change Tracker documentation](/docs/changetracker/8_1/)
+2. Check the main [Change Tracker documentation](/docs/changetracker/8_2/)
 3. Contact [Netwrix support](https://www.netwrix.com/support.html)

--- a/docs/kb/changetracker/troubleshooting-and-errors/certificate-thumbprint-mismatch.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/certificate-thumbprint-mismatch.md
@@ -5,12 +5,17 @@ keywords:
   - Netwrix Agent
   - certificate thumbprint
   - Hub Server
+  - IIS Certificate
+  - HubDetails.xml
+  - Netwrix Agent Service
+  - Hub Adapter
+  - trusted thumbprint
 sidebar_label: Certificate Thumbprint Mismatch
 tags: [kb, troubleshooting-and-errors]
 title: "Certificate Thumbprint Mismatch"
 knowledge_article_id: kA04u0000000JaGCAU
 products:
-  - change-tracker
+  - changetracker
 ---
 
 # Certificate Thumbprint Mismatch
@@ -19,11 +24,7 @@ products:
 
 The following error occurs when using a custom or unrecognized IIS Certificate:
 
-```
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-#                                                   Example Message:													  #
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
+```text
 2017-10-08 11:17:36,935 [Threadpool worker] ERROR NNT.Hub.ServiceClient.HubAdapter - Certificate thumbprint does not match trusted (BAD1067FBAB59CCED21786657C672F6AB5BE824C/6F7F11707C0C93CD0F7E92D5BC0F1C9345D68A64). Consider setting Thumbprint in HubDetails.xml. Server certificate details
 ```
 

--- a/docs/kb/changetracker/troubleshooting-and-errors/error-503-unable-to-access-change-tracker-login-screen.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/error-503-unable-to-access-change-tracker-login-screen.md
@@ -15,13 +15,13 @@ keywords:
   - 503 Service Unavailable
   - web application pool identity
 products:
-  - change-tracker
+  - changetracker
 sidebar_label: Error 503 — Unable to Access Login Screen
 tags:
   - kb
   - troubleshooting-and-errors
 title: "Error 503 — Unable to Access Change Tracker Login Screen"
-knowledge_article_id: ""
+knowledge_article_id: kA0Qk0000000LFlKAM
 ---
 
 # Error 503 — Unable to Access Change Tracker Login Screen
@@ -46,4 +46,5 @@ The Change Tracker web application pool is not running. The application pool may
 2. Locate the Change Tracker web application pool, right-click it, and select **Advanced Settings...**
 3. Under the **Process Model** section, locate the **Identity** node, select it, and click the ellipsis button.
 4. Click **Set...**, and specify new credentials for the account to run the application pool.
-5. Click **OK** > **OK** > **OK** to save changes. Right-click the pool and select **Start** to run it.
+5. Click **OK** > **OK** > **OK** to save changes.
+6. Right-click the pool and select **Start** to run it.


### PR DESCRIPTION
## Summary

Small follow-up covering 2 Batch 1 style fixes carried over from Batch 3a session review, plus a 3-file 8.1→8.2 link cleanup identified as still outstanding.

## Changes

- Removes ASCII banner from an example error message and tags the fenced code block as `text`
- Splits a combined save/start step into two distinct numbered steps
- Normalizes `products` field from `change-tracker` to the canonical `changetracker` ID on the two touched articles
- Expands a thin keyword list to meet the 8–12 minimum
- Populates a real `knowledge_article_id` that was previously empty
- Updates stale `/docs/changetracker/8_1/` links to `8_2` across 3 files

## Testing

- kb-pr-open (Vale + Dale + Derek): 0 Vale errors, Dale clean, Derek findings applied
- Local build: successful, no broken links or anchor errors

Closes #1218