### PR TITLE
fix(kb): repair invalid YAML front matter blocking Docusaurus 3.10.2 build

### DIFF
--- a/docs/kb/auditor/troubleshooting-and-errors/data-collection-errors/error-the-new-task-has-been-created-but-may-not-run-because-of-an-error-exception-from-hresult-0x800.md
+++ b/docs/kb/auditor/troubleshooting-and-errors/data-collection-errors/error-the-new-task-has-been-created-but-may-not-run-because-of-an-error-exception-from-hresult-0x800.md
@@ -15,7 +15,7 @@ products:
   - auditor
 sidebar_label: 'Error: "The new task has been created but may not '
 tags: []
-title: "Error: "The new task has been created but may not run because of an error:" Exception from HRESULT: 0x80070520.""
+title: 'Error: "The new task has been created but may not run because of an error: Exception from HRESULT: 0x80070520."'
 knowledge_article_id: kA00g000000H9ZBCA0
 ---
 


### PR DESCRIPTION
## What

Fixes invalid YAML in the `title` front matter of one KB article:

`docs/kb/auditor/troubleshooting-and-errors/data-collection-errors/error-the-new-task-has-been-created-but-may-not-run-because-of-an-error-exception-from-hresult-0x800.md`

```diff
-title: "Error: "The new task has been created but may not run because of an error:" Exception from HRESULT: 0x80070520.""
+title: 'Error: "The new task has been created but may not run because of an error: Exception from HRESULT: 0x80070520."'
```

The old value used unescaped nested double quotes, so the YAML parser terminated the string early and threw `bad indentation of a mapping entry`. The value is now single-quoted and matches the H1 exactly.

## Why

`@docusaurus/core` **3.10.2** replaced its front-matter parser (`@docusaurus/utils` switched from `gray-matter@^4.0.3` to the stricter `@11ty/gray-matter@^1.0.0`). The lenient parser on `dev` (3.10.1) tolerated this malformed value; the stricter one throws a fatal `YAMLException` that aborts the production build.

This is a **latent defect** already on `dev` — surfaced by Dependabot PR #1232 (Docusaurus 3.10.1 → 3.10.2). Once this merges, #1232 will pass on rebase, and any future Docusaurus bump won't break the `dev` → `main` sync/deploy on this file.

## Verification

- Strict `js-yaml` parse (the 3.10.2 path) now succeeds.
- `title` equals the H1 exactly (per KB frontmatter rule).
- This was the **only** strict-parser failure across all 22,812 `.md`/`.mdx` files under `docs/`.
- Pre-commit anchor-link check passed.

## Optional follow-ups (left out to keep this a single-purpose build fix)

- `tags: []` is missing the mandatory `kb` tag (`docs/kb/CLAUDE.md`).
- `sidebar_label` is truncated mid-word with a trailing space — valid YAML, just untidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1237