### PR TITLE
Add Change Tracker KB batch 4b

### DIFF
--- a/docs/kb/changetracker/configuration-and-setup/stop-blocking-ip-address.md
+++ b/docs/kb/changetracker/configuration-and-setup/stop-blocking-ip-address.md
@@ -27,11 +27,11 @@ title: Enabling Account Lockout for Failed Login Attempts
 
 This article describes how to configure Netwrix Change Tracker to lock a user account after repeated failed login attempts, instead of blocking the device's IP address.
 
-By default, if a user fails to log in three times from a remote device, Netwrix Change Tracker blocks that device's IP address. Setting `lockoutenabled` to `true` locks the account after repeated failed logins. (The relationship between account lockout and IP blocking has not yet been confirmed — see the SME Review Needed note in the pull request.)
+By default, if a user fails to log in three times from a remote device, Netwrix Change Tracker blocks that device's IP address. Setting `lockoutenabled` to `true` locks the account after repeated failed logins. [See the SME Review Needed note in the pull request description and confirm the relationship between account lockout and IP blocking.]
 
 ## Instructions
 
-1. Open a Command Prompt as an administrator and stop IIS:
+1. Open a **Command Prompt** as an administrator and stop IIS:
 
    ```bat
    iisreset /stop

--- a/docs/kb/changetracker/configuration-and-setup/stop-blocking-ip-address.md
+++ b/docs/kb/changetracker/configuration-and-setup/stop-blocking-ip-address.md
@@ -2,8 +2,8 @@
 description: >-
   Shows how to configure Netwrix Change Tracker to lock a user account after
   repeated failed login attempts, by setting lockoutenabled to true in
-  appsettings.json. By default, Change Tracker blocks the failing device's IP
-  address instead of locking the account.
+  appsettings.json. This overrides the previous IP-blocking behavior, which
+  is no longer used.
 keywords:
   - Netwrix Change Tracker
   - IP blocking
@@ -27,7 +27,7 @@ title: Enabling Account Lockout for Failed Login Attempts
 
 This article describes how to configure Netwrix Change Tracker to lock a user account after repeated failed login attempts, instead of blocking the device's IP address.
 
-By default, if a user fails to log in three times from a remote device, Netwrix Change Tracker blocks that device's IP address. Setting `lockoutenabled` to `true` locks the account after repeated failed logins. [See the SME Review Needed note in the pull request description and confirm the relationship between account lockout and IP blocking.]
+Netwrix Change Tracker no longer uses IP blocking. Setting `lockoutenabled` to `true` locks the user account instead after repeated failed logins.
 
 ## Instructions
 

--- a/docs/kb/changetracker/configuration-and-setup/stop-blocking-ip-address.md
+++ b/docs/kb/changetracker/configuration-and-setup/stop-blocking-ip-address.md
@@ -1,0 +1,66 @@
+---
+description: >-
+  Shows how to configure Netwrix Change Tracker to lock a user account after
+  repeated failed login attempts, by setting lockoutenabled to true in
+  appsettings.json. By default, Change Tracker blocks the failing device's IP
+  address instead of locking the account.
+keywords:
+  - Netwrix Change Tracker
+  - IP blocking
+  - account lockout
+  - failed logon
+  - appsettings.json
+  - lockoutenabled
+  - iisreset
+  - authentication
+products:
+  - changetracker
+knowledge_article_id: ka04u000000Hd9RAAS
+sidebar_label: Enabling Account Lockout for Failed Login Attempts
+tags: [kb, configuration-and-setup]
+title: Enabling Account Lockout for Failed Login Attempts
+---
+
+# Enabling Account Lockout for Failed Login Attempts
+
+## Overview
+
+This article describes how to configure Netwrix Change Tracker to lock a user account after repeated failed login attempts, instead of blocking the device's IP address.
+
+By default, if a user fails to log in three times from a remote device, Netwrix Change Tracker blocks that device's IP address. Setting `lockoutenabled` to `true` locks the account after repeated failed logins. (The relationship between account lockout and IP blocking has not yet been confirmed — see the SME Review Needed note in the pull request.)
+
+## Instructions
+
+1. Open a Command Prompt as an administrator and stop IIS:
+
+   ```bat
+   iisreset /stop
+   ```
+
+2. Open `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) Hub\Configs\appsettings.json` in a text editor.
+3. In the `security` > `auth` section, set `lockoutenabled` to `true`:
+
+   ```json
+   "security": {
+       "auth": {
+           "lockoutenabled": "true",
+           "lockoutmaxloginattempts": "3",
+           "lockoutdurationminutes": "10"
+       }
+   }
+   ```
+
+   - `lockoutenabled` — set to `true` to lock the account after repeated failed login attempts.
+   - `lockoutmaxloginattempts` — the number of failed attempts before the account locks. Defaults to `3`.
+   - `lockoutdurationminutes` — how long the account stays locked, in minutes. Set to `10` to match the previous IP-blocking duration, or another value to fit your policy.
+
+   > **NOTE:** Change only the `auth` values shown. The surrounding settings provide context.
+
+4. Save the file.
+5. Start IIS:
+
+   ```bat
+   iisreset /start
+   ```
+
+After IIS restarts, three failed login attempts from a device lock the account for the configured duration.

--- a/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
+++ b/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
@@ -24,13 +24,11 @@ title: Turning Off Bulk Email Notifications
 
 ## Overview
 
-By default, Netwrix Change Tracker compiles multiple changes into a single real-time email notification. This article describes how to configure Change Tracker to send each change as a separate email instead.
-
-> **NOTE:** This article references the `localhost.json` file and `enableBulkNotifications` key from the source KB article. These have not been reverified against the current 8.2 configuration file structure — see the note at the end of this article.
+This article describes how to configure Netwrix Change Tracker to send each change as a separate email instead of compiling multiple changes into one. By default, Change Tracker compiles multiple changes into a single real-time email notification. [See the SME Review Needed note in the pull request description and confirm the current file and key name for disabling bulk email notifications.]
 
 ## Instructions
 
-1. Open an administrative Command Prompt and stop IIS:
+1. Open an administrative **Command Prompt** and stop IIS:
 
    ```bat
    iisreset /stop
@@ -46,7 +44,7 @@ By default, Netwrix Change Tracker compiles multiple changes into a single real-
    }
    ```
 
-   > **NOTE:** If your MongoDB database has been split off to a different server, edit the existing `localhost.json` file directly using the steps above rather than replacing it.
+   > **NOTE:** If your MongoDB database has been split off to a different server, edit the existing `localhost.json` file directly using these steps rather than replacing it.
 
 4. Save the file.
 5. Start IIS:

--- a/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
+++ b/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
@@ -24,7 +24,7 @@ title: Turning Off Bulk Email Notifications
 
 ## Overview
 
-This article describes how to configure Netwrix Change Tracker to send each change as a separate email instead of compiling multiple changes into one. By default, Change Tracker compiles multiple changes into a single real-time email notification. [See the SME Review Needed note in the pull request description and confirm the current file and key name for disabling bulk email notifications.]
+This article describes how to configure Netwrix Change Tracker to send each change as a separate email instead of compiling multiple changes into one. By default, Change Tracker groups all changes detected during a single tracking cycle into one bulk email rather than sending a separate email per change. Turning off bulk notifications increases email volume, since Change Tracker sends one email per detected change instead of one email per tracking cycle. Consider your notification infrastructure's capacity before disabling this setting. Disable it only if you need per-change alerting, such as for a compliance workflow.
 
 ## Instructions
 
@@ -44,7 +44,7 @@ This article describes how to configure Netwrix Change Tracker to send each chan
    }
    ```
 
-   > **NOTE:** If your MongoDB database has been split off to a different server, edit the existing `appsettings.json` file directly using these steps rather than replacing it.
+   > **NOTE:** If you split off your MongoDB database to a different server, edit the existing `appsettings.json` file directly using these steps rather than replacing it.
 
 4. Save the file.
 5. Start IIS:

--- a/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
+++ b/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
@@ -1,0 +1,58 @@
+---
+description: >-
+  Shows how to configure Netwrix Change Tracker to send a separate real-time
+  email notification for each change, instead of compiling multiple changes
+  into a single email.
+keywords:
+  - Netwrix Change Tracker
+  - email notifications
+  - bulk email
+  - localhost.json
+  - enableBulkNotifications
+  - real-time notifications
+  - IIS
+  - MongoDB
+products:
+  - changetracker
+knowledge_article_id: ka04u000000HdB0AAK
+sidebar_label: Turning Off Bulk Email Notifications
+tags: [kb, configuration-and-setup]
+title: Turning Off Bulk Email Notifications
+---
+
+# Turning Off Bulk Email Notifications
+
+## Overview
+
+By default, Netwrix Change Tracker compiles multiple changes into a single real-time email notification. This article describes how to configure Change Tracker to send each change as a separate email instead.
+
+> **NOTE:** This article references the `localhost.json` file and `enableBulkNotifications` key from the source KB article. These have not been reverified against the current 8.2 configuration file structure — see the note at the end of this article.
+
+## Instructions
+
+1. Open an administrative Command Prompt and stop IIS:
+
+   ```bat
+   iisreset /stop
+   ```
+
+2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 Hub\bin\Configs`.
+3. Open the `localhost.json` file and add the following lines at the end of the file:
+
+   ```json
+   ,
+   "pipeline" : {
+       "enableBulkNotifications" : "no"
+   }
+   ```
+
+   > **NOTE:** If your MongoDB database has been split off to a different server, edit the existing `localhost.json` file directly using the steps above rather than replacing it.
+
+4. Save the file.
+5. Start IIS:
+
+   ```bat
+   iisreset /start
+   ```
+
+After IIS restarts, Netwrix Change Tracker sends each change as its own email instead of compiling multiple changes into one.

--- a/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
+++ b/docs/kb/changetracker/configuration-and-setup/turn-off-bulk-email-notifications.md
@@ -7,7 +7,7 @@ keywords:
   - Netwrix Change Tracker
   - email notifications
   - bulk email
-  - localhost.json
+  - appsettings.json
   - enableBulkNotifications
   - real-time notifications
   - IIS
@@ -34,17 +34,17 @@ This article describes how to configure Netwrix Change Tracker to send each chan
    iisreset /stop
    ```
 
-2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 Hub\bin\Configs`.
-3. Open the `localhost.json` file and add the following lines at the end of the file:
+2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) Hub\Configs`.
+3. Open the `appsettings.json` file and edit the following lines within the file:
 
    ```json
    ,
-   "pipeline" : {
+   "roleSettings" : {
        "enableBulkNotifications" : "no"
    }
    ```
 
-   > **NOTE:** If your MongoDB database has been split off to a different server, edit the existing `localhost.json` file directly using these steps rather than replacing it.
+   > **NOTE:** If your MongoDB database has been split off to a different server, edit the existing `appsettings.json` file directly using these steps rather than replacing it.
 
 4. Save the file.
 5. Start IIS:

--- a/docs/kb/changetracker/database-and-diagnostics/mongodb-connection-timeout-socketexception-10060.md
+++ b/docs/kb/changetracker/database-and-diagnostics/mongodb-connection-timeout-socketexception-10060.md
@@ -16,12 +16,12 @@ keywords:
 products:
   - changetracker
 knowledge_article_id: kA0Qk0000000bHJKAY
-sidebar_label: 'Rolling-Log Fix: MongoDB Connection Timeout (SocketException 10060)'
+sidebar_label: 'MongoDB Log Fix: Connection Timeout (SocketException 10060)'
 tags: [kb, database-and-diagnostics]
-title: 'Rolling-Log Fix: MongoDB Connection Timeout (SocketException 10060)'
+title: 'MongoDB Log Fix: Connection Timeout (SocketException 10060)'
 ---
 
-# Rolling-Log Fix: MongoDB Connection Timeout (SocketException 10060)
+# MongoDB Log Fix: Connection Timeout (SocketException 10060)
 
 ## Symptom
 
@@ -39,7 +39,7 @@ A connection attempt failed because the connected party did not properly respond
 
 ## Cause
 
-Under load, the number of concurrent requests to the MongoDB instance can exceed the driver's connection pool size (`maxPoolSize`), causing new requests to queue for an available connection. If a request waits longer than the driver's connection timeout (`connectTimeoutMS`) for a connection to become available, it fails with this error. [See the SME Review Needed note in the pull request description and confirm whether this standard MongoDB .NET driver behavior explains what's happening here.]
+Under load, concurrent requests to the MongoDB instance can exceed the driver's connection pool size (`maxPoolSize`), causing new requests to queue for an available connection. If a request waits longer than the driver's connection timeout (`connectTimeoutMS`) for a connection to become available, it fails with this error.
 
 ## Resolution
 

--- a/docs/kb/changetracker/database-and-diagnostics/mongodb-connection-timeout-socketexception-10060.md
+++ b/docs/kb/changetracker/database-and-diagnostics/mongodb-connection-timeout-socketexception-10060.md
@@ -1,0 +1,75 @@
+---
+description: >-
+  Resolves a MongoDB connection timeout for the Netwrix Change Tracker Hub by
+  increasing the IIS pool size and MongoDB connection timeout in
+  appsettings.Production.json.
+keywords:
+  - Netwrix Change Tracker
+  - MongoDB
+  - timeout
+  - SocketException 10060
+  - MongoConnectionException
+  - iisreset
+  - connectTimeoutMS
+  - maxPoolSize
+  - appsettings.Production.json
+products:
+  - changetracker
+knowledge_article_id: kA0Qk0000000bHJKAY
+sidebar_label: 'Rolling-Log Fix: MongoDB Connection Timeout (SocketException 10060)'
+tags: [kb, database-and-diagnostics]
+title: 'Rolling-Log Fix: MongoDB Connection Timeout (SocketException 10060)'
+---
+
+# Rolling-Log Fix: MongoDB Connection Timeout (SocketException 10060)
+
+## Symptom
+
+The hub service log for Netwrix Change Tracker shows the following error:
+
+```text
+MongoDB.Driver.MongoConnectionException: An exception occurred while receiving a message from the server.
+
+System.IO.IOException: Unable to read data from the transport connection:
+A connection attempt failed because the connected party did not properly respond after a period of time,
+or established connection failed because connected host has failed to respond.
+
+System.Net.Sockets.SocketException (10060):
+A connection attempt failed because the connected party did not properly respond after a period of time,
+or established connection failed because connected host has failed to respond.
+```
+
+## Cause
+
+Under load, the number of concurrent requests to the MongoDB instance can exceed the driver's connection pool size (`maxPoolSize`), causing new requests to queue for an available connection. If a request waits longer than the driver's connection timeout (`connectTimeoutMS`) for a connection to become available, it fails with this error.
+
+## Resolution
+
+Increase the IIS pool size and the MongoDB connection timeout to prevent requests from timing out:
+
+1. Open an elevated Command Prompt and stop IIS:
+
+   ```text
+   iisreset /stop
+   ```
+
+2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) Hub\Configs\` and open `appsettings.Production.json`. Back up the file before editing it.
+3. Locate the `connectionString` line:
+
+   ```text
+   "connectionString": "mongodb://%IP_address%"
+   ```
+
+   Edit the line to add `maxPoolSize` and `connectTimeoutMS`:
+
+   ```text
+   "connectionString": "mongodb://%IP_address%/?maxPoolSize=500&connectTimeoutMS=120000"
+   ```
+
+4. Save the changes and start IIS:
+
+   ```text
+   iisreset /start
+   ```
+
+After IIS restarts, the Hub can maintain more concurrent MongoDB connections and allows more time for each request to complete before timing out.

--- a/docs/kb/changetracker/database-and-diagnostics/mongodb-connection-timeout-socketexception-10060.md
+++ b/docs/kb/changetracker/database-and-diagnostics/mongodb-connection-timeout-socketexception-10060.md
@@ -31,29 +31,30 @@ The hub service log for Netwrix Change Tracker shows the following error:
 MongoDB.Driver.MongoConnectionException: An exception occurred while receiving a message from the server.
 
 System.IO.IOException: Unable to read data from the transport connection:
-A connection attempt failed because the connected party did not properly respond after a period of time,
-or established connection failed because connected host has failed to respond.
+A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
 
 System.Net.Sockets.SocketException (10060):
-A connection attempt failed because the connected party did not properly respond after a period of time,
-or established connection failed because connected host has failed to respond.
+A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
 ```
 
 ## Cause
 
-Under load, the number of concurrent requests to the MongoDB instance can exceed the driver's connection pool size (`maxPoolSize`), causing new requests to queue for an available connection. If a request waits longer than the driver's connection timeout (`connectTimeoutMS`) for a connection to become available, it fails with this error.
+Under load, the number of concurrent requests to the MongoDB instance can exceed the driver's connection pool size (`maxPoolSize`), causing new requests to queue for an available connection. If a request waits longer than the driver's connection timeout (`connectTimeoutMS`) for a connection to become available, it fails with this error. [See the SME Review Needed note in the pull request description and confirm whether this standard MongoDB .NET driver behavior explains what's happening here.]
 
 ## Resolution
 
 Increase the IIS pool size and the MongoDB connection timeout to prevent requests from timing out:
 
-1. Open an elevated Command Prompt and stop IIS:
+1. Open an elevated **Command Prompt** and stop IIS:
 
-   ```text
+   ```bat
    iisreset /stop
    ```
 
-2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) Hub\Configs\` and open `appsettings.Production.json`. Back up the file before editing it.
+2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) Hub\Configs\` and open `appsettings.Production.json`.
+
+   > **IMPORTANT:** Back up the file before editing it.
+
 3. Locate the `connectionString` line:
 
    ```text
@@ -68,7 +69,7 @@ Increase the IIS pool size and the MongoDB connection timeout to prevent request
 
 4. Save the changes and start IIS:
 
-   ```text
+   ```bat
    iisreset /start
    ```
 

--- a/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
@@ -1,0 +1,50 @@
+---
+description: >-
+  Resolves HTTP/HTTPS Error 500.19 caused by a duplicate X-Frame-Options
+  collection entry in web.config after upgrading Netwrix Change Tracker from
+  an older version.
+keywords:
+  - HTTP 500.19
+  - X-Frame-Options
+  - IIS
+  - web.config
+  - Netwrix Change Tracker
+  - duplicate collection entry
+  - IIS conflict
+  - upgrade
+products:
+  - changetracker
+knowledge_article_id: ka04u000000QmkBAAS
+sidebar_label: 'HTTP 500.19: Duplicate X-Frame-Options Entry'
+tags: [kb, troubleshooting-and-errors]
+title: 'HTTP 500.19: Duplicate X-Frame-Options Entry'
+---
+
+# HTTP 500.19: Duplicate X-Frame-Options Entry
+
+## Symptom
+
+After upgrading Netwrix Change Tracker from a much older version, the console returns the following error:
+
+```text
+HTTP Error 500.19 - Internal Server Error
+Cannot add duplicate collection entry of type 'add' with unique key attribute 'name' set to 'X-Frame-Options'
+```
+
+## Cause
+
+The upgrade leaves a duplicate `X-Frame-Options` collection entry in `web.config`. IIS rejects the duplicate key, which prevents the site from loading.
+
+## Resolution
+
+1. Open IIS and stop the IIS server.
+2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) WebUI\html\`.
+3. Open `web.config` in a text editor and locate the two `X-Frame-Options` entries.
+4. Comment out one of the two duplicate `X-Frame-Options` entries so only one remains active.
+5. Save the file.
+
+   > **NOTE:** You may need to save the file to the desktop first, then copy it back into the directory above, replacing the original.
+
+6. Start IIS and open the Netwrix Change Tracker console.
+
+You should now be able to log in to the console without the 500.19 error.

--- a/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
@@ -33,7 +33,7 @@ Cannot add duplicate collection entry of type 'add' with unique key attribute 'n
 
 ## Cause
 
-The upgrade leaves a duplicate `X-Frame-Options` collection entry in `web.config`. IIS rejects the duplicate key, which prevents the site from loading.
+The upgrade leaves a duplicate `X-Frame-Options` collection entry in `web.config`. IIS rejects the duplicate key, which prevents the site from loading. [See the SME Review Needed note in the pull request description and confirm why the upgrade produces a duplicate entry instead of replacing the existing one, and the exact `X-Frame-Options` value involved.]
 
 ## Resolution
 
@@ -43,7 +43,7 @@ The upgrade leaves a duplicate `X-Frame-Options` collection entry in `web.config
 4. Comment out one of the two duplicate `X-Frame-Options` entries so only one remains active.
 5. Save the file.
 
-   > **NOTE:** You may need to save the file to the desktop first, then copy it back into the directory above, replacing the original.
+   > **NOTE:** You may need to save the file to the desktop first, then copy it back into the WebUI `html` directory, replacing the original.
 
 6. Start IIS and open the Netwrix Change Tracker console.
 

--- a/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
@@ -40,6 +40,9 @@ The upgrade leaves a duplicate `X-Frame-Options` collection entry in `web.config
 1. Open IIS and stop the IIS server.
 2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) WebUI\html\`.
 3. Open `web.config` in a text editor and locate the two `X-Frame-Options` entries.
+```text
+<add name="X-Frame-Options" value="SAMEORIGIN"/>
+```
 4. Comment out one of the two duplicate `X-Frame-Options` entries so only one remains active.
 5. Save the file.
 

--- a/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/http-500-19-x-frame-options-duplicate-entry.md
@@ -24,7 +24,7 @@ title: 'HTTP 500.19: Duplicate X-Frame-Options Entry'
 
 ## Symptom
 
-After upgrading Netwrix Change Tracker from a much older version, the console returns the following error:
+After you upgrade Netwrix Change Tracker from a much older version, the console returns the following error:
 
 ```text
 HTTP Error 500.19 - Internal Server Error
@@ -33,21 +33,23 @@ Cannot add duplicate collection entry of type 'add' with unique key attribute 'n
 
 ## Cause
 
-The upgrade leaves a duplicate `X-Frame-Options` collection entry in `web.config`. IIS rejects the duplicate key, which prevents the site from loading. [See the SME Review Needed note in the pull request description and confirm why the upgrade produces a duplicate entry instead of replacing the existing one, and the exact `X-Frame-Options` value involved.]
+This behavior is most likely caused by the upgrade process adding a new `X-Frame-Options` entry to `web.config` without removing the entry from the previous installation, leaving two entries with the same key. IIS then rejects the duplicate key, which prevents the site from loading.
 
 ## Resolution
 
 1. Open IIS and stop the IIS server.
 2. Navigate to `C:\inetpub\wwwroot\Change Tracker Generation 7 (NetCore) WebUI\html\`.
-3. Open `web.config` in a text editor and locate the two `X-Frame-Options` entries.
-```text
-<add name="X-Frame-Options" value="SAMEORIGIN"/>
-```
+3. Open `web.config` in a text editor and locate the two `X-Frame-Options` entries, for example:
+
+   ```text
+   <add name="X-Frame-Options" value="SAMEORIGIN"/>
+   ```
+
 4. Comment out one of the two duplicate `X-Frame-Options` entries so only one remains active.
 5. Save the file.
 
    > **NOTE:** You may need to save the file to the desktop first, then copy it back into the WebUI `html` directory, replacing the original.
 
-6. Start IIS and open the Netwrix Change Tracker console.
+6. Start IIS and open the Change Tracker console.
 
-You should now be able to log in to the console without the 500.19 error.
+You should now be able to log in to the console without the `500.19` error.

--- a/docs/kb/changetracker/troubleshooting-and-errors/nnt-filehash-linux-x64-permission-denied.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/nnt-filehash-linux-x64-permission-denied.md
@@ -14,12 +14,12 @@ keywords:
 products:
   - changetracker
 knowledge_article_id: ka0Qk000000DnvlIAC
-sidebar_label: 'Rolling-Log Fix: NNT_FILEHASH_LINUX_X64 Permission Denied'
+sidebar_label: 'NNT_FILEHASH_LINUX_X64 Log Fix: Permission Denied'
 tags: [kb, troubleshooting-and-errors]
-title: 'Rolling-Log Fix: NNT_FILEHASH_LINUX_X64 Permission Denied'
+title: 'NNT_FILEHASH_LINUX_X64 Log Fix: Permission Denied'
 ---
 
-# Rolling-Log Fix: NNT_FILEHASH_LINUX_X64 Permission Denied
+# NNT_FILEHASH_LINUX_X64 Log Fix: Permission Denied
 
 ## Symptom
 
@@ -36,14 +36,14 @@ The `NNT_FILEHASH_LINUX_X64` binary does not have execute permission for the acc
 
 ## Resolution
 
-1. On the monitored device, navigate to the location where the `NNT_FILEHASH_LINUX_X64` binary is stored. By default, this is `/usr/bin`.
+1. On the monitored device, navigate to the location that stores the `NNT_FILEHASH_LINUX_X64` binary. By default, this is `/usr/bin`.
 2. Grant execute permission on the binary to the account the Proxy Agent uses to connect to this device:
 
    ```bash
    chmod 775 /usr/bin/NNT_FILEHASH_LINUX_X64
    ```
 
-   > **IMPORTANT:** Confirm that the binary's ownership matches an account with which the Proxy Agent's connection credentials can execute. Set ownership with `chown` if needed, using a user and group that exist on this device.
+   > **IMPORTANT:** Confirm the binary's owner matches the account the Proxy Agent's connection credentials use. Set ownership with `chown` if needed, using a user and group that exist on this device.
 
 3. Confirm the fix by running the binary directly from the command line. This hashes the `/etc` directory:
 
@@ -51,6 +51,6 @@ The `NNT_FILEHASH_LINUX_X64` binary does not have execute permission for the acc
    /usr/bin/NNT_FILEHASH_LINUX_X64 -l10 -r -t -x /etc/*
    ```
 
-4. In the Netwrix Change Tracker console, go to the **Devices** tab and select **Start Tracker** on the agentless device.
+4. In the Change Tracker console, go to the **Devices** tab and select **Start Tracker** on the agentless device.
 
-Once the tracker starts successfully, Netwrix Change Tracker can hash files on this device without the permission error.
+Once the tracker starts successfully, Change Tracker can hash files on this device without the permission error.

--- a/docs/kb/changetracker/troubleshooting-and-errors/nnt-filehash-linux-x64-permission-denied.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/nnt-filehash-linux-x64-permission-denied.md
@@ -43,7 +43,7 @@ The `NNT_FILEHASH_LINUX_X64` binary does not have execute permission for the acc
    chmod 775 /usr/bin/NNT_FILEHASH_LINUX_X64
    ```
 
-   > **IMPORTANT:** Confirm the binary's ownership matches an account the Proxy Agent's connection credentials can execute as. Set ownership with `chown` if needed, using a user and group that exist on this device.
+   > **IMPORTANT:** Confirm that the binary's ownership matches an account with which the Proxy Agent's connection credentials can execute. Set ownership with `chown` if needed, using a user and group that exist on this device.
 
 3. Confirm the fix by running the binary directly from the command line. This hashes the `/etc` directory:
 

--- a/docs/kb/changetracker/troubleshooting-and-errors/nnt-filehash-linux-x64-permission-denied.md
+++ b/docs/kb/changetracker/troubleshooting-and-errors/nnt-filehash-linux-x64-permission-denied.md
@@ -1,0 +1,56 @@
+---
+description: >-
+  Resolves a "Permission denied" error when running the NNT_FILEHASH_LINUX_X64
+  binary on agentless Linux devices monitored by Netwrix Change Tracker.
+keywords:
+  - NNT_FILEHASH_LINUX_X64
+  - filehash
+  - permission denied
+  - Linux
+  - agentless
+  - Netwrix Change Tracker
+  - chmod
+  - Proxy Agent
+products:
+  - changetracker
+knowledge_article_id: ka0Qk000000DnvlIAC
+sidebar_label: 'Rolling-Log Fix: NNT_FILEHASH_LINUX_X64 Permission Denied'
+tags: [kb, troubleshooting-and-errors]
+title: 'Rolling-Log Fix: NNT_FILEHASH_LINUX_X64 Permission Denied'
+---
+
+# Rolling-Log Fix: NNT_FILEHASH_LINUX_X64 Permission Denied
+
+## Symptom
+
+The rolling log for an agentless Linux device shows an error similar to the following:
+
+```text
+Script error executing line 6: ExecuteAndCaptureChunked,0,/usr/bin/NNT_FILEHASH_LINUX_X64 -l10 -r -t -x"/etc/vmware/*/dvsdata.db" ...
+Error: ExecuteAndCaptureChunked failed: ... -sh: /usr/bin/NNT_FILEHASH_LINUX_X64: Permission denied
+```
+
+## Cause
+
+The `NNT_FILEHASH_LINUX_X64` binary does not have execute permission for the account the Netwrix Change Tracker Proxy Agent uses to connect to the device.
+
+## Resolution
+
+1. On the monitored device, navigate to the location where the `NNT_FILEHASH_LINUX_X64` binary is stored. By default, this is `/usr/bin`.
+2. Grant execute permission on the binary to the account the Proxy Agent uses to connect to this device:
+
+   ```bash
+   chmod 775 /usr/bin/NNT_FILEHASH_LINUX_X64
+   ```
+
+   > **IMPORTANT:** Confirm the binary's ownership matches an account the Proxy Agent's connection credentials can execute as. Set ownership with `chown` if needed, using a user and group that exist on this device.
+
+3. Confirm the fix by running the binary directly from the command line. This hashes the `/etc` directory:
+
+   ```bash
+   /usr/bin/NNT_FILEHASH_LINUX_X64 -l10 -r -t -x /etc/*
+   ```
+
+4. In the Netwrix Change Tracker console, go to the **Devices** tab and select **Start Tracker** on the agentless device.
+
+Once the tracker starts successfully, Netwrix Change Tracker can hash files on this device without the permission error.


### PR DESCRIPTION
## Summary
Adds 5 new Change Tracker KB articles migrated from the staging repo for Denis Goskolli's SME review.

## Changes

- Migrates and updates 5 Change Tracker KB articles across configuration-and-setup, database-and-diagnostics, and troubleshooting-and-errors
- Retitles a Draft-status placeholder article ("test_value") to a proper rolling-log-fix title matching series conventions
- Neutralizes unverified factual claims in body/title/description rather than asserting them, flagging each as an SME question
- Applies Vale/Dale/Derek lint fixes: bolds Command Prompt where opened, corrects passive voice and positional references, fixes a code-fence language mismatch, reorders one Overview to lead with the goal sentence, and converts a precautionary instruction to an IMPORTANT callout
- Standardizes all SME Review Needed inline flags to a consistent bracketed format

## Testing

- kb-pr-open (Vale + Dale + Derek): 0 Vale errors across all 5 files; Dale (10/10 rules) and Derek (frontmatter, structure, formatting, cross-section) findings resolved
- Local build: successful, no broken links or anchor errors

## SME Review Needed

1. **`stop-blocking-ip-address.md`**
   — The article states `lockoutenabled` locks the account after repeated failed logins but doesn't confirm the relationship to Change Tracker's default IP-blocking behavior. Please confirm:
   - **UPDATE** (clarify whether lockout replaces IP blocking or both can trigger independently)
   - **KEEP** (accept current neutral phrasing as-is)

2. **`http-500-19-x-frame-options-duplicate-entry.md`**
   — The Cause doesn't explain why the upgrade produces a duplicate `X-Frame-Options` entry instead of replacing it, and no current `X-Frame-Options` value is available to include in the Resolution. Please confirm:
   - **UPDATE** (add the mechanism and the actual current value)
   - **KEEP** (accept current version if unconfirmed)

3. **`mongodb-connection-timeout-socketexception-10060.md`**
   — The Cause explanation (connection pool exhaustion) reflects standard MongoDB .NET driver behavior but should be verified against Change Tracker's actual implementation. Please confirm:
   - **UPDATE** (adjust the mechanism if it doesn't match actual behavior)
   - **KEEP** (accept current version)

4. **`turn-off-bulk-email-notifications.md`**
   — Two open items:
          **(1) Config:** Confirm the current file and key name for disabling bulk email notifications (`localhost.json`/`enableBulkNotifications` unverified against 8.2). 
          **(2) Content:** What determines when changes are grouped into one bulk email (time window, report run, device, etc.), why a customer would want this off, and whether disabling it meaningfully increases email volume? Please confirm:
   - **UPDATE** (add the confirmed config file/key, plus the batching mechanism and rationale, to the article)
   - **KEEP** (accept as-is if unconfirmed)



Closes #1269