### PR TITLE
Fix stale CODEOWNERS paths for PolicyPak

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,11 +57,11 @@
 /static/files/directorymanager/ @netwrix/directorymanager-docs
 /static/images/directorymanager/ @netwrix/directorymanager-docs
 
-# Endpoint Policy Manager team
-/docs/endpointpolicymanager/ @netwrix/endpointpolicymanager-docs
-/sidebars/endpointpolicymanager.js @netwrix/endpointpolicymanager-docs
-/static/files/endpointpolicymanager/ @netwrix/endpointpolicymanager-docs
-/static/images/endpointpolicymanager/ @netwrix/endpointpolicymanager-docs
+# Endpoint Policy Manager team (product now branded PolicyPak)
+/docs/policypak/ @netwrix/endpointpolicymanager-docs
+/sidebars/policypak.js @netwrix/endpointpolicymanager-docs
+/static/files/policypak/ @netwrix/endpointpolicymanager-docs
+/static/images/policypak/ @netwrix/endpointpolicymanager-docs
 
 # Endpoint Protector team
 /docs/endpointprotector/ @netwrix/endpointprotector-docs


### PR DESCRIPTION
## Summary
- The docs, sidebar, and static asset paths were renamed from \`endpointpolicymanager\` to \`policypak\` at some point, but \`.github/CODEOWNERS\` still references the old paths
- As a result, PRs touching PolicyPak docs (e.g. #1288) haven't been auto-assigning reviewers
- Updates the path patterns to \`docs/policypak/\`, \`sidebars/policypak.js\`, \`static/files/policypak/\`, and \`static/images/policypak/\` — team slug (\`@netwrix/endpointpolicymanager-docs\`) is unchanged since it still exists under that name

## Test plan
- [x] Confirmed \`@netwrix/endpointpolicymanager-docs\` team still exists via GitHub API
- [x] Confirmed actual folder names (\`docs/policypak\`, \`sidebars/policypak.js\`, \`static/images/policypak\`) via repo inspection
- [ ] Confirm reviewer auto-assignment works on the next PolicyPak PR