### PR TITLE
Stop route changes from animating scroll position

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,6 +96,7 @@ const config = {
     defaultLocale: 'en',
     locales: ['en'],
   },
+  clientModules: ['./src/clientModules/scrollBehavior.js'],
   presets: [
     [
       'classic',

--- a/src/clientModules/scrollBehavior.js
+++ b/src/clientModules/scrollBehavior.js
@@ -1,0 +1,56 @@
+// Docusaurus scrolls to the top (or to a hash target) on every route change.
+// Our global `scroll-behavior: smooth` (src/css/custom.css) makes the browser
+// animate that scroll. We only want the animation for anchor navigation within
+// the same page (e.g. TOC clicks) — a new page should land instantly, whether
+// at the top or at an anchor.
+export function onRouteUpdate({ previousLocation, location }) {
+  const samePage = previousLocation?.pathname === location.pathname;
+  document.documentElement.style.scrollBehavior = samePage ? 'smooth' : 'auto';
+
+  // On a fresh page load (no previousLocation) Docusaurus leaves hash scrolling
+  // to the browser's native fragment navigation. In dev, `docusaurus start`
+  // serves an empty shell and renders content client-side, so the target
+  // element doesn't exist yet when the browser tries to scroll to it — it
+  // never retries. Handle that case ourselves, landing instantly once the
+  // element shows up.
+  if (!previousLocation && location.hash) {
+    scrollToHashOnceRendered(location.hash);
+  }
+}
+
+export function onRouteDidUpdate() {
+  document.documentElement.style.scrollBehavior = '';
+}
+
+function scrollToHashOnceRendered(hash) {
+  const id = decodeURIComponent(hash.substring(1));
+  const root = document.getElementById('__docusaurus') ?? document.body;
+  let debounceTimer;
+
+  const attemptScroll = () => {
+    if (window.location.hash !== hash) {
+      cleanup();
+      return;
+    }
+    document.getElementById(id)?.scrollIntoView({ behavior: 'instant' });
+  };
+
+  // Debounce so we scroll once the DOM has stopped changing, not on the first
+  // sighting of the element — later mutations (syntax highlighting, reserved
+  // image space resolving, etc.) can still shift it out from under the navbar.
+  const scheduleScroll = () => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(attemptScroll, 150);
+  };
+
+  const cleanup = () => {
+    clearTimeout(debounceTimer);
+    clearTimeout(stopTimer);
+    observer.disconnect();
+  };
+
+  const observer = new MutationObserver(scheduleScroll);
+  observer.observe(root, { childList: true, subtree: true, attributes: true });
+  scheduleScroll();
+  const stopTimer = setTimeout(cleanup, 2000);
+}


### PR DESCRIPTION
## Summary
- Global `scroll-behavior: smooth` (`src/css/custom.css`) made every page navigation visibly animate scroll-to-top/anchor instead of snapping, since Docusaurus resets scroll position via `window.scrollTo`/`scrollIntoView` on each route change
- Added `src/clientModules/scrollBehavior.js`, registered via `clientModules` in `docusaurus.config.js`, that disables smooth scrolling for cross-page navigation while preserving it for same-page anchor clicks (TOC links, etc.)
- Also handles a fresh full-page load to a hash URL (target element doesn't exist yet in the dev server's client-rendered shell) and waits for layout to settle before scrolling so anchors land clear of the sticky navbar

## Test plan
- [x] Navigate to a new page with no anchor — lands at top instantly
- [x] Navigate (fresh load and in-app) to a new page with an anchor — lands at the anchor instantly, clear of the sticky navbar
- [x] Click a TOC/anchor link while already on the page — still animates smoothly