### PR TITLE
Set Priority = P1 and Status = Backlog on auto-created PR tracking issues

### DIFF
--- a/.github/workflows/auto-create-pr-tracking-issues.yml
+++ b/.github/workflows/auto-create-pr-tracking-issues.yml
@@ -107,7 +107,8 @@ jobs:
 
             // 4. Set project fields
             await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', 'c0f74161', 'Work Category = Admin Support');
-            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b', 'Priority = P2');
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', 'c2ae6a84', 'Priority = P1');
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xF8', 'f75ad846', 'Status = Backlog');
 
             console.log(`✓ Created issue #${issue.number} linked to PR #${pr.number}`);
 
@@ -214,7 +215,8 @@ jobs:
 
             // 4. Set project fields
             await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXU', '7d3f2431', 'Work Category = Publishing Pipeline');
-            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', '5280356b', 'Priority = P2');
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xOU', 'c2ae6a84', 'Priority = P1');
             await setField('PVTSSF_lADOB435Ds4A7py9zg_TaXY', '8f39fde1', 'Pipeline Stage = PR Open');
+            await setField('PVTSSF_lADOB435Ds4A7py9zgv4xF8', 'f75ad846', 'Status = Backlog');
 
             console.log(`✓ Created issue #${issue.number} linked to PR #${pr.number}`);


### PR DESCRIPTION
## Summary
- Tracking issues created by `auto-create-pr-tracking-issues.yml` (both the Admin Support and Publishing Pipeline jobs) now get Priority = P1 instead of P2.
- Both jobs now also set Status = Backlog on creation, so tracking issues never land on the project board without a status.

## Changes
- `.github/workflows/auto-create-pr-tracking-issues.yml`: replaced the `Priority = P2` (`5280356b`) field mutation with `Priority = P1` (`c2ae6a84`) in both jobs; added a `Status = Backlog` (`f75ad846`) field mutation in both jobs.

## Testing
- No local execution (workflow only runs on `pull_request: review_requested` events) — verified field/option IDs against the live project schema via `gh api graphql` against `netwrix/projects/2` before editing.
- `actionlint` not run in this environment; no syntax changes beyond two `setField` call edits, following the existing `setField` helper pattern already used elsewhere in the file.