### PR TITLE
Fix carousel indicator dots getting clipped

### DIFF
--- a/src/components/CommunityHighlights/index.js
+++ b/src/components/CommunityHighlights/index.js
@@ -231,17 +231,17 @@ function CommunityHighlights() {
                   </div>
                 )}
               </div>
-              {featuredTopics.length > 1 && (
-                <div className={styles.carouselIndicators}>
-                  {featuredTopics.map((_, index) => (
-                    <button
-                      key={index}
-                      className={`${styles.indicator} ${index === currentSlide ? styles.active : ''}`}
-                      onClick={() => setCurrentSlide(index)}
-                    />
-                  ))}
-                </div>
-              )}
+            </div>
+          )}
+          {featuredTopics.length > 1 && (
+            <div className={styles.carouselIndicators}>
+              {featuredTopics.map((_, index) => (
+                <button
+                  key={index}
+                  className={`${styles.indicator} ${index === currentSlide ? styles.active : ''}`}
+                  onClick={() => setCurrentSlide(index)}
+                />
+              ))}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- The active indicator dot in the community highlights carousel scales up on click, but it lived inside the `overflow: hidden` wrapper meant to clip the sliding track, so the scaled dot got cut off at the bottom.
- Move the indicator dots outside that wrapper so they render fully.

## Test plan
- [ ] `DOCS_PRODUCT=pingcastle npm run start` and confirm the active carousel dot renders as a full circle

Closes #1300