### PR TITLE
Delete docs/policypak/knowledgebase/_category_.json

### DIFF
--- a/docs/policypak/knowledgebase/_category_.json
+++ b/docs/policypak/knowledgebase/_category_.json
@@ -1,9 +1,0 @@
-{
-  "label": "Netwrix PolicyPak Knowledge Base Articles",
-  "position": 20,
-  "collapsed": true,
-  "collapsible": true,
-  "link": {
-    "type": "generated-index"
-  }
-}


### PR DESCRIPTION
This folder has been empty since before February. If not needed, it should be deleted. Previous PR attempted to remove this file before product renaming: https://github.com/netwrix/docs/pull/363. 