### PR TITLE
Add Required Permissions section to Host Inventory docs

### DIFF
--- a/docs/accessanalyzer/11.6/admin/settings/hostinventory.md
+++ b/docs/accessanalyzer/11.6/admin/settings/hostinventory.md
@@ -26,7 +26,7 @@ this information.
 
 :::info
 Leave the default setting of all the groups selected. Consult with
-[Netwrix Support](https://www.netwrix.com/support.html) prior to turning off any of these property
+[Netwrix Support](https://www.netwrix.com/support.html) before turning off any of these property
 groups.
 :::
 
@@ -45,15 +45,15 @@ host inventory process:
   from a host
 
     - Default setting is 1200 seconds
-    - If thread cannot receive an active response from target host, the thread will move on to the
+    - If thread can't receive an active response from target host, the thread will move on to the
       next host in the queue
 
-- Stop on Failed Ping – If the Stop on Failed Ping checkbox is selected, hosts that do not respond
-  to pings are not queried. Otherwise, hosts will be queried regardless.
+- Stop on Failed Ping – If the Stop on Failed Ping checkbox is selected, hosts that don't respond
+  to pings aren't queried. Otherwise, hosts will be queried regardless.
 - PING timeout [in seconds] – Indicates the time a thread will spend pinging a host
 
     - Default setting is 4 seconds
-    - If thread cannot connect with a host, the host will be designated as being offline and the
+    - If thread can't connect with a host, the host will be designated as being offline and the
       thread will move on to the next host in the queue
 
 - Only refresh inventory items older than [time selected] – Indicates the time that needs to pass
@@ -61,7 +61,7 @@ host inventory process:
 
     - Default setting is 60 days
     - The number textbox has a five-character limit
-    - The drop-down menu includes the time-units of:
+    - The dropdown menu includes the time-units of:
 
         - Hours
         - Days
@@ -73,7 +73,7 @@ host inventory process:
       topic for additional information.
 
 The Desired Host List Views section at the bottom contains all available host lists, both
-out-of-the-box lists and custom-created lists. There are seven Default Hosts Lists which correspond
+built-in lists and custom-created lists. There are seven Default Hosts Lists which correspond
 to the solutions that target them. During the host inventory process, hosts which meet the filter
 criteria for these default lists are automatically populated into that host list. A checkmark in
 front of the host list indicates that the list is visible in the **Host Management** > **All Hosts**
@@ -91,7 +91,7 @@ filter criteria. These lists correspond to the pre-configured solution jobs whic
 
 ### AD Host List
 
-The **AD** Host List can be expanded and contains five sub-groups utilized by the Active Directory
+The **AD** Host List can be expanded and contains five sub-groups used by the Active Directory
 Solution and the Active Directory Inventory Solution:
 
 ![AD Host List](/images/accessanalyzer/11.6/admin/settings/ad.webp)
@@ -106,7 +106,7 @@ The sub-groups are:
 
 ### ALL WINDOWS HOSTS Host List
 
-The **ALL WINDOWS HOSTS** Host List is utilized primarily by the Windows Solution.
+The **ALL WINDOWS HOSTS** Host List is used primarily by the Windows Solution.
 
 ![ALL WINDOWS HOSTS Host List](/images/accessanalyzer/11.6/admin/settings/allwindowshosts.webp)
 
@@ -114,7 +114,7 @@ There are no sub-groups for ALL WINDOWS HOSTS.
 
 ### DG Host List
 
-The **DG** Host List can be expanded and contains three sub-groups utilized by the Data Access
+The **DG** Host List can be expanded and contains three sub-groups used by the Data Access
 Governance for File System Solution.
 
 ![DG Host List](/images/accessanalyzer/11.6/admin/settings/dg.webp)
@@ -127,7 +127,7 @@ The sub-groups are:
 
 ### EXCHANGE Host List
 
-The **EXCHANGE** Host List can be expanded and contains six sub-groups utilized by the Exchange
+The **EXCHANGE** Host List can be expanded and contains six sub-groups used by the Exchange
 Solution. Four of these sub-groups can also be expand.
 
 ![EXCHANGE Host List](/images/accessanalyzer/11.6/admin/settings/exchange.webp)
@@ -146,7 +146,7 @@ The sub-groups are:
 
 ### SQL Servers Host List
 
-The **SQL SERVERS** Host List is utilized primarily by the SQL Solution.
+The **SQL SERVERS** Host List is used primarily by the SQL Solution.
 
 ![SQL Servers Host List](/images/accessanalyzer/11.6/admin/settings/sqlservers.webp)
 
@@ -154,7 +154,7 @@ There are no sub-groups for SQL SERVERS.
 
 ### Windows Server Host List
 
-The **Windows Server** Host List can be expanded and contains three sub-groups utilized by the
+The **Windows Server** Host List can be expanded and contains three sub-groups used by the
 Windows Solution.
 
 ![Windows Server Host List](/images/accessanalyzer/11.6/admin/settings/windowsserver.webp)
@@ -167,7 +167,7 @@ The sub-groups are:
 
 ### Work Station Host List
 
-The **Work Station** Host List can be expanded and contains one sub-group utilized by the Windows
+The **Work Station** Host List can be expanded and contains one sub-group used by the Windows
 Solution.
 
 ![Work Station Host List](/images/accessanalyzer/11.6/admin/settings/workstation.webp)
@@ -178,33 +178,34 @@ The single sub-group is:
 
 ## Required Permissions
 
-The host inventory process collects the four property groups above using different mechanisms,
-each with its own permission requirement on the target host:
+The host inventory process collects the four property groups (Operating System, Application,
+Network, and Hardware) using different mechanisms, each with its own permission requirement on the
+target host:
 
-- **Operating System properties** (version, service pack, product type, and related items) are
-  read from the target's registry. This requires the Remote Registry service to be running on the
-  target, and the account used must have local administrator rights (or be explicitly delegated
+- **Operating System properties** (version, service pack, product type, and related items) come
+  from the target's registry. This requires the Remote Registry service to be running on the
+  target, and the account used must have local administrator rights (or explicitly delegated
   Remote Registry access).
 - **Application properties** (for example, SQL Server, IIS, clustering, and Exchange role/version)
-  are read from a mix of registry, WMI, and Active Directory, depending on the specific property.
+  come from a mix of registry, WMI, and Active Directory, depending on the specific property.
   WMI-sourced properties require WMI namespace access on the target (local administrator by
-  default). Exchange role and version are read from Active Directory first, and only fall back to
-  WMI if that lookup does not return a result.
-- **Network properties** (for example, domain/workgroup name and AD site) are primarily read using
-  low-privilege network APIs that do not require administrative rights, with a WMI fallback for
-  some properties if the primary method does not return a result.
-- **Hardware properties** (manufacturer, model, serial number) are read from WMI and require the
+  default). Exchange role and version come from Active Directory first, and only fall back to
+  WMI if that lookup doesn't return a result.
+- **Network properties** (for example, domain/workgroup name and AD site) come primarily from
+  low-privilege network APIs that don't require administrative rights, with a WMI fallback for
+  some properties if the primary method doesn't return a result.
+- **Hardware properties** (manufacturer, model, serial number) come from WMI and require the
   same administrative-equivalent access as other WMI-sourced properties.
 
 :::info
-Because Operating System and Hardware properties depend on Remote Registry and WMI access, the
-account used for host inventory should be provisioned as a local administrator (or with explicitly
-delegated Remote Registry and WMI namespace permissions) on the hosts being inventoried. A standard
-authenticated domain account without local admin rights is sufficient for Network properties and
-the Active Directory-based portion of Application properties, but not for the registry- and
-WMI-based properties.
+Because Operating System and Hardware properties depend on Remote Registry and WMI access, provision
+the account used for host inventory as a local administrator (or with explicitly delegated Remote
+Registry and WMI namespace permissions) on the inventoried hosts. A standard authenticated domain
+account without local admin rights is sufficient for Network properties and the Active
+Directory-based portion of Application properties, but not for the registry- and WMI-based
+properties.
 :::
 
-If the account used lacks the required access on a given host, the properties normally supplied by
-the denied mechanism are expected to be left blank rather than causing the entire host inventory
-record to fail.
+If the account used lacks the required access on a given host, host inventory should leave the
+properties normally supplied by that mechanism blank rather than failing the entire host inventory
+record.

--- a/docs/accessanalyzer/11.6/admin/settings/hostinventory.md
+++ b/docs/accessanalyzer/11.6/admin/settings/hostinventory.md
@@ -175,3 +175,36 @@ Solution.
 The single sub-group is:
 
 - ALL WINDOWS WORKSTATIONS
+
+## Required Permissions
+
+The host inventory process collects the four property groups above using different mechanisms,
+each with its own permission requirement on the target host:
+
+- **Operating System properties** (version, service pack, product type, and related items) are
+  read from the target's registry. This requires the Remote Registry service to be running on the
+  target, and the account used must have local administrator rights (or be explicitly delegated
+  Remote Registry access).
+- **Application properties** (for example, SQL Server, IIS, clustering, and Exchange role/version)
+  are read from a mix of registry, WMI, and Active Directory, depending on the specific property.
+  WMI-sourced properties require WMI namespace access on the target (local administrator by
+  default). Exchange role and version are read from Active Directory first, and only fall back to
+  WMI if that lookup does not return a result.
+- **Network properties** (for example, domain/workgroup name and AD site) are primarily read using
+  low-privilege network APIs that do not require administrative rights, with a WMI fallback for
+  some properties if the primary method does not return a result.
+- **Hardware properties** (manufacturer, model, serial number) are read from WMI and require the
+  same administrative-equivalent access as other WMI-sourced properties.
+
+:::info
+Because Operating System and Hardware properties depend on Remote Registry and WMI access, the
+account used for host inventory should be provisioned as a local administrator (or with explicitly
+delegated Remote Registry and WMI namespace permissions) on the hosts being inventoried. A standard
+authenticated domain account without local admin rights is sufficient for Network properties and
+the Active Directory-based portion of Application properties, but not for the registry- and
+WMI-based properties.
+:::
+
+If the account used lacks the required access on a given host, the properties normally supplied by
+the denied mechanism are expected to be left blank rather than causing the entire host inventory
+record to fail.

--- a/docs/accessanalyzer/12.0/admin/settings/hostinventory.md
+++ b/docs/accessanalyzer/12.0/admin/settings/hostinventory.md
@@ -174,3 +174,36 @@ Solution.
 The single sub-group is:
 
 - ALL WINDOWS WORKSTATIONS
+
+## Required Permissions
+
+The host inventory process collects the four property groups above using different mechanisms,
+each with its own permission requirement on the target host:
+
+- **Operating System properties** (version, service pack, product type, and related items) are
+  read from the target's registry. This requires the Remote Registry service to be running on the
+  target, and the account used must have local administrator rights (or be explicitly delegated
+  Remote Registry access).
+- **Application properties** (for example, SQL Server, IIS, clustering, and Exchange role/version)
+  are read from a mix of registry, WMI, and Active Directory, depending on the specific property.
+  WMI-sourced properties require WMI namespace access on the target (local administrator by
+  default). Exchange role and version are read from Active Directory first, and only fall back to
+  WMI if that lookup does not return a result.
+- **Network properties** (for example, domain/workgroup name and AD site) are primarily read using
+  low-privilege network APIs that do not require administrative rights, with a WMI fallback for
+  some properties if the primary method does not return a result.
+- **Hardware properties** (manufacturer, model, serial number) are read from WMI and require the
+  same administrative-equivalent access as other WMI-sourced properties.
+
+:::info
+Because Operating System and Hardware properties depend on Remote Registry and WMI access, the
+account used for host inventory should be provisioned as a local administrator (or with explicitly
+delegated Remote Registry and WMI namespace permissions) on the hosts being inventoried. A standard
+authenticated domain account without local admin rights is sufficient for Network properties and
+the Active Directory-based portion of Application properties, but not for the registry- and
+WMI-based properties.
+:::
+
+If the account used lacks the required access on a given host, the properties normally supplied by
+the denied mechanism are expected to be left blank rather than causing the entire host inventory
+record to fail.

--- a/docs/accessanalyzer/12.0/admin/settings/hostinventory.md
+++ b/docs/accessanalyzer/12.0/admin/settings/hostinventory.md
@@ -26,7 +26,7 @@ this information.
 
 :::info
 Leave the default setting of all the groups selected. Consult with
-[Netwrix Support](https://www.netwrix.com/support.html) prior to turning off any of these property
+[Netwrix Support](https://www.netwrix.com/support.html) before turning off any of these property
 groups.
 :::
 
@@ -45,15 +45,15 @@ host inventory process:
   from a host
 
     - Default setting is 1200 seconds
-    - If thread cannot receive an active response from target host, the thread will move on to the
+    - If thread can't receive an active response from target host, the thread will move on to the
       next host in the queue
 
-- Stop on Failed Ping – If the Stop on Failed Ping checkbox is selected, hosts that do not respond
-  to pings are not queried. Otherwise, hosts will be queried regardless.
+- Stop on Failed Ping – If the Stop on Failed Ping checkbox is selected, hosts that don't respond
+  to pings aren't queried. Otherwise, hosts will be queried regardless.
 - PING timeout [in seconds] – Indicates the time a thread will spend pinging a host
 
     - Default setting is 4 seconds
-    - If thread cannot connect with a host, the host will be designated as being offline and the
+    - If thread can't connect with a host, the host will be designated as being offline and the
       thread will move on to the next host in the queue
 
 - Only refresh inventory items older than [time selected] – Indicates the time that needs to pass
@@ -61,7 +61,7 @@ host inventory process:
 
     - Default setting is 60 days
     - The number textbox has a five-character limit
-    - The drop-down menu includes the time-units of:
+    - The dropdown menu includes the time-units of:
 
         - Hours
         - Days
@@ -72,7 +72,7 @@ host inventory process:
       [Host Discovery Wizard](/docs/accessanalyzer/12.0/admin/hostdiscovery/wizard/overview.md) topic for additional information.
 
 The Desired Host List Views section at the bottom contains all available host lists, both
-out-of-the-box lists and custom-created lists. There are seven Default Hosts Lists which correspond
+built-in lists and custom-created lists. There are seven Default Hosts Lists which correspond
 to the solutions that target them. During the host inventory process, hosts which meet the filter
 criteria for these default lists are automatically populated into that host list. A checkmark in
 front of the host list indicates that the list is visible in the **Host Management** > **All Hosts**
@@ -90,7 +90,7 @@ filter criteria. These lists correspond to the pre-configured solution jobs whic
 
 ### AD Host List
 
-The **AD** Host List can be expanded and contains five sub-groups utilized by the Active Directory
+The **AD** Host List can be expanded and contains five sub-groups used by the Active Directory
 Solution and the Active Directory Inventory Solution:
 
 ![AD Host List](/images/accessanalyzer/12.0/admin/settings/ad.webp)
@@ -105,7 +105,7 @@ The sub-groups are:
 
 ### ALL WINDOWS HOSTS Host List
 
-The **ALL WINDOWS HOSTS** Host List is utilized primarily by the Windows Solution.
+The **ALL WINDOWS HOSTS** Host List is used primarily by the Windows Solution.
 
 ![ALL WINDOWS HOSTS Host List](/images/accessanalyzer/12.0/admin/settings/allwindowshosts.webp)
 
@@ -113,7 +113,7 @@ There are no sub-groups for ALL WINDOWS HOSTS.
 
 ### DG Host List
 
-The **DG** Host List can be expanded and contains three sub-groups utilized by the Data Access
+The **DG** Host List can be expanded and contains three sub-groups used by the Data Access
 Governance for File System Solution.
 
 ![DG Host List](/images/accessanalyzer/12.0/admin/settings/dg.webp)
@@ -126,7 +126,7 @@ The sub-groups are:
 
 ### EXCHANGE Host List
 
-The **EXCHANGE** Host List can be expanded and contains six sub-groups utilized by the Exchange
+The **EXCHANGE** Host List can be expanded and contains six sub-groups used by the Exchange
 Solution. Four of these sub-groups can also be expand.
 
 ![EXCHANGE Host List](/images/accessanalyzer/12.0/admin/settings/exchange.webp)
@@ -145,7 +145,7 @@ The sub-groups are:
 
 ### SQL Servers Host List
 
-The **SQL SERVERS** Host List is utilized primarily by the SQL Solution.
+The **SQL SERVERS** Host List is used primarily by the SQL Solution.
 
 ![SQL Servers Host List](/images/accessanalyzer/12.0/admin/settings/sqlservers.webp)
 
@@ -153,7 +153,7 @@ There are no sub-groups for SQL SERVERS.
 
 ### Windows Server Host List
 
-The **Windows Server** Host List can be expanded and contains three sub-groups utilized by the
+The **Windows Server** Host List can be expanded and contains three sub-groups used by the
 Windows Solution.
 
 ![Windows Server Host List](/images/accessanalyzer/12.0/admin/settings/windowsserver.webp)
@@ -166,7 +166,7 @@ The sub-groups are:
 
 ### Work Station Host List
 
-The **Work Station** Host List can be expanded and contains one sub-group utilized by the Windows
+The **Work Station** Host List can be expanded and contains one sub-group used by the Windows
 Solution.
 
 ![Work Station Host List](/images/accessanalyzer/12.0/admin/settings/workstation.webp)
@@ -177,33 +177,34 @@ The single sub-group is:
 
 ## Required Permissions
 
-The host inventory process collects the four property groups above using different mechanisms,
-each with its own permission requirement on the target host:
+The host inventory process collects the four property groups (Operating System, Application,
+Network, and Hardware) using different mechanisms, each with its own permission requirement on the
+target host:
 
-- **Operating System properties** (version, service pack, product type, and related items) are
-  read from the target's registry. This requires the Remote Registry service to be running on the
-  target, and the account used must have local administrator rights (or be explicitly delegated
+- **Operating System properties** (version, service pack, product type, and related items) come
+  from the target's registry. This requires the Remote Registry service to be running on the
+  target, and the account used must have local administrator rights (or explicitly delegated
   Remote Registry access).
 - **Application properties** (for example, SQL Server, IIS, clustering, and Exchange role/version)
-  are read from a mix of registry, WMI, and Active Directory, depending on the specific property.
+  come from a mix of registry, WMI, and Active Directory, depending on the specific property.
   WMI-sourced properties require WMI namespace access on the target (local administrator by
-  default). Exchange role and version are read from Active Directory first, and only fall back to
-  WMI if that lookup does not return a result.
-- **Network properties** (for example, domain/workgroup name and AD site) are primarily read using
-  low-privilege network APIs that do not require administrative rights, with a WMI fallback for
-  some properties if the primary method does not return a result.
-- **Hardware properties** (manufacturer, model, serial number) are read from WMI and require the
+  default). Exchange role and version come from Active Directory first, and only fall back to
+  WMI if that lookup doesn't return a result.
+- **Network properties** (for example, domain/workgroup name and AD site) come primarily from
+  low-privilege network APIs that don't require administrative rights, with a WMI fallback for
+  some properties if the primary method doesn't return a result.
+- **Hardware properties** (manufacturer, model, serial number) come from WMI and require the
   same administrative-equivalent access as other WMI-sourced properties.
 
 :::info
-Because Operating System and Hardware properties depend on Remote Registry and WMI access, the
-account used for host inventory should be provisioned as a local administrator (or with explicitly
-delegated Remote Registry and WMI namespace permissions) on the hosts being inventoried. A standard
-authenticated domain account without local admin rights is sufficient for Network properties and
-the Active Directory-based portion of Application properties, but not for the registry- and
-WMI-based properties.
+Because Operating System and Hardware properties depend on Remote Registry and WMI access, provision
+the account used for host inventory as a local administrator (or with explicitly delegated Remote
+Registry and WMI namespace permissions) on the inventoried hosts. A standard authenticated domain
+account without local admin rights is sufficient for Network properties and the Active
+Directory-based portion of Application properties, but not for the registry- and WMI-based
+properties.
 :::
 
-If the account used lacks the required access on a given host, the properties normally supplied by
-the denied mechanism are expected to be left blank rather than causing the entire host inventory
-record to fail.
+If the account used lacks the required access on a given host, host inventory should leave the
+properties normally supplied by that mechanism blank rather than failing the entire host inventory
+record.


### PR DESCRIPTION
Documents the per-property-group permission requirements (Remote Registry, WMI, AD) for the host inventory process