### PR TITLE
Add Azure Files support to Activity Monitor integration docs

### DIFF
--- a/docs/threatmanager/3.3/install/integration/activitymonitor.md
+++ b/docs/threatmanager/3.3/install/integration/activitymonitor.md
@@ -6,17 +6,27 @@ sidebar_position: 10
 
 # Netwrix Activity Monitor Integration
 
-The Activity Monitor can be configured to send file system data and/or Active Directory and/or
-Microsoft Entra ID data to Threat Manager. It must be installed and configured to monitor the target
+The Activity Monitor can be configured to send file system, Active Directory, and Microsoft Entra
+ID activity to Threat Manager. Install and configure the Activity Monitor to monitor the target
 environment. See the
-[Netwrix Activity Monitor](https://helpcenter.netwrix.com/category/activitymonitor) documentation
+[Netwrix Activity Monitor](https://docs.netwrix.com/docs/activitymonitor/10_0/) documentation
 for additional information.
 
-For Threat Manager to receive the event stream data, you must configure the Activity Monitor accordingly.
-For file system activity events, use the Threat Manager Syslog template for the
-desired monitored host configuration. For Active Directory activity events, generate an App Token in
-Threat Manager and then use that app token to configure the domain’s output to Threat Manager.
+For Threat Manager to receive the event stream data, configure the Activity Monitor output for
+each event source.
+
+## Active Directory and Microsoft Entra ID activity events
+
+Active Directory and Microsoft Entra ID activity events use the native Netwrix Threat Manager
+output. Generate an App Token in Threat Manager, then use that app token to configure the domain's
+or tenant's output to Threat Manager.
 
 The Threat Manager DC Sync threat is sourced by the Activity Monitor's Replication AD monitoring
-configuration. Configure it to exclude domain controllers on the Host
-(From) filter.
+configuration. Configure it to exclude domain controllers on the Host (From) filter.
+
+## File system activity events
+
+File system activity events, including Windows file servers, NAS devices, and Azure Files storage
+accounts, use the Threat Manager Syslog template for the desired monitored host configuration. See
+the [Add Azure Files Storage Accounts](/docs/activitymonitor/10.0/admin/monitoredhosts/add/azurefiles.md) topic
+to add Azure Files storage accounts as a monitored host.


### PR DESCRIPTION
## Summary
- Restructures the Activity Monitor integration page into sections grouped by output mechanism (native Threat Manager output for AD/Entra ID, Syslog for file system events)
- Documents Azure Files storage account monitoring support, linking to Activity Monitor's existing Azure Files setup guide
- Fixes a stale external link that redirected to the Activity Monitor v8.0 docs instead of v10.0

Stacked on #1333.

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>