### PR TITLE
Fixes a mismatch between 10.8 and 10.9 SQL Server requirements

### DIFF
--- a/docs/auditor/10.9/requirements/sqlserver.md
+++ b/docs/auditor/10.9/requirements/sqlserver.md
@@ -13,12 +13,17 @@ generation, Reporting Services (or Advanced Services) are also required.
 The following table lists supported SQL Server versions and editions.
 
 Due to limited database size, Netwrix recommends Express Edition (with Reporting Services) only for
-evaluation, PoC, or small environments. For production environment, consider using Standard or
-Enterprise Edition.
+evaluation, PoC, or small environments **when using SQL Server 2022 or earlier**. For production
+environments, consider using Standard or Enterprise Edition.
+
+**NOTE:** SQL Server 2025 Express Edition does not include Power BI Report Server (PBIRS) or any
+built-in reporting services. If reporting functionality is required, use Standard or Enterprise
+Edition with SQL Server 2025, or remain on SQL Server Express 2022 or earlier. See the SQL Server
+2025 row in the table below for details.
 
 | Version                                                                      | Edition                                                                                                                                                                                                                                                       |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SQL Server 2025                                                              | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/sql-server/sql-server-downloads?msockid=112beb089ec7691328c3fc2e9fa568c1) with [Power BI Report Server](https://www.microsoft.com/en-us/download/details.aspx?id=105944) (for evaluation, PoC, and small environments) |
+| SQL Server 2025                                                              | - Standard or Enterprise Edition<br/>**NOTE:** Express Edition is supported for SQL Server 2025, but does not include Power BI Report Server (PBIRS) or any built-in reporting services. Reporting functionality is not available with SQL Server 2025 Express. If reporting is required, use Standard or Enterprise Edition with SQL Server 2025, or remain on [SQL Server 2022 Express](https://www.microsoft.com/en-us/download/details.aspx?id=104781) with [SQL Server Reporting Services 2022](https://www.microsoft.com/en-us/download/details.aspx?id=104502). Note that using SSRS 2022 (or earlier) with SQL Server 2025 Express is not an officially supported configuration and may break if Microsoft introduces incompatible changes in a future update. |
 | SQL Server 2022                                                              | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/download/details.aspx?id=104781) with [Reporting Services](https://www.microsoft.com/en-us/download/details.aspx?id=104502) (for evaluation, PoC, and small environments) |
 | SQL Server 2019 (on-premises Windows version) cumulative update 10 and above | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/download/details.aspx?id=101064) with [Reporting Services](https://www.microsoft.com/en-us/download/details.aspx?id=100122) (for evaluation, PoC, and small environments)                  |
 | SQL Server 2017                                                              | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/download/details.aspx?id=55994) with [Reporting Services](https://www.microsoft.com/en-us/download/details.aspx?id=55252) (for evaluation, PoC, and small environments)                  |
@@ -114,7 +119,8 @@ Consider the following:
 - Supported versions are 2012 and later.
 - Reporting Services supports only English-language operating systems.
 - Supported editions are Enterprise, Standard, and Express with Advanced Services (it includes
-  Reporting Services).
+  Reporting Services). **Note:** SQL Server 2025 Express Edition does not include any reporting
+  services. For SQL Server 2025, only Standard and Enterprise Editions support report generation.
 - If downloading SQL Server Express Edition with Advanced Services from Microsoft site, ensure
   you download the file whose name contains SQLEXPRADV. Otherwise, the installer won't deploy Reporting Services, and you won't be able to analyze and report on collected data.
 

--- a/docs/auditor/10.9/requirements/sqlserver.md
+++ b/docs/auditor/10.9/requirements/sqlserver.md
@@ -6,24 +6,24 @@ sidebar_position: 40
 
 # Requirements for SQL Server to Store Audit Data
 
-If you plan to generate reports, use alerts and run search queries in Netwrix Auditor, consider that
-your deployment must include Microsoft SQL Server where Netwrix Auditor stores audit data. For report
-generation, Reporting Services (or Advanced Services) are also required.
+If you plan to generate reports, use alerts, and run search queries in Netwrix Auditor, your
+deployment must include Microsoft SQL Server where Netwrix Auditor stores audit data. Report
+generation also requires Reporting Services (or Advanced Services).
 
 The following table lists supported SQL Server versions and editions.
 
 Due to limited database size, Netwrix recommends Express Edition (with Reporting Services) only for
-evaluation, PoC, or small environments **when using SQL Server 2022 or earlier**. For production
-environments, consider using Standard or Enterprise Edition.
+evaluation, proof of concept (PoC), or small environments **when using SQL Server 2022 or earlier**.
+For production environments, consider using Standard or Enterprise Edition.
 
-**NOTE:** SQL Server 2025 Express Edition does not include Power BI Report Server (PBIRS) or any
-built-in reporting services. If reporting functionality is required, use Standard or Enterprise
+**NOTE:** SQL Server 2025 Express Edition doesn't include Power BI Report Server (PBIRS) or any
+built-in reporting services. If you require reporting functionality, use Standard or Enterprise
 Edition with SQL Server 2025, or remain on SQL Server Express 2022 or earlier. See the SQL Server
-2025 row in the table below for details.
+2025 row in the following table for details.
 
 | Version                                                                      | Edition                                                                                                                                                                                                                                                       |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| SQL Server 2025                                                              | - Standard or Enterprise Edition<br/>**NOTE:** Express Edition is supported for SQL Server 2025, but does not include Power BI Report Server (PBIRS) or any built-in reporting services. Reporting functionality is not available with SQL Server 2025 Express. If reporting is required, use Standard or Enterprise Edition with SQL Server 2025, or remain on [SQL Server 2022 Express](https://www.microsoft.com/en-us/download/details.aspx?id=104781) with [SQL Server Reporting Services 2022](https://www.microsoft.com/en-us/download/details.aspx?id=104502). Note that using SSRS 2022 (or earlier) with SQL Server 2025 Express is not an officially supported configuration and may break if Microsoft introduces incompatible changes in a future update. |
+| SQL Server 2025                                                              | - Standard or Enterprise Edition<br/>**NOTE:** SQL Server 2025 supports Express Edition, but that edition doesn't include Power BI Report Server (PBIRS) or any built-in reporting services. Reporting functionality isn't available with SQL Server 2025 Express. If you require reporting, use Standard or Enterprise Edition with SQL Server 2025, or remain on [SQL Server 2022 Express](https://www.microsoft.com/en-us/download/details.aspx?id=104781) with [SQL Server Reporting Services 2022](https://www.microsoft.com/en-us/download/details.aspx?id=104502). Using SSRS 2022 (or earlier) with SQL Server 2025 Express isn't an officially supported configuration and may break if Microsoft introduces incompatible changes in a future update. |
 | SQL Server 2022                                                              | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/download/details.aspx?id=104781) with [Reporting Services](https://www.microsoft.com/en-us/download/details.aspx?id=104502) (for evaluation, PoC, and small environments) |
 | SQL Server 2019 (on-premises Windows version) cumulative update 10 and above | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/download/details.aspx?id=101064) with [Reporting Services](https://www.microsoft.com/en-us/download/details.aspx?id=100122) (for evaluation, PoC, and small environments)                  |
 | SQL Server 2017                                                              | - Standard or Enterprise Edition - [Express Edition](https://www.microsoft.com/en-us/download/details.aspx?id=55994) with [Reporting Services](https://www.microsoft.com/en-us/download/details.aspx?id=55252) (for evaluation, PoC, and small environments)                  |
@@ -31,16 +31,15 @@ Edition with SQL Server 2025, or remain on SQL Server Express 2022 or earlier. S
 | SQL Server 2014                                                              | - Standard or Enterprise Edition - [Express Edition with Advanced Services](https://www.microsoft.com/en-us/download/details.aspx?id=42299) (for evaluation, PoC, and small environments)                                                                      |
 | SQL Server 2012                                                              | - Standard or Enterprise Edition - [Express Edition with Advanced Services](https://www.microsoft.com/en-us/download/details.aspx?id=56042) (for evaluation, PoC, and small environments)                                                                       |
 
-**NOTE:** SQL express is only supported for small environments. It might cause performance issues on
-the medium and large environments.
+**NOTE:** Netwrix supports SQL Express only for small environments. It might cause performance
+issues in medium and large environments.
 
-SQL Server
-[AlwaysOn Availability Group](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server)
-can also be used for hosting Netwrix Auditor audit databases. For that, after specifying audit
-database settings in Netwrix Auditor, you should manually add created database to a properly
-configured AlwaysOn Availability Group. Take these steps each time Netwrix Auditor creates a new audit database.
+You can also host Netwrix Auditor audit databases on a SQL Server
+[AlwaysOn Availability Group](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/overview-of-always-on-availability-groups-sql-server).
+After you specify audit database settings in Netwrix Auditor, manually add the new database to a
+properly configured AlwaysOn Availability Group. Repeat this step each time Netwrix Auditor creates a new audit database.
 
-**NOTE:** Multi-subnet Listener configurations for SQL Server AlwaysOn aren't supported.
+**NOTE:** Netwrix Auditor doesn't support Multi-subnet Listener configurations for SQL Server AlwaysOn.
 
 See the
 [Add a database to an Always On availability group with the 'Availability Group Wizard'](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/availability-group-add-database-to-group-wizard)
@@ -48,11 +47,10 @@ Microsoft article for details on adding a database to AlwaysOn Availability Grou
 
 You can configure Netwrix Auditor to use an existing SQL Server instance, or deploy a new instance.
 
-If your deployment planning reveals that SQL Server Express Edition will be suitable for your
-production environment, then you can install, for example, SQL Server 2016 SP2 Express with Advanced
-Services using the Audit Database Settings wizard or by manually downloading it from Microsoft web
-site. See the Install Microsoft SQL Server and Reporting Services section for additional
-information.
+If your deployment planning shows that SQL Server Express Edition suits your production environment,
+you can install, for example, SQL Server 2016 SP2 Express with Advanced Services using the Audit
+Database Settings wizard, or download it manually from the Microsoft website. See the Install
+Microsoft SQL Server and Reporting Services section for additional information.
 
 ## SQL Server and Databases
 
@@ -73,9 +71,9 @@ For production deployment in bigger environments, Netwrix recommends Microsoft S
 Standard Edition or higher because of the limited database size and other limitations of Express
 Edition.
 
-Make your choice based on the size of the environment you are going to monitor, the number of users
-and other factors. This refers, for example, to Netwrix Auditor for Network Devices: if you need to
-audit successful logons to these devices, consider that your data sources produce a large number of activity records, so plan for SQL Server Standard or Enterprise edition (Express edition won't be sufficient).
+Make your choice based on the size of the environment you plan to monitor, the number of users, and
+other factors. This refers, for example, to Netwrix Auditor for Network Devices: if you need to
+audit successful logons to these devices, your data sources produce a large number of activity records, so plan for SQL Server Standard or Enterprise edition (Express edition won't be sufficient).
 
 Netwrix Auditor supports automated size calculation for all its databases in total, displaying the
 result, in particular, in the
@@ -90,14 +88,14 @@ creates an Audit Database. Default database name is `Netwrix_Auditor_<monitoring
 Netwrix strongly recommends targeting each monitoring plan at a separate database.
 
 Also, Netwrix Auditor automatically creates several dedicated databases on the default SQL Server instance.
-These databases are intended for storing various data, as listed in the following table.
+These databases store various data, as listed in the following table.
 
 | Database name                   | Description                                                                                                                                                                               |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Netwrix_AlertsDB`              | Stores alerts.                                                                                                                                                                            |
 | `Netwrix_Auditor_API`           | Stores activity records collected using Integration API.                                                                                                                                  |
 | `Netwrix_Auditor_EventLog`      | Stores internal event records.                                                                                                                                                            |
-| **`Netwrix_CategoriesDB`**      | Intended for integration with Netwrix Data Classification. This database is always created but is involved in the workflow only if the DDC Provider is enabled. See [Sensitive Data Discovery](/docs/auditor/10.9//admin/settings/sensitivedatadiscovery.md) for instructions on enabling the DDC Provider. |
+| **`Netwrix_CategoriesDB`**      | Intended for integration with Netwrix Data Classification. Netwrix Auditor always creates this database, but it participates in the workflow only when you enable the DDC Provider. See [Sensitive Data Discovery](/docs/auditor/10.9//admin/settings/sensitivedatadiscovery.md) for instructions on enabling the DDC Provider. |
 | `Netwrix_CommonDB`              | Stores views to provide cross-database reporting.                                                                                                                                         |
 | `Netwrix_ImportDB`              | Stores data imported from Long-Term Archive.                                                                                                                                              |
 | **`Netwrix_OverviewReportsDB`** | Stores data required for overview reports.                                                                                                                                                |
@@ -119,10 +117,10 @@ Consider the following:
 - Supported versions are 2012 and later.
 - Reporting Services supports only English-language operating systems.
 - Supported editions are Enterprise, Standard, and Express with Advanced Services (it includes
-  Reporting Services). **Note:** SQL Server 2025 Express Edition does not include any reporting
+  Reporting Services). **Note:** SQL Server 2025 Express Edition doesn't include any reporting
   services. For SQL Server 2025, only Standard and Enterprise Editions support report generation.
-- If downloading SQL Server Express Edition with Advanced Services from Microsoft site, ensure
-  you download the file whose name contains SQLEXPRADV. Otherwise, the installer won't deploy Reporting Services, and you won't be able to analyze and report on collected data.
+- If you download SQL Server Express Edition with Advanced Services from the Microsoft site, ensure
+  the file name contains SQLEXPRADV. Otherwise, the installer won't deploy Reporting Services, and you can't analyze and report on collected data.
 
 For example, this section provides instructions on how to:
 
@@ -130,60 +128,60 @@ For example, this section provides instructions on how to:
 
 For detailed information on installing other versions/editions, refer to Microsoft website.
 
-Maximum database size provided in SQL Server Express editions may be insufficient for storing data
-in bigger infrastructures. Thus, when planning for SQL Server, consider maximum database capacity in
-different editions, considering the size of the audited environment.
+The maximum database size in SQL Server Express editions may be insufficient for storing data
+in bigger infrastructures. Thus, when planning for SQL Server, compare the maximum database capacity
+in different editions against the size of the audited environment.
 
 ## SQL Server
 
 When planning for SQL Server that will host Auditor databases, consider the following:
 
-- For PoC, evaluation scenario or small environment SQL Server can run on the same computer where
-  Netwrix Auditor Server will be installed, or on the remote machine accessible by Netwrix Auditor.
+- For PoC, evaluation scenario, or small environment SQL Server can run on the same computer where
+  you install Netwrix Auditor Server, or on a remote machine accessible by Netwrix Auditor.
   Remember to check connection settings and access rights.
 - In large and extra-large infrastructures, install SQL Server on a separate server or cluster.
   Netwrix doesn't recommend installing Netwrix Auditor and SQL Server on the same server in such environments.
 - If you plan to have Netwrix Auditor and SQL Server running on different machines, establish fast
   and reliable connection between them (100 Mbps or higher).
-- Both standalone servers and SQL Server clusters are supported, as well as AlwaysOn Availability
-  Groups (Multi-subnet Listener configurations for SQL Server AlwaysOn aren't supported).
+- Netwrix Auditor supports both standalone servers and SQL Server clusters, as well as AlwaysOn
+  Availability Groups (it doesn't support Multi-subnet Listener configurations for SQL Server AlwaysOn).
 - You can configure Netwrix Auditor to use an existing SQL Server instance, or create a new one. As
   an option, you can install SQL Server 2016 Express Edition, using the Audit Database Settings
-  wizard or manually downloading it from Microsoft web site (see Install Microsoft SQL Server and
+  wizard, or download it manually from the Microsoft website (see Install Microsoft SQL Server and
   Reporting Services).
 
-**CAUTION:** Don't install Netwrix Auditor databases to a production SQL Server instance. Such instances may have a lot of maintenance plans or scripts running that may affect data
-uploaded by the product. The product databases are designed for reporting and searching and don't
+**CAUTION:** Don't install Netwrix Auditor databases to a production SQL Server instance. Such instances may run many maintenance plans or scripts that can affect the data
+the product uploads. The product databases are designed for reporting and searching and don't
 require maintenance or backup. For the long-term data storage, Netwrix Auditor uses Long-Term
 Archive. See [File-Based Repository for Long-Term Archive](/docs/auditor/10.9/requirements/longtermarchive.md) for additional
 information.
 
-If you select to set up a new SQL Server instance, Netwrix Auditor assigns the _sysadmin_ server role to the current user account (which must be a member of the local Administrators group).
+If you choose to set up a new SQL Server instance, Netwrix Auditor assigns the _sysadmin_ server role to the current user account (which must be a member of the local Administrators group).
 
 Specify the data drive for storing the SQL Server databases (the default is the system drive).
 
-- If you plan to have more than one Netwrix Auditor Server in your network, ensure you configure them to use different SQL Server instances. The same SQL Server instance can't be used to store
-  audit data collected by several Netwrix Auditor Servers.
+- If you plan to have more than one Netwrix Auditor Server in your network, ensure you configure them to use different SQL Server instances. Several Netwrix Auditor Servers can't share the same
+  SQL Server instance for storing audit data.
 - Ensure the account that writes data to the audit databases hosted on the default SQL Server has
   sufficient access rights. Assign this account the following roles:
 
     1. **Database owner (db_owner)** database-level role
     2. dbcreator server-level role
 
-    This account can be specified when you configure the
+    You can specify this account when you configure the
     [Audit Database](/docs/auditor/10.9/admin/settings/auditdatabase.md) settings.
 
 ## Database Sizing
 
 For database sizing, estimate the following:
 
-- Size of the environment you are going to monitor
+- Size of the environment you plan to monitor
 - Amount of activity records produced by the audited system
 - Retention policy for the audit databases
 - Maximum database size supported by different SQL Server versions
 
-To estimate the number of the activity records produced by your data sources, collected, and saved by
-Auditor during the week, you can use the Activity records by date widget of the Health Status
+To estimate the number of activity records that your data sources produce and that Auditor collects
+and saves during the week, use the Activity records by date widget of the Health Status
 dashboard. See the
 [Activity Records Statistics](/docs/auditor/10.9/admin/healthstatus/dashboard/activityrecordstatistics.md) topic for
 additional information.
@@ -194,7 +192,7 @@ capacity and daily growth for each database, you can click View details and exam
 the table. See the [Database Statistics](/docs/auditor/10.9/admin/healthstatus/dashboard/databasestatistics.md)
 topic for additional information.
 
-This feature is supported only for SQL Server 2012 SP3 and later.
+This feature works only with SQL Server 2012 SP3 and later.
 
 Remember that database size in SQL Server Express editions may be insufficient. For example,
 Microsoft SQL Server 2012 SP3 Express Edition has the following limitations which may affect
@@ -215,8 +213,8 @@ following:
 - By default, database name will be `Netwrix_Auditor_<monitoring_plan_name>`; you can name the
   database as you need, for example, `Active_Directory_Audit_Data`.
 
-To avoid syntax errors, for instance, in the PowerShell cmdlets, use the
-underscore character (`_`) instead of space character in the database names.
+To avoid syntax errors, for instance in PowerShell cmdlets, use the
+underscore character (`_`) instead of the space character in database names.
 
 If the database doesn't yet exist on the specified SQL Server instance, Netwrix Auditor creates it there. For
 this operation to succeed, ensure that the Netwrix Auditor service account has sufficient rights on that
@@ -244,8 +242,8 @@ To change database retention after product deployment:
 
 ![audit_db_settings](/images/auditor/10.9/requirements/audit_db_settings.webp)
 
-**Step 2 –** In the dialog displayed, ensure the Clear stale data when a database retention
-period is exceeded: is set to ON, then click Modify to specify the required retention period (in
+**Step 2 –** In the dialog displayed, set Clear stale data when a database retention
+period is exceeded: to ON, then click Modify to specify the required retention period (in
 days).
 
 This setting also applies to the `Netwrix_Auditor_API` database.
@@ -254,7 +252,7 @@ This setting also applies to the `Netwrix_Auditor_API` database.
 
 This is the account that Auditor uses to write the collected audit data to the audit databases.
 
-This account must be granted the **Database owner (`db_owner`)** role and the **dbcreator** server
+Grant this account the **Database owner (`db_owner`)** role and the **dbcreator** server
 role on the SQL Server instance hosting your audit databases.
 
 To assign the **dbcreator** and **`db_owner`** roles:
@@ -277,10 +275,10 @@ the **`db_owner`** role to.
 **Step 8 –** Select the **User Mapping** tab. Select all databases used by Auditor to store audit
 data in the upper pane and check **`db_owner`** in the lower pane.
 
-**NOTE:** This step is only required when changing the existing Audit Database Account to a new one.
+**NOTE:** Perform this step only when you change the existing Audit Database Account to a new one.
 
-**Step 9 –** If the account that you want to assign the **`db_owner`** role to has been already
-added to **SQL Server Logins**, expand the **Security** > **Logins** node, right-click the account,
+**Step 9 –** If the account that you want to assign the **`db_owner`** role to already exists
+in **SQL Server Logins**, expand the **Security** > **Logins** node, right-click the account,
 select **Properties** from the pop-up menu, and edit its roles.
 
 Starting with version 9.96, you can use Group Managed Service Account (gMSA) for that purpose.


### PR DESCRIPTION
10.8 docs had received an update with notes about SQL Server and PBIRS 2025, but those notes were absent from the 10.9 version of the same doc. This edit updates the 10.9 docs to include those same notes.