### PR TITLE
Address review feedback on single-product build fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,15 +35,14 @@ PRODUCTS.forEach(product => {
 // generateDocusaurusPlugins() applies — otherwise redirects reference routes
 // from products that were never built in this run.
 const targetProduct = process.env.DOCS_PRODUCT;
+if (targetProduct && !PRODUCTS.some(product => product.id === targetProduct)) {
+  throw new Error(`DOCS_PRODUCT="${targetProduct}" does not match any product id in src/config/products.js`);
+}
 const redirectProducts = targetProduct
   ? PRODUCTS.filter(product => product.id === targetProduct)
   : PRODUCTS;
 
-const latestVersionMap = targetProduct
-  ? Object.fromEntries(
-      Object.entries(getLatestVersionUrlMap()).filter(([productId]) => productId === targetProduct)
-    )
-  : getLatestVersionUrlMap();
+const latestVersionMap = getLatestVersionUrlMap();
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -61,10 +60,13 @@ const config = {
   // throw on anything that is not configured correctly
   // Relaxed to 'warn' for single-product builds (DOCS_PRODUCT set): the navbar
   // always links to every product, but a filtered build only generates routes
-  // for one of them, so cross-product navbar links are expected to be unresolved.
+  // for one of them, so cross-product navbar (site) links are expected to be
+  // unresolved. Markdown links and anchors resolve within the target product's
+  // own plugin instance regardless of filtering, so those stay strict to catch
+  // real mistakes during single-product iteration.
   onBrokenLinks: targetProduct ? 'warn' : 'throw',
-  onBrokenMarkdownLinks: targetProduct ? 'warn' : 'throw',
-  onBrokenAnchors: targetProduct ? 'warn' : 'throw',
+  onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Set Mermaid
   markdown: {


### PR DESCRIPTION
## Summary
Follow-up to #1355, addressing the automated code review feedback ([comment](https://github.com/netwrix/docs/pull/1355#issuecomment-5247450571)):

- Validate `DOCS_PRODUCT` against known product ids and fail loudly on a typo, instead of silently producing an empty-looking-successful build
- Narrow the `onBrokenLinks` relaxation to `onBrokenLinks` itself — `onBrokenMarkdownLinks` and `onBrokenAnchors` resolve within a single product's own plugin instance regardless of filtering, so they stay strict to keep catching real mistakes during single-product iteration
- Drop the `latestVersionMap` filter, since `createRedirects` only runs against routes that exist in the current build; filtering it had no effect and the comment overstated its role

## Test plan
- [x] `DOCS_PRODUCT=pingcastl` (typo) now fails immediately with a clear error instead of silently succeeding
- [x] `DOCS_PRODUCT=pingcastle` (valid) still builds successfully
- [x] Full unfiltered `npm run build` passes with strict broken-link enforcement unchanged

Closes #1360