### PR TITLE
Hide version filter unless a single product is selected in search

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -694,6 +694,10 @@ export default function SearchBar() {
         ];
     }, [selectedProducts]);
 
+    const isSingleProductSelected = useMemo(() => {
+        return selectedProducts.filter(p => p !== '__all__' && p !== '__none__').length === 1;
+    }, [selectedProducts]);
+
     // This is where we will portal the filters into the modal DOM.
     const [modalHeaderEl, setModalHeaderEl] = useState(null);
     // Holds the closeModal function passed up from the inner DocSearch component.
@@ -774,18 +778,10 @@ export default function SearchBar() {
             {modalHeaderEl &&
                 createPortal(
                     <>
-                        {/* Custom controls: product + version filters */}
+                        {/* Custom controls: version + product filters */}
                         <div className="search-custom-controls">
-                            <MultiSelectDropdown
-                                label="Products"
-                                options={PRODUCT_OPTIONS}
-                                selectedValues={selectedProducts}
-                                onChange={onChangeProducts}
-                                placeholder="All products"
-                            />
-                            {/* availableVersions always holds the '__all__' sentinel at index 0,
-                                so length > 1 means a specific product is selected (R2). */}
-                            {availableVersions.length > 1 && (
+                            {/* Version filtering only makes sense when exactly one product is selected. */}
+                            {isSingleProductSelected && (
                                 <MultiSelectDropdown
                                     label="Versions"
                                     options={availableVersions}
@@ -794,6 +790,13 @@ export default function SearchBar() {
                                     placeholder="All versions"
                                 />
                             )}
+                            <MultiSelectDropdown
+                                label="Products"
+                                options={PRODUCT_OPTIONS}
+                                selectedValues={selectedProducts}
+                                onChange={onChangeProducts}
+                                placeholder="All products"
+                            />
                         </div>
                         {/* Our own close button — replaces the DocSearch-Close button
                             (which is hidden via CSS) so we avoid mutating React-owned

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -20,6 +20,12 @@ import {getVersionsForProducts, dedupeToLatestVersion} from '../searchUtils';
 
 let DocSearchModal = null;
 
+// Versions only mean something within one product, so the Versions control — and
+// the version filter behind it — is gated on exactly one product being selected.
+function isSingleProduct(products) {
+    return (products || []).filter(p => p !== '__all__' && p !== '__none__').length === 1;
+}
+
 function importDocSearchModalIfNeeded() {
     if (DocSearchModal) {
         return Promise.resolve();
@@ -204,9 +210,11 @@ function useTransformItems(selectedVersionsRef) {
     const [transformItems] = useState(() => (items) => {
         const mapped = items.map((item) => ({...item, url: processSearchResultUrl(item.url)}));
         // Modal version state never holds the '__all__' sentinel (MultiSelectDropdown
-        // maps the All toggle to []) and can't hold versions without a product
-        // (filters reset on open; onChangeProducts prunes orphan versions), so
-        // non-empty means a real version filter is active — de-dupe off (R3).
+        // maps the All toggle to []) and can only be non-empty while exactly one
+        // product is selected (filters reset on open; onChangeProducts clears versions
+        // whenever the selection stops being a single product — the same condition that
+        // shows the Versions control), so non-empty means a real, visible version filter
+        // is active — de-dupe off (R3).
         const versionFilterActive = (selectedVersionsRef.current || []).length > 0;
         return ungroup(versionFilterActive ? mapped : dedupeToLatestVersion(mapped));
     });
@@ -664,8 +672,13 @@ export default function SearchBar() {
         if (typeof window !== 'undefined') {
             sessionStorage.setItem('docs_product_filter', JSON.stringify(newProducts));
         }
-        // Clear versions that don't exist for the new product selection
-        const validVersions = new Set(getVersionsForProducts(newProducts));
+        // Drop versions the new selection can't show. The Versions control only renders
+        // for a single product, so anything other than one product clears versions
+        // outright — otherwise a hidden filter would keep suppressing results (and
+        // de-duplication) with no UI to clear it.
+        const validVersions = new Set(
+            isSingleProduct(newProducts) ? getVersionsForProducts(newProducts) : [],
+        );
         const cleaned = selectedVersionsRef.current.filter(v => validVersions.has(v));
         if (cleaned.length !== selectedVersionsRef.current.length) {
             selectedVersionsRef.current = cleaned;
@@ -694,9 +707,7 @@ export default function SearchBar() {
         ];
     }, [selectedProducts]);
 
-    const isSingleProductSelected = useMemo(() => {
-        return selectedProducts.filter(p => p !== '__all__' && p !== '__none__').length === 1;
-    }, [selectedProducts]);
+    const isSingleProductSelected = useMemo(() => isSingleProduct(selectedProducts), [selectedProducts]);
 
     // This is where we will portal the filters into the modal DOM.
     const [modalHeaderEl, setModalHeaderEl] = useState(null);

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -47,12 +47,34 @@ const PRODUCT_OPTIONS = [
 });
 
 // Checkbox-based multi-select component
-function MultiSelect({label, options, selectedValues, onChange}) {
+function MultiSelect({label, options, selectedValues, onChange, topMargin, maxHeight, growToFill = true, sizeScale = 1}) {
     // options[0] is the "All products" sentinel — skip it for the checkbox list
     const productOptions = options.filter(o => o.value !== '__all__');
     const allSelected = selectedValues.includes('__all__');
     const noneSelected = selectedValues.length === 0;
     const someSelected = !allSelected && !noneSelected;
+
+    // With only one real option, there's nothing to filter — show it as a
+    // plain, always-selected label instead of a confusing single-row checkbox list.
+    if (productOptions.length === 1) {
+        return (
+            <div style={{display: 'flex', flexDirection: 'column', flexShrink: 0, marginTop: topMargin}}>
+                <label style={{display: 'block', marginBottom: '8px', fontWeight: 'bold'}}>
+                    {label}
+                </label>
+                <div style={{
+                    border: '2px solid var(--ifm-color-emphasis-300)',
+                    borderRadius: '8px',
+                    background: 'var(--ifm-background-color)',
+                    padding: '4px 10px',
+                    fontSize: '13px',
+                    color: 'var(--ifm-color-emphasis-700)',
+                }}>
+                    {productOptions[0].label}
+                </div>
+            </div>
+        );
+    }
 
     const selectAllRef = useRef(null);
 
@@ -92,15 +114,16 @@ function MultiSelect({label, options, selectedValues, onChange}) {
         borderRadius: '8px',
         overflowY: 'auto',
         background: 'var(--ifm-background-color)',
-        flex: 1,
+        flex: growToFill ? 1 : '0 1 auto',
         minHeight: 0,
+        maxHeight,
     };
 
     const rowStyle = {
         display: 'flex',
         alignItems: 'center',
         gap: '8px',
-        padding: '4px 10px',
+        padding: `${4 * sizeScale}px 10px`,
         cursor: 'pointer',
         fontSize: '13px',
         lineHeight: '1.3',
@@ -122,7 +145,7 @@ function MultiSelect({label, options, selectedValues, onChange}) {
     };
 
     return (
-        <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0}}>
+        <div style={{display: 'flex', flexDirection: 'column', flex: growToFill ? 1 : '0 1 auto', minHeight: 0, marginTop: topMargin}}>
             <label style={{display: 'block', marginBottom: '8px', fontWeight: 'bold', flexShrink: 0}}>
                 {label}
             </label>
@@ -322,6 +345,10 @@ function SearchPageContent() {
     const [resultsPerPage, setResultsPerPage] = useState(resultsPerPageFromUrl);
 
     const availableVersions = useMemo(() => getVersionsForProducts(selectedProducts), [selectedProducts]);
+
+    const isSingleProductSelected = useMemo(() => {
+        return selectedProducts.filter(p => p !== '__all__' && p !== '__none__').length === 1;
+    }, [selectedProducts]);
 
     // Clear orphan versions when products change
     const handleProductChange = useCallback((newProducts) => {
@@ -834,8 +861,9 @@ function SearchPageContent() {
                             options={PRODUCT_OPTIONS}
                             selectedValues={selectedProducts}
                             onChange={handleProductChange}
+                            maxHeight={isSingleProductSelected ? (isMobile ? '132px' : 'calc((100vh - var(--ifm-navbar-height)) * 0.60)') : undefined}
                         />
-                        {availableVersions.length > 0 && (
+                        {isSingleProductSelected && (
                             <MultiSelect
                                 label="Versions"
                                 options={[
@@ -844,6 +872,8 @@ function SearchPageContent() {
                                 ]}
                                 selectedValues={selectedVersions}
                                 onChange={setSelectedVersions}
+                                topMargin="16px"
+                                sizeScale={1.1}
                             />
                         )}
                     </div>{/* closes filters div */}

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -47,12 +47,25 @@ const PRODUCT_OPTIONS = [
 });
 
 // Checkbox-based multi-select component
-function MultiSelect({label, options, selectedValues, onChange, topMargin, maxHeight, growToFill = true, sizeScale = 1}) {
+function MultiSelect({label, options, selectedValues, onChange, topMargin, maxHeight, sizeScale = 1}) {
     // options[0] is the "All products" sentinel — skip it for the checkbox list
     const productOptions = options.filter(o => o.value !== '__all__');
     const allSelected = selectedValues.includes('__all__');
     const noneSelected = selectedValues.length === 0;
     const someSelected = !allSelected && !noneSelected;
+
+    // Hooks must run on every render — the option count changes at runtime (the
+    // Versions list re-renders with a different product's versions), so the
+    // single-option early return below has to sit after them or React throws
+    // "Rendered fewer hooks than expected".
+    const selectAllRef = useRef(null);
+
+    useEffect(() => {
+        if (selectAllRef.current) {
+            selectAllRef.current.indeterminate = someSelected;
+            if (!someSelected) selectAllRef.current.indeterminate = false;
+        }
+    }, [someSelected]);
 
     // With only one real option, there's nothing to filter — show it as a
     // plain, always-selected label instead of a confusing single-row checkbox list.
@@ -75,15 +88,6 @@ function MultiSelect({label, options, selectedValues, onChange, topMargin, maxHe
             </div>
         );
     }
-
-    const selectAllRef = useRef(null);
-
-    useEffect(() => {
-        if (selectAllRef.current) {
-            selectAllRef.current.indeterminate = someSelected;
-            if (!someSelected) selectAllRef.current.indeterminate = false;
-        }
-    }, [someSelected]);
 
     function handleSelectAll() {
         if (allSelected && !someSelected) {
@@ -114,7 +118,7 @@ function MultiSelect({label, options, selectedValues, onChange, topMargin, maxHe
         borderRadius: '8px',
         overflowY: 'auto',
         background: 'var(--ifm-background-color)',
-        flex: growToFill ? 1 : '0 1 auto',
+        flex: 1,
         minHeight: 0,
         maxHeight,
     };
@@ -145,7 +149,7 @@ function MultiSelect({label, options, selectedValues, onChange, topMargin, maxHe
     };
 
     return (
-        <div style={{display: 'flex', flexDirection: 'column', flex: growToFill ? 1 : '0 1 auto', minHeight: 0, marginTop: topMargin}}>
+        <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, marginTop: topMargin}}>
             <label style={{display: 'block', marginBottom: '8px', fontWeight: 'bold', flexShrink: 0}}>
                 {label}
             </label>
@@ -544,9 +548,10 @@ function SearchPageContent() {
                 facetFilters.push(realProducts.map(p => `product_name:${p}`)); // Array within array = OR logic
             }
 
-            // A version filter is only active while a product filter is active — stale
-            // URL/sessionStorage versions must not silently filter while the panel is hidden.
-            const realVersions = realProducts.length > 0 ? selectedVersions.filter(v => v !== '__all__') : [];
+            // A version filter is only active while the Versions panel is visible, i.e.
+            // exactly one product is selected. Versions left over in state, the URL, or
+            // sessionStorage must not silently filter results the user can't unfilter.
+            const realVersions = realProducts.length === 1 ? selectedVersions.filter(v => v !== '__all__') : [];
             if (realVersions.length > 0) {
                 facetFilters.push(realVersions.map(v => `product_version:${v}`)); // Array within array = OR logic
             }
@@ -594,7 +599,7 @@ function SearchPageContent() {
             const urlProducts = selectedProducts.filter(p => p !== '__all__' && p !== '__none__');
             if (urlProducts.length > 0) params.set('products', urlProducts.join(','));
             // Same activation rule as makeSearch: never advertise a version filter the UI doesn't show.
-            const urlVersions = urlProducts.length > 0 ? selectedVersions.filter(v => v !== '__all__') : [];
+            const urlVersions = urlProducts.length === 1 ? selectedVersions.filter(v => v !== '__all__') : [];
             if (urlVersions.length > 0) params.set('versions', urlVersions.join(','));
             if (resultsPerPage !== 25) params.set('resultsPerPage', String(resultsPerPage));
             if (currentPage > 1) params.set('page', String(currentPage));

--- a/src/theme/SearchPage/index.js
+++ b/src/theme/SearchPage/index.js
@@ -868,7 +868,10 @@ function SearchPageContent() {
                             onChange={handleProductChange}
                             maxHeight={isSingleProductSelected ? (isMobile ? '132px' : 'calc((100vh - var(--ifm-navbar-height)) * 0.60)') : undefined}
                         />
-                        {isSingleProductSelected && (
+                        {/* The length guard covers a product name from a stale URL or
+                            sessionStorage that no longer exists in the config — one product is
+                            selected, but it contributes no versions, so there is nothing to list. */}
+                        {isSingleProductSelected && availableVersions.length > 0 && (
                             <MultiSelect
                                 label="Versions"
                                 options={[


### PR DESCRIPTION
## Summary
- In the search modal and the full search results page, the version filter now only shows when exactly one product is selected, since versions don't apply meaningfully across multiple products
- Reordered the modal's filter controls so Versions appears before Products
- Adjusted spacing/sizing of the filters sidebar on the results page

## Test plan
- [ ] Open the search modal, select multiple products, confirm no version filter appears
- [ ] Select a single product, confirm the version filter appears and works
- [ ] Repeat on the /search results page
- [ ] Check spacing/sizing of the Products/Versions boxes on the results page at various viewport heights

Closes #1378