### PR TITLE
Fix stale stats endpoint in license usage KB article

### DIFF
--- a/docs/kb/auditor/system-administration/licensing-and-compliance/essential-netwrix-license-usage-data-and-url-resources.md
+++ b/docs/kb/auditor/system-administration/licensing-and-compliance/essential-netwrix-license-usage-data-and-url-resources.md
@@ -7,7 +7,7 @@ keywords:
   - Netwrix Auditor
   - whitelist URLs
   - license.nwxcorp
-  - stats.netwrix.com
+  - stats.nwxcorp.com
   - updates.netwrix.com
   - netwrix.com
 products:
@@ -39,6 +39,6 @@ If a Netwrix server in your environment has limited Internet access, whitelist t
 https://license.nwxcorp.com/
 http://updates.netwrix.com/
 http://www.netwrix.com/
-https://stats.netwrix.com/
+https://stats.nwxcorp.com/
 ```
 


### PR DESCRIPTION
The article listed https://stats.netwrix.com/ as a URL to whitelist for license usage reporting. This hostname no longer resolves (or was never correct). Packet capture against a live Auditor instance confirms the product now reports to stats.nwxcorp.com instead.

Updated the URL to https://stats.nwxcorp.com/ to match current behavior.

Closes #1387